### PR TITLE
feat: lint --fix + wiki_search dates + P20 test coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ codegen-units = 1
 strip = true
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.75"
 license = "AGPL-3.0"

--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ Claude Code 설정 (`~/.claude/settings.json`)에 추가:
 
 | 날짜 | 버전 | 변경사항 |
 |------|------|---------|
+| 2026-04-12 | v0.3.1 | `secall lint --fix` stale DB 정리 (#15), `wiki_search` created/updated 필드 (#13), P20 테스트 커버리지 강화 (+16 tests) |
 | 2026-04-12 | v0.3.0 | 세션 분류 (regex 규칙, `secall classify`), 위키 플러그인 백엔드 (Ollama, LM Studio), `--include-automated` 플래그 |
 | 2026-04-10 | P17 | 대화형 온보딩 (`secall init` 위저드), `secall config` CLI, git 브랜치 설정 |
 | 2026-04-10 | P16 | Knowledge Graph — frontmatter 기반 결정적 그래프 추출, `secall graph build/stats/export`, MCP `graph_query`, sync Phase 3.7 |

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -291,6 +291,8 @@ impl SeCallMcpServer {
             title: String,
             preview: String,
             name_match: bool,
+            created: Option<String>,
+            updated: Option<String>,
         }
 
         let mut matches: Vec<Match> = walkdir::WalkDir::new(&search_root)
@@ -334,11 +336,16 @@ impl SeCallMcpServer {
 
                 let preview: String = content.chars().take(500).collect();
 
+                // frontmatter에서 created/updated 추출
+                let (created, updated) = extract_wiki_dates(&content);
+
                 Some(Match {
                     path: rel,
                     title,
                     preview,
                     name_match,
+                    created,
+                    updated,
                 })
             })
             .collect();
