### PR TITLE
feat(ingest): 벡터 임베딩 진행률 로그 추가

### DIFF
--- a/crates/secall/src/commands/ingest.rs
+++ b/crates/secall/src/commands/ingest.rs
@@ -274,9 +274,12 @@ pub async fn ingest_sessions(
 
     // 벡터 인덱싱 일괄 처리 (BM25/vault와 분리하여 체감 속도 개선)
     if !vector_tasks.is_empty() {
-        eprintln!("Embedding {} session(s)...", vector_tasks.len());
+        let total = vector_tasks.len();
+        eprintln!("Embedding {total} session(s)...");
         let tz = config.timezone();
-        for session in &vector_tasks {
+        for (i, session) in vector_tasks.iter().enumerate() {
+            let short = &session.id[..8.min(session.id.len())];
+            eprintln!("  [{}/{total}] {short} ({} turns)", i + 1, session.turns.len());
             if let Err(e) = engine.index_session_vectors(db, session, tz).await {
                 tracing::warn!(session = &session.id[..8.min(session.id.len())], error = %e, "vector embedding failed");
                 error_details.push(IngestError {


### PR DESCRIPTION
## Summary
- `ingest_sessions` 벡터 임베딩 루프에 `[i/total] <session_id> (N turns)` 진행 로그 추가
- 대용량 배치(예: 455개 세션)에서 마지막 임베딩 단계가 멈춘 것처럼 보이던 체감 문제 해결

## Background
`secall ingest --auto`가 수백 개 세션을 긁어오면 BM25/vault 인덱싱은 빠르게 끝나지만, 이후 순차 HNSW insert 단계가 수십 분 걸릴 수 있음. 기존에는 시작 시 `Embedding N session(s)...` 한 줄만 찍고 침묵하여, 프로세스 행인지 진행 중인지 `sample` 떠서 확인해야 했음.

## Test plan
- [x] `cargo check -p secall` 통과
- [ ] 수 개 세션으로 `secall ingest` 실행 시 진행 로그가 세션마다 stderr에 출력되는지 확인