@@ -350,11 +357,18 @@ impl SeCallMcpServer {
         let results: Vec<serde_json::Value> = matches
             .into_iter()
             .map(|m| {
-                serde_json::json!({
+                let mut obj = serde_json::json!({
                     "path": m.path,
                     "title": m.title,
                     "preview": m.preview,
-                })
+                });
+                if let Some(created) = m.created {
+                    obj["created"] = serde_json::Value::String(created);
+                }
+                if let Some(updated) = m.updated {
+                    obj["updated"] = serde_json::Value::String(updated);
+                }
+                obj
             })
             .collect();
 
@@ -522,6 +536,29 @@ pub async fn start_mcp_http_server(
     Ok(())
 }
 
+/// wiki md frontmatter에서 created/updated 값을 추출.
+fn extract_wiki_dates(content: &str) -> (Option<String>, Option<String>) {
+    let fm = match content.strip_prefix("---\n") {
+        Some(rest) => match rest.split_once("\n---") {
+            Some((fm, _)) => fm,
+            None => return (None, None),
+        },
+        None => return (None, None),
+    };
+
+    let mut created = None;
+    let mut updated = None;
+    for line in fm.lines() {
+        let trimmed = line.trim();
+        if let Some(val) = trimmed.strip_prefix("created:") {
+            created = Some(val.trim().trim_matches('"').to_string());
+        } else if let Some(val) = trimmed.strip_prefix("updated:") {
+            updated = Some(val.trim().trim_matches('"').to_string());
+        }
+    }
+    (created, updated)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
@@ -569,5 +606,36 @@ mod tests {
         };
         let result = server.recall(Parameters(params)).await;
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_extract_wiki_dates_both() {
+        let content = "---\ntitle: Test\ncreated: 2026-04-10\nupdated: 2026-04-12\n---\n# Test";
+        let (created, updated) = super::extract_wiki_dates(content);
+        assert_eq!(created.as_deref(), Some("2026-04-10"));
+        assert_eq!(updated.as_deref(), Some("2026-04-12"));
+    }
+
+    #[test]
+    fn test_extract_wiki_dates_none() {
+        let content = "---\ntitle: Test\n---\n# Test";
+        let (created, updated) = super::extract_wiki_dates(content);
+        assert!(created.is_none());
+        assert!(updated.is_none());
+    }
+
+    #[test]
+    fn test_extract_wiki_dates_no_frontmatter() {
+        let content = "# Just a heading\nSome text";
+        let (created, updated) = super::extract_wiki_dates(content);
+        assert!(created.is_none());
+        assert!(updated.is_none());
+    }
+
+    #[test]
+    fn test_extract_wiki_dates_quoted() {
+        let content = "---\ncreated: \"2026-04-10\"\n---\n";
+        let (created, _) = super::extract_wiki_dates(content);
+        assert_eq!(created.as_deref(), Some("2026-04-10"));
     }
 }

--- a/crates/secall-core/src/vault/git.rs
+++ b/crates/secall-core/src/vault/git.rs
@@ -112,12 +112,7 @@ impl<'a> VaultGit<'a> {
         let new_files = if !already_up_to_date {
             self.run_git(&["diff", "--stat", "HEAD@{1}", "HEAD"])
                 .ok()
-                .map(|o| {
-                    String::from_utf8_lossy(&o.stdout)
-                        .lines()
-                        .filter(|l| l.contains("raw/sessions/"))
-                        .count()
-                })
+                .map(|o| count_new_session_files(&String::from_utf8_lossy(&o.stdout)))
                 .unwrap_or(0)
         } else {
             0
@@ -204,4 +199,49 @@ pub struct PullResult {
 
 pub struct PushResult {
     pub committed: usize,
+}
+
+/// git diff --stat 출력에서 raw/sessions/ 경로가 포함된 라인 수를 카운트.
+pub(crate) fn count_new_session_files(diff_stat_output: &str) -> usize {
+    diff_stat_output
+        .lines()
+        .filter(|l| l.contains("raw/sessions/"))
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_count_single_session() {
+        let output = " raw/sessions/2026-04-01/abc.md | 45 ++++\n 1 file changed";
+        assert_eq!(count_new_session_files(output), 1);
+    }
+
+    #[test]
+    fn test_count_multiple_mixed() {
+        let output = " raw/sessions/2026-04-01/abc.md | 45 ++++\n \
+                       raw/sessions/2026-04-01/def.md | 12 ++\n \
+                       wiki/projects/foo.md           |  8 +\n \
+                       3 files changed, 65 insertions(+)";
+        assert_eq!(count_new_session_files(output), 2);
+    }
+
+    #[test]
+    fn test_count_no_sessions() {
+        let output = " wiki/topics/rust.md | 20 ++\n index.md | 3 +\n 2 files changed";
+        assert_eq!(count_new_session_files(output), 0);
+    }
+
+    #[test]
+    fn test_count_empty() {
+        assert_eq!(count_new_session_files(""), 0);
+    }
+
+    #[test]
+    fn test_count_summary_not_counted() {
+        let output = " raw/sessions/x.md | 1 +\n 1 file changed, 1 insertion(+)";
+        assert_eq!(count_new_session_files(output), 1);
+    }
 }

--- a/crates/secall-core/src/vault/index.rs
+++ b/crates/secall-core/src/vault/index.rs
@@ -4,6 +4,33 @@ use anyhow::Result;
 
 use crate::ingest::Session;
 
+/// 인덱스 한 줄 엔트리 생성 (I/O 없음)
+pub(crate) fn build_entry_line(
+    link_path: &str,
+    title: &str,
+    turns: usize,
+    agent: &str,
+    time_str: &str,
+) -> String {
+    format!(
+        "- [[{}|{}]] — {}턴, {}, {}\n",
+        link_path, title, turns, agent, time_str
+    )
+}
+
+/// content에 entry를 삽입하거나 append.
+/// - "## Sessions\n\n" 헤더 있으면 직후 삽입 (최신 항목이 맨 위)
+/// - 헤더 없으면 content 끝에 "\n## Sessions\n\n{entry}" 추가
+pub(crate) fn insert_into_content(content: &mut String, entry: &str) {
+    if let Some(pos) = content.find("## Sessions\n\n") {
+        let insert_at = pos + "## Sessions\n\n".len();
+        content.insert_str(insert_at, entry);
+    } else {
+        content.push_str("\n## Sessions\n\n");
+        content.push_str(entry);
+    }
+}
+
 pub fn update_index(
     vault_path: &Path,
     session: &Session,
@@ -47,20 +74,70 @@ pub fn update_index(
         .to_string();
     let turns = session.turns.len();
 
-    let new_entry = format!(
-        "- [[{}|{}]] — {}턴, {}, {}\n",
-        link_path, title, turns, agent, time_str
-    );
-
-    // Insert after "## Sessions\n\n" header (at the beginning of the list)
-    if let Some(pos) = content.find("## Sessions\n\n") {
-        let insert_at = pos + "## Sessions\n\n".len();
-        content.insert_str(insert_at, &new_entry);
-    } else {
-        content.push_str("\n## Sessions\n\n");
-        content.push_str(&new_entry);
-    }
+    let new_entry = build_entry_line(&link_path, &title, turns, agent, &time_str);
+    insert_into_content(&mut content, &new_entry);
 
     std::fs::write(&index_path, content)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_entry_line_format() {
+        let line = build_entry_line(
+            "raw/sessions/2026-04-01/abc",
+            "디버깅 세션",
+            5,
+            "claude-code",
+            "14:30",
+        );
+        assert_eq!(
+            line,
+            "- [[raw/sessions/2026-04-01/abc|디버깅 세션]] — 5턴, claude-code, 14:30\n"
+        );
+    }
+
+    #[test]
+    fn test_insert_with_header() {
+        let mut content =
+            "---\ntype: index\n---\n\n# seCall Index\n\n## Sessions\n\n- [[old|old entry]] — 3턴, codex, 10:00\n"
+                .to_string();
+        insert_into_content(
+            &mut content,
+            "- [[new|new entry]] — 5턴, claude-code, 14:30\n",
+        );
+        let sessions_pos = content.find("## Sessions\n\n").unwrap();
+        let after_header = &content[sessions_pos + "## Sessions\n\n".len()..];
+        assert!(after_header.starts_with("- [[new|"));
+    }
+
+    #[test]
+    fn test_insert_creates_header() {
+        let mut content = "---\ntype: index\n---\n\n# seCall Index\n\n".to_string();
+        insert_into_content(
+            &mut content,
+            "- [[first|first entry]] — 1턴, claude-code, 09:00\n",
+        );
+        assert!(content.contains("## Sessions\n\n- [[first|"));
+    }
+
+    #[test]
+    fn test_insert_empty_content() {
+        let mut content = String::new();
+        insert_into_content(&mut content, "- [[x|x]] — 1턴, a, 00:00\n");
+        assert!(content.contains("## Sessions\n\n- [[x|x]]"));
+    }
+
+    #[test]
+    fn test_insert_preserves_existing() {
+        let mut content =
+            "## Sessions\n\n- [[a|a]] — 1턴, x, 00:00\n- [[b|b]] — 2턴, y, 01:00\n".to_string();
+        insert_into_content(&mut content, "- [[c|c]] — 3턴, z, 02:00\n");
+        let idx_c = content.find("[[c|c]]").unwrap();
+        let idx_a = content.find("[[a|a]]").unwrap();
+        assert!(idx_c < idx_a, "새 엔트리가 기존 엔트리 앞에 삽입");
+    }
 }

--- a/crates/secall/src/commands/classify.rs
+++ b/crates/secall/src/commands/classify.rs
@@ -33,16 +33,11 @@ pub async fn run_backfill(dry_run: bool) -> Result<()> {
         .collect::<anyhow::Result<_>>()?;
 
     for (session_id, _cwd, _project, _agent, first_content) in &sessions {
-        // 첫 번째 user turn 내용으로 규칙 매칭
-        let matched_type = compiled_rules.iter().find_map(|(re, session_type)| {
-            if re.is_match(first_content) {
-                Some(session_type.clone())
-            } else {
-                None
-            }
-        });
-
-        let new_type = matched_type.unwrap_or_else(|| classification.default.clone());
+        let new_type = super::ingest::apply_classification(
+            &compiled_rules,
+            first_content,
+            &classification.default,
+        );
 
         let short_id = &session_id[..8.min(session_id.len())];
         if dry_run {

--- a/crates/secall/src/commands/ingest.rs
+++ b/crates/secall/src/commands/ingest.rs
@@ -322,6 +322,27 @@ pub async fn ingest_sessions(
     })
 }
 
+/// 컴파일된 regex 규칙과 첫 번째 user turn 내용으로 session_type 결정.
+pub(crate) fn apply_classification(
+    compiled_rules: &[(regex::Regex, String)],
+    first_user_content: &str,
+    default_type: &str,
+) -> String {
+    if compiled_rules.is_empty() {
+        return default_type.to_string();
+    }
+    compiled_rules
+        .iter()
+        .find_map(|(re, session_type)| {
+            if re.is_match(first_user_content) {
+                Some(session_type.clone())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| default_type.to_string())
+}
+
 /// 단일 Session을 vault + BM25 + 벡터 목록에 ingest
 #[allow(clippy::too_many_arguments)]
 fn ingest_single_session(
@@ -350,25 +371,17 @@ fn ingest_single_session(
 
     // 세션 분류: 첫 번째 user turn의 내용을 규칙과 매칭
     {
-        let classification = &config.ingest.classification;
-        if !compiled_rules.is_empty() {
-            let first_user_content = session
-                .turns
-                .iter()
-                .find(|t| t.role == secall_core::ingest::Role::User)
-                .map(|t| t.content.as_str())
-                .unwrap_or("");
-
-            let matched_type = compiled_rules.iter().find_map(|(re, session_type)| {
-                if re.is_match(first_user_content) {
-                    Some(session_type.clone())
-                } else {
-                    None
-                }
-            });
-
-            session.session_type = matched_type.unwrap_or_else(|| classification.default.clone());
-        }
+        let first_user_content = session
+            .turns
+            .iter()
+            .find(|t| t.role == secall_core::ingest::Role::User)
+            .map(|t| t.content.as_str())
+            .unwrap_or("");
+        session.session_type = apply_classification(
+            compiled_rules,
+            first_user_content,
+            &config.ingest.classification.default,
+        );
     }
 
     // 실제 session.id 기준 중복 체크 (--force 시 기존 데이터 삭제 후 재삽입)
@@ -532,4 +545,67 @@ fn find_session_by_id(id: &str) -> Result<Vec<PathBuf>> {
         }
     }
     Ok(found)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    fn rules(patterns: &[(&str, &str)]) -> Vec<(Regex, String)> {
+        patterns
+            .iter()
+            .map(|(p, t)| (Regex::new(p).unwrap(), t.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_matches_first_rule() {
+        let r = rules(&[("^\\[자동화\\]", "automated")]);
+        assert_eq!(
+            apply_classification(&r, "[자동화] 월간 보고", "interactive"),
+            "automated"
+        );
+    }
+
+    #[test]
+    fn test_matches_second_rule() {
+        let r = rules(&[("^\\[자동화\\]", "automated"), ("^# Wiki", "automated")]);
+        assert_eq!(
+            apply_classification(&r, "# Wiki Update", "interactive"),
+            "automated"
+        );
+    }
+
+    #[test]
+    fn test_no_match_uses_default() {
+        let r = rules(&[("^\\[자동화\\]", "automated")]);
+        assert_eq!(
+            apply_classification(&r, "일반 질문입니다", "interactive"),
+            "interactive"
+        );
+    }
+
+    #[test]
+    fn test_empty_rules_returns_default() {
+        assert_eq!(
+            apply_classification(&[], "아무 내용", "interactive"),
+            "interactive"
+        );
+    }
+
+    #[test]
+    fn test_empty_content() {
+        let r = rules(&[("^\\[자동화\\]", "automated")]);
+        assert_eq!(apply_classification(&r, "", "interactive"), "interactive");
+    }
+
+    #[test]
+    fn test_first_match_wins() {
+        let r = rules(&[("test", "type-a"), ("test", "type-b")]);
+        assert_eq!(
+            apply_classification(&r, "test content", "default"),
+            "type-a"
+        );
+    }
 }

--- a/crates/secall/src/commands/lint.rs
+++ b/crates/secall/src/commands/lint.rs
@@ -5,7 +5,7 @@ use secall_core::{
     vault::Config,
 };
 
-pub fn run(json: bool, errors_only: bool) -> Result<()> {
+pub fn run(json: bool, errors_only: bool, fix: bool) -> Result<()> {
     let config = Config::load_or_default();
     let db_path = get_default_db_path();
     let db = Database::open(&db_path)?;
@@ -14,6 +14,9 @@ pub fn run(json: bool, errors_only: bool) -> Result<()> {
 
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
+        if fix {
+            run_fix(&db, &report)?;
+        }
         return Ok(());
     }
 
@@ -58,10 +61,57 @@ pub fn run(json: bool, errors_only: bool) -> Result<()> {
         println!("Agents: {}", agent_str.join(", "));
     }
 
-    // Exit with code 1 if there are errors
-    if report.summary.errors > 0 {
+    // --fix: auto-repair L001 (stale DB records)
+    if fix {
+        run_fix(&db, &report)?;
+    }
+
+    // Exit with code 1 if there are errors (after fix, re-count)
+    let remaining_errors = if fix {
+        // Re-run lint to get updated count
+        let updated = run_lint(&db, &config)?;
+        updated.summary.errors
+    } else {
+        report.summary.errors
+    };
+
+    if remaining_errors > 0 {
         std::process::exit(1);
     }
 
+    Ok(())
+}
+
+fn run_fix(
+    db: &Database,
+    report: &secall_core::ingest::lint::LintReport,
+) -> Result<()> {
+    let stale: Vec<&str> = report
+        .findings
+        .iter()
+        .filter(|f| f.code == "L001" && f.session_id.is_some())
+        .filter(|f| f.message.contains("vault file missing"))
+        .filter_map(|f| f.session_id.as_deref())
+        .collect();
+
+    if stale.is_empty() {
+        eprintln!("[fix] No stale DB records to clean up.");
+        return Ok(());
+    }
+
+    eprintln!(
+        "[fix] Removing {} stale DB record(s) with missing vault files...",
+        stale.len()
+    );
+    for session_id in &stale {
+        match db.delete_session(session_id) {
+            Ok(()) => eprintln!("  deleted {}", &session_id[..session_id.len().min(8)]),
+            Err(e) => eprintln!(
+                "  failed to delete {}: {e}",
+                &session_id[..session_id.len().min(8)]
+            ),
+        }
+    }
+    eprintln!("[fix] Done. {} record(s) removed.", stale.len());
     Ok(())
 }

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -133,6 +133,10 @@ enum Commands {
         /// Only show errors (skip warn/info)
         #[arg(long)]
         errors_only: bool,
+
+        /// Auto-fix: delete stale DB records for missing vault files (L001)
+        #[arg(long)]
+        fix: bool,
     },
 
     /// Start MCP server
@@ -350,8 +354,12 @@ async fn main() -> anyhow::Result<()> {
         Commands::Classify { dry_run } => {
             commands::classify::run_backfill(dry_run).await?;
         }
-        Commands::Lint { json, errors_only } => {
-            commands::lint::run(json, errors_only)?;
+        Commands::Lint {
+            json,
+            errors_only,
+            fix,
+        } => {
+            commands::lint::run(json, errors_only, fix)?;
         }
         Commands::Mcp { http } => {
             commands::mcp::run(http).await?;


### PR DESCRIPTION
## Summary
- **Issue #15**: `secall lint --fix` — L001 vault file missing 항목의 stale DB 레코드 자동 삭제
- **Issue #13**: `wiki_search` MCP 도구에 `created`/`updated` 날짜 필드 추가 (frontmatter 파싱)
- **P20**: 순수 함수 추출 + 유닛 테스트 16개 추가 (`vault/index.rs`, `vault/git.rs`, `ingest.rs`)
- `classify.rs` 중복 분류 로직 제거 → `ingest::apply_classification()` 재사용

closes #13, closes #15

## Changes
| File | Description |
|------|-------------|
| `commands/lint.rs` | `--fix` 플래그 + `run_fix()` 함수 (stale L001 레코드 삭제) |
| `commands/ingest.rs` | `apply_classification()` 순수 함수 추출 + 6 테스트 |
| `commands/classify.rs` | 중복 로직 제거, `super::ingest::apply_classification()` 호출 |
| `mcp/server.rs` | `extract_wiki_dates()` + `created`/`updated` 필드 + 4 테스트 |
| `vault/index.rs` | `build_entry_line()`, `insert_into_content()` 추출 + 5 테스트 |
| `vault/git.rs` | `count_new_session_files()` 추출 + 5 테스트 |
| `main.rs` | `Lint` 커맨드에 `--fix` 플래그 추가 |

## Test plan
- [x] `cargo test` — 220 tests passed
- [x] `cargo check` — no errors
- [ ] `secall lint --fix` with stale DB records
- [ ] `wiki_search` via MCP returns `created`/`updated` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)