### PR TITLE
feat(api+obsidian): P25 Phase 0-1 — REST API + Obsidian plugin MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,6 +3206,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "tower-http",
  "tracing",
  "usearch",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ zip = { version = "=2.3.0", default-features = false, features = ["deflate"] }
 regex = "1"
 openvino = { version = "0.9", features = ["runtime-linking"] }
 libloading = "0.8"
+tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/secall-core/Cargo.toml
+++ b/crates/secall-core/Cargo.toml
@@ -27,6 +27,7 @@ sha2.workspace = true
 regex.workspace = true
 futures-util.workspace = true
 axum.workspace = true
+tower-http.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true

--- a/crates/secall-core/src/mcp/mod.rs
+++ b/crates/secall-core/src/mcp/mod.rs
@@ -1,5 +1,7 @@
 pub mod instructions;
+pub mod rest;
 pub mod server;
 pub mod tools;
 
+pub use rest::start_rest_server;
 pub use server::{start_mcp_http_server, start_mcp_server, SeCallMcpServer};

--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -1,0 +1,113 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Json, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Router,
+};
+use tower_http::cors::{Any, CorsLayer};
+
+use super::server::SeCallMcpServer;
+use super::tools::{GetParams, GraphQueryParams, RecallParams, WikiSearchParams};
+use crate::search::hybrid::SearchEngine;
+use crate::store::db::Database;
+
+type AppState = Arc<SeCallMcpServer>;
+
+/// REST API 라우터 생성
+pub fn rest_router(server: SeCallMcpServer) -> Router {
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let state: AppState = Arc::new(server);
+
+    Router::new()
+        .route("/api/recall", post(api_recall))
+        .route("/api/get", post(api_get))
+        .route("/api/status", get(api_status))
+        .route("/api/wiki", post(api_wiki))
+        .route("/api/graph", post(api_graph))
+        .layer(cors)
+        .with_state(state)
+}
+
+/// REST + MCP 통합 서버 시작 (loopback 전용)
+pub async fn start_rest_server(
+    db: Database,
+    search: SearchEngine,
+    vault_path: std::path::PathBuf,
+    port: u16,
+) -> anyhow::Result<()> {
+    let db_arc = Arc::new(std::sync::Mutex::new(db));
+    let search_arc = Arc::new(search);
+    let server = SeCallMcpServer::new(db_arc, search_arc, vault_path);
+    let router = rest_router(server);
+
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+
+    tracing::info!(addr = %addr, "REST API server listening");
+    tracing::info!("endpoints: /api/recall, /api/get, /api/status, /api/wiki, /api/graph");
+
+    axum::serve(listener, router).await?;
+    Ok(())
+}
+
+async fn api_recall(
+    State(s): State<AppState>,
+    Json(p): Json<RecallParams>,
+) -> impl IntoResponse {
+    match s.do_recall(p).await {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => error_response(e),
+    }
+}
+
+async fn api_get(
+    State(s): State<AppState>,
+    Json(p): Json<GetParams>,
+) -> impl IntoResponse {
+    match s.do_get(p) {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => error_response(e),
+    }
+}
+
+async fn api_status(State(s): State<AppState>) -> impl IntoResponse {
+    match s.do_status() {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => error_response(e),
+    }
+}
+
+async fn api_wiki(
+    State(s): State<AppState>,
+    Json(p): Json<WikiSearchParams>,
+) -> impl IntoResponse {
+    match s.do_wiki_search(p) {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => error_response(e),
+    }
+}
+
+async fn api_graph(
+    State(s): State<AppState>,
+    Json(p): Json<GraphQueryParams>,
+) -> impl IntoResponse {
+    match s.do_graph_query(p) {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => error_response(e),
+    }
+}
+
+fn error_response(e: anyhow::Error) -> axum::response::Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({"error": e.to_string()})),
+    )
+        .into_response()
+}

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -11,24 +11,10 @@ use super::instructions::build_instructions;
 use super::tools::{
     GetParams, GraphQueryParams, QueryType, RecallParams, StatusParams, WikiSearchParams,
 };
-use crate::error::SecallError;
 use crate::search::bm25::{SearchFilters, SearchResult};
 use crate::search::hybrid::{diversify_by_session, parse_temporal_filter, SearchEngine};
 use crate::store::db::Database;
 use crate::store::SessionRepo;
-
-fn to_mcp_error(e: SecallError) -> McpError {
-    match &e {
-        SecallError::SessionNotFound(_) | SecallError::TurnNotFound { .. } => {
-            McpError::invalid_params(e.to_string(), None)
-        }
-        SecallError::DatabaseNotInitialized => McpError::internal_error(e.to_string(), None),
-        SecallError::Parse { .. } | SecallError::UnsupportedFormat(_) => {
-            McpError::invalid_params(e.to_string(), None)
-        }
-        _ => McpError::internal_error(e.to_string(), None),
-    }
-}
 
 #[derive(Clone)]
 pub struct SeCallMcpServer {
@@ -39,7 +25,7 @@ pub struct SeCallMcpServer {
     vault_path: PathBuf,
 }
 
-#[tool_router]
+/// 공통 로직 메서드 — REST 핸들러와 MCP tool 모두에서 호출
 impl SeCallMcpServer {
     pub fn new(db: Arc<Mutex<Database>>, search: Arc<SearchEngine>, vault_path: PathBuf) -> Self {
         Self {
@@ -50,14 +36,10 @@ impl SeCallMcpServer {
         }
     }
 
-    /// Search agent session history
-    #[tool(
-        description = "Search agent session history. Use keyword queries for exact terms, semantic queries for conceptual search, or temporal queries for time-based filtering."
-    )]
-    async fn recall(
+    pub async fn do_recall(
         &self,
-        Parameters(params): Parameters<RecallParams>,
-    ) -> Result<CallToolResult, McpError> {
+        params: RecallParams,
+    ) -> anyhow::Result<serde_json::Value> {
         let limit = params.limit.unwrap_or(10).min(50);
 
         let mut base_filters = SearchFilters {
@@ -69,7 +51,6 @@ impl SeCallMcpServer {
             ..Default::default()
         };
 
-        // Apply any temporal filters first
         for item in &params.queries {
             if let QueryType::Temporal = item.query_type {
                 if let Some(tf) = parse_temporal_filter(&item.query) {
@@ -85,31 +66,18 @@ impl SeCallMcpServer {
             match item.query_type {
                 QueryType::Temporal => {}
                 QueryType::Keyword => {
-                    // BM25 search — sync, lock the DB
                     let results = {
-                        let db = self.db.lock().map_err(|e| {
-                            McpError::internal_error(format!("DB lock error: {e}"), None)
-                        })?;
-                        self.search
-                            .search_bm25(&db, &item.query, &base_filters, limit)
-                            .map_err(|e| {
-                                McpError::internal_error(format!("BM25 error: {e}"), None)
-                            })?
+                        let db = self.db.lock().map_err(|e| anyhow::anyhow!("DB lock: {e}"))?;
+                        self.search.search_bm25(&db, &item.query, &base_filters, limit)?
                     };
                     all_results.extend(results);
                 }
                 QueryType::Semantic => {
-                    // Step 1: embed query (async, no DB lock held)
                     match self.search.embed_query(&item.query).await {
                         Ok(Some(embedding)) => {
-                            // Step 2: lock DB and search vectors synchronously
                             let results = {
-                                let db = self.db.lock().map_err(|e| {
-                                    McpError::internal_error(format!("DB lock error: {e}"), None)
-                                })?;
-                                self.search
-                                    .search_with_embedding(&db, &embedding, limit, &base_filters)
-                                    .map_err(|e| McpError::internal_error(e.to_string(), None))?
+                                let db = self.db.lock().map_err(|e| anyhow::anyhow!("DB lock: {e}"))?;
+                                self.search.search_with_embedding(&db, &embedding, limit, &base_filters)?
                             };
                             all_results.extend(results);
                         }
@@ -117,30 +85,22 @@ impl SeCallMcpServer {
                             tracing::info!("vector search disabled (Ollama not available)");
                         }
                         Err(e) => {
-                            return Err(McpError::internal_error(
-                                format!("embedding failed: {e}"),
-                                None,
-                            ));
+                            return Err(anyhow::anyhow!("embedding failed: {e}"));
                         }
                     }
                 }
             }
         }
 
-        // Check if any keyword query was present
         let has_keyword = params
             .queries
             .iter()
             .any(|q| matches!(q.query_type, QueryType::Keyword));
 
         if !has_keyword && all_results.is_empty() {
-            let json = serde_json::json!({ "results": [], "count": 0 });
-            return Ok(CallToolResult::success(vec![Content::text(
-                serde_json::to_string_pretty(&json).unwrap_or_default(),
-            )]));
+            return Ok(serde_json::json!({ "results": [], "count": 0 }));
         }
 
-        // Deduplicate and sort
         all_results.sort_by(|a, b| {
             b.score
                 .partial_cmp(&a.score)
@@ -149,20 +109,14 @@ impl SeCallMcpServer {
         let mut seen = std::collections::HashSet::new();
         all_results.retain(|r| seen.insert((r.session_id.clone(), r.turn_index)));
 
-        // 세션 다양성 적용
         let max_per = base_filters.max_per_session.unwrap_or(2);
         all_results = diversify_by_session(all_results, max_per);
-
         all_results.truncate(limit);
 
         let count = all_results.len();
 
-        // 관련 세션 그래프 탐색 (2홉, 최대 5개)
         let related_sessions = {
-            let db = self
-                .db
-                .lock()
-                .map_err(|e| McpError::internal_error(format!("DB lock error: {e}"), None))?;
+            let db = self.db.lock().map_err(|e| anyhow::anyhow!("DB lock: {e}"))?;
             let seed_ids: Vec<&str> = all_results
                 .iter()
                 .map(|r| r.session_id.as_str())
@@ -172,28 +126,16 @@ impl SeCallMcpServer {
             db.get_related_sessions(&seed_ids, 2, 5).unwrap_or_default()
         };
 
-        let json = serde_json::json!({
+        Ok(serde_json::json!({
             "results": all_results,
             "count": count,
             "related_sessions": related_sessions,
-        });
-
-        Ok(CallToolResult::success(vec![Content::text(
-            serde_json::to_string_pretty(&json).unwrap_or_default(),
-        )]))
+        }))
     }
 
-    /// Get a specific session or turn by ID
-    #[tool(
-        description = "Retrieve a specific session or turn. Use session_id for full session metadata, session_id:N for a specific turn."
-    )]
-    fn get(&self, Parameters(params): Parameters<GetParams>) -> Result<CallToolResult, McpError> {
-        let db = self
-            .db
-            .lock()
-            .map_err(|e| McpError::internal_error(format!("DB lock error: {e}"), None))?;
+    pub fn do_get(&self, params: GetParams) -> anyhow::Result<serde_json::Value> {
+        let db = self.db.lock().map_err(|e| anyhow::anyhow!("DB lock: {e}"))?;
 
-        // Parse "session_id:turn_index" or just "session_id"
         let (session_id, turn_index) = if let Some(colon_pos) = params.id.rfind(':') {
             let sid = &params.id[..colon_pos];
             let tidx_str = &params.id[colon_pos + 1..];
@@ -207,89 +149,83 @@ impl SeCallMcpServer {
         };
 
         if let Some(turn_idx) = turn_index {
-            match db.get_turn(&session_id, turn_idx) {
-                Ok(turn) => {
-                    let json_val = serde_json::json!({
-                        "turn_index": turn.turn_index,
-                        "role": turn.role,
-                        "content": turn.content,
-                    });
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&json_val).unwrap_or_default(),
-                    )]))
-                }
-                Err(e) => Err(to_mcp_error(e)),
-            }
+            let turn = db.get_turn(&session_id, turn_idx)?;
+            Ok(serde_json::json!({
+                "turn_index": turn.turn_index,
+                "role": turn.role,
+                "content": turn.content,
+            }))
         } else {
-            match db.get_session_meta(&session_id) {
-                Ok(meta) => {
-                    let mut json_val = serde_json::to_value(&meta).unwrap_or_default();
-                    if params.full.unwrap_or(false) {
-                        if let Some(vault_path) = &meta.vault_path {
-                            if let Ok(content) = std::fs::read_to_string(vault_path) {
-                                json_val["content"] = serde_json::Value::String(content);
-                            }
-                        }
+            let meta = db.get_session_meta(&session_id)?;
+            let mut json_val = serde_json::to_value(&meta).unwrap_or_default();
+            if params.full.unwrap_or(false) {
+                let content = if let Some(vault_path) = &meta.vault_path {
+                    std::fs::read_to_string(vault_path).ok()
+                } else {
+                    None
+                };
+                // vault 파일이 없으면 DB turns를 합쳐 fallback content 생성
+                let content = content.or_else(|| {
+                    let mut stmt = db
+                        .conn()
+                        .prepare(
+                            "SELECT role, content FROM turns WHERE session_id = ?1 ORDER BY turn_index",
+                        )
+                        .ok()?;
+                    let rows: Vec<(String, String)> = stmt
+                        .query_map(rusqlite::params![&session_id], |row| {
+                            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                        })
+                        .ok()?
+                        .filter_map(|r| r.ok())
+                        .collect();
+                    if rows.is_empty() {
+                        return None;
                     }
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&json_val).unwrap_or_default(),
-                    )]))
+                    let mut buf = String::new();
+                    for (role, text) in &rows {
+                        buf.push_str(&format!("## {}\n\n{}\n\n", role, text));
+                    }
+                    Some(buf)
+                });
+                if let Some(c) = content {
+                    json_val["content"] = serde_json::Value::String(c);
                 }
-                Err(e) => Err(to_mcp_error(e)),
             }
+            Ok(json_val)
         }
     }
 
-    /// Show index health: session count, embedding status, recent ingests
-    #[tool(description = "Show index health: session count, embedding status, recent ingests.")]
-    fn status(&self, _params: Parameters<StatusParams>) -> String {
-        let db = match self.db.lock() {
-            Ok(d) => d,
-            Err(e) => return format!("error: DB lock failed: {e}"),
-        };
-        match db.get_stats() {
-            Ok(stats) => format!(
-                "sessions: {}\nturns: {}\nvectors: {}\nrecent_ingests: {}",
-                stats.session_count,
-                stats.turn_count,
-                stats.vector_count,
-                stats.recent_ingests.len(),
-            ),
-            Err(e) => format!("error: {e}"),
-        }
+    pub fn do_status(&self) -> anyhow::Result<serde_json::Value> {
+        let db = self.db.lock().map_err(|e| anyhow::anyhow!("DB lock: {e}"))?;
+        let stats = db.get_stats()?;
+        Ok(serde_json::json!({
+            "sessions": stats.session_count,
+            "turns": stats.turn_count,
+            "vectors": stats.vector_count,
+            "recent_ingests": stats.recent_ingests.len(),
+        }))
     }
 
-    /// Search wiki knowledge pages
-    #[tool(
-        description = "Search wiki knowledge pages. Returns matching wiki articles from projects, topics, and decisions."
-    )]
-    fn wiki_search(
+    pub fn do_wiki_search(
         &self,
-        Parameters(params): Parameters<WikiSearchParams>,
-    ) -> Result<CallToolResult, McpError> {
+        params: WikiSearchParams,
+    ) -> anyhow::Result<serde_json::Value> {
         let wiki_dir = self.vault_path.join("wiki");
         let limit = params.limit.unwrap_or(5);
         let query_lower = params.query.to_lowercase();
 
         if !wiki_dir.exists() {
-            let json = serde_json::json!({ "results": [], "count": 0 });
-            return Ok(CallToolResult::success(vec![Content::text(
-                serde_json::to_string_pretty(&json).unwrap_or_default(),
-            )]));
+            return Ok(serde_json::json!({ "results": [], "count": 0 }));
         }
 
-        // wiki/ 하위 MD 파일 수집 (category 필터 적용)
-        // category는 허용 목록으로 검증 — 임의 경로 탐색 방지
         let search_root = if let Some(ref cat) = params.category {
             match cat.as_str() {
                 "projects" | "topics" | "decisions" => wiki_dir.join(cat),
                 _ => {
-                    return Err(McpError::invalid_params(
-                        format!(
-                            "invalid category '{}': must be one of projects, topics, decisions",
-                            cat
-                        ),
-                        None,
+                    return Err(anyhow::anyhow!(
+                        "invalid category '{}': must be one of projects, topics, decisions",
+                        cat
                     ));
                 }
             }
@@ -298,10 +234,7 @@ impl SeCallMcpServer {
         };
 
         if !search_root.exists() {
-            let json = serde_json::json!({ "results": [], "count": 0 });
-            return Ok(CallToolResult::success(vec![Content::text(
-                serde_json::to_string_pretty(&json).unwrap_or_default(),
-            )]));
+            return Ok(serde_json::json!({ "results": [], "count": 0 }));
         }
 
         struct Match {
@@ -340,7 +273,6 @@ impl SeCallMcpServer {
                     .to_string_lossy()
                     .to_string();
 
-                // title: 첫 번째 # 헤더 or 파일명
                 let title = content
                     .lines()
                     .find(|l| l.starts_with("# "))
@@ -353,8 +285,6 @@ impl SeCallMcpServer {
                     });
 
                 let preview: String = content.chars().take(500).collect();
-
-                // frontmatter에서 created/updated 추출
                 let (created, updated) = extract_wiki_dates(&content);
 
                 Some(Match {
@@ -368,7 +298,6 @@ impl SeCallMcpServer {
             })
             .collect();
 
-        // 파일명 매칭을 우선 정렬
         matches.sort_by_key(|m| !m.name_match);
         matches.truncate(limit);
 
@@ -391,37 +320,24 @@ impl SeCallMcpServer {
             .collect();
 
         let count = results.len();
-        let json = serde_json::json!({ "results": results, "count": count });
-        Ok(CallToolResult::success(vec![Content::text(
-            serde_json::to_string_pretty(&json).unwrap_or_default(),
-        )]))
+        Ok(serde_json::json!({ "results": results, "count": count }))
     }
 
-    /// Query knowledge graph: find neighbors and relationships of a node
-    #[tool(
-        description = "Query the knowledge graph. Find neighbors and relationships of a node (session, project, agent, tool). Use depth to expand traversal. Returns connected nodes and edge types."
-    )]
-    fn graph_query(
+    pub fn do_graph_query(
         &self,
-        Parameters(params): Parameters<GraphQueryParams>,
-    ) -> Result<CallToolResult, McpError> {
-        let db = self
-            .db
-            .lock()
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        let depth = params.depth.unwrap_or(1).min(3); // 최대 3홉
+        params: GraphQueryParams,
+    ) -> anyhow::Result<serde_json::Value> {
+        let db = self.db.lock().map_err(|e| anyhow::anyhow!("DB lock: {e}"))?;
+        let depth = params.depth.unwrap_or(1).min(3);
 
-        // 1홉 이웃 조회
-        let neighbors = db.get_neighbors(&params.node_id).map_err(to_mcp_error)?;
+        let neighbors = db.get_neighbors(&params.node_id)?;
 
-        // relation 필터 적용
         let filtered: Vec<_> = if let Some(ref rel) = params.relation {
             neighbors.into_iter().filter(|(_, r, _)| r == rel).collect()
         } else {
             neighbors
         };
 
-        // depth > 1이면 BFS로 확장 (2홉, 3홉)
         let mut all_neighbors = filtered.clone();
         if depth > 1 {
             let mut visited = std::collections::HashSet::new();
@@ -451,7 +367,6 @@ impl SeCallMcpServer {
             }
         }
 
-        // 결과 JSON
         let results: Vec<serde_json::Value> = all_neighbors
             .iter()
             .map(|(id, rel, dir)| {
@@ -464,13 +379,79 @@ impl SeCallMcpServer {
             .collect();
 
         let count = results.len();
-        let json = serde_json::json!({
+        Ok(serde_json::json!({
             "query_node": params.node_id,
             "depth": depth,
             "results": results,
             "count": count,
-        });
+        }))
+    }
+}
 
+/// MCP tool wrappers — 공통 do_*() 메서드를 CallToolResult로 래핑
+#[tool_router]
+impl SeCallMcpServer {
+    #[tool(
+        description = "Search agent session history. Use keyword queries for exact terms, semantic queries for conceptual search, or temporal queries for time-based filtering."
+    )]
+    async fn recall(
+        &self,
+        Parameters(params): Parameters<RecallParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let json = self
+            .do_recall(params)
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&json).unwrap_or_default(),
+        )]))
+    }
+
+    #[tool(
+        description = "Retrieve a specific session or turn. Use session_id for full session metadata, session_id:N for a specific turn."
+    )]
+    fn get(&self, Parameters(params): Parameters<GetParams>) -> Result<CallToolResult, McpError> {
+        let json = self
+            .do_get(params)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&json).unwrap_or_default(),
+        )]))
+    }
+
+    #[tool(description = "Show index health: session count, embedding status, recent ingests.")]
+    fn status(&self, _params: Parameters<StatusParams>) -> String {
+        match self.do_status() {
+            Ok(json) => serde_json::to_string_pretty(&json).unwrap_or_default(),
+            Err(e) => format!("error: {e}"),
+        }
+    }
+
+    #[tool(
+        description = "Search wiki knowledge pages. Returns matching wiki articles from projects, topics, and decisions."
+    )]
+    fn wiki_search(
+        &self,
+        Parameters(params): Parameters<WikiSearchParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let json = self
+            .do_wiki_search(params)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&json).unwrap_or_default(),
+        )]))
+    }
+
+    #[tool(
+        description = "Query the knowledge graph. Find neighbors and relationships of a node (session, project, agent, tool). Use depth to expand traversal. Returns connected nodes and edge types."
+    )]
+    fn graph_query(
+        &self,
+        Parameters(params): Parameters<GraphQueryParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let json = self
+            .do_graph_query(params)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
         Ok(CallToolResult::success(vec![Content::text(
             serde_json::to_string_pretty(&json).unwrap_or_default(),
         )]))

--- a/crates/secall/src/commands/mod.rs
+++ b/crates/secall/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod migrate;
 pub mod model;
 pub mod recall;
 pub mod reindex;
+pub mod serve;
 pub mod status;
 pub mod sync;
 pub mod wiki;

--- a/crates/secall/src/commands/serve.rs
+++ b/crates/secall/src/commands/serve.rs
@@ -1,0 +1,24 @@
+use anyhow::Result;
+use secall_core::{
+    mcp::rest::start_rest_server,
+    search::tokenizer::create_tokenizer,
+    search::vector::create_vector_indexer,
+    search::{Bm25Indexer, SearchEngine},
+    store::{get_default_db_path, Database},
+    vault::Config,
+};
+
+pub async fn run(port: u16) -> Result<()> {
+    let db_path = get_default_db_path();
+    let db = Database::open(&db_path)?;
+
+    let config = Config::load_or_default();
+    let tok = create_tokenizer(&config.search.tokenizer)
+        .map_err(|e| anyhow::anyhow!("tokenizer init failed: {e}"))?;
+    let bm25 = Bm25Indexer::new(tok);
+    let vector = create_vector_indexer(&config).await;
+    let search = SearchEngine::new(bm25, vector);
+    let vault_path = config.vault.path.clone();
+
+    start_rest_server(db, search, vault_path, port).await
+}

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -166,6 +166,13 @@ enum Commands {
         http: Option<String>,
     },
 
+    /// Start REST API server for Obsidian plugin and external clients
+    Serve {
+        /// Port number (default: 8080)
+        #[arg(long, short, default_value = "8080")]
+        port: u16,
+    },
+
     /// Manage ONNX embedding models
     Model {
         #[command(subcommand)]
@@ -416,6 +423,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Mcp { http } => {
             commands::mcp::run(http).await?;
+        }
+        Commands::Serve { port } => {
+            commands::serve::run(port).await?;
         }
         Commands::Model { action } => match action {
             ModelAction::Download { force } => {

--- a/docs/plans/p25-obsidian-plugin-task-01.md
+++ b/docs/plans/p25-obsidian-plugin-task-01.md
@@ -1,0 +1,266 @@
+---
+type: task
+status: ready
+plan: p25-obsidian-plugin
+task_number: 1
+title: REST API 서버 (secall serve)
+updated_at: 2026-04-14
+---
+
+# Task 01 — REST API 서버 (`secall serve`)
+
+## 목표
+
+MCP tool 로직을 공통 레이어로 추출하고, REST 엔드포인트를 추가하여
+`secall serve --port 8080`으로 REST + MCP를 동시에 서빙한다.
+
+## 아키텍처
+
+```
+SeCallMcpServer
+├── do_recall()  ──┐
+├── do_get()     ──┤── 공통 로직 (Result<Value>)
+├── do_status()  ──┤
+├── do_wiki()    ──┤
+├── do_graph()   ──┘
+│
+├── #[tool] recall()      → CallToolResult  (MCP 진입점)
+├── #[tool] get()         → CallToolResult
+│   ...
+│
+├── REST handlers (axum)
+│   ├── POST /api/recall  → Json<Value>
+│   ├── POST /api/get     → Json<Value>
+│   ├── GET  /api/status  → Json<Value>
+│   ├── POST /api/wiki    → Json<Value>
+│   └── POST /api/graph   → Json<Value>
+│
+└── /mcp                  → 기존 MCP (StreamableHttpService)
+```
+
+## Changed files
+
+### 1. `crates/secall-core/src/mcp/server.rs` (수정)
+
+**핵심 변경**: 5개 MCP tool에서 핵심 로직을 `pub` 메서드로 추출.
+
+현재 각 tool 메서드는:
+1. params에서 값 추출
+2. db/search 호출 → serde_json::Value 생성
+3. CallToolResult::success(Content::text(...)) 로 래핑
+
+변경 후:
+```rust
+impl SeCallMcpServer {
+    // --- 공통 로직 (pub) ---
+
+    pub async fn do_recall(&self, params: RecallParams) -> Result<serde_json::Value, SecallError> {
+        // 기존 recall() 내부 로직 그대로 이동
+        // McpError 대신 SecallError 반환
+        // 마지막에 json!({...}) 반환 (CallToolResult 래핑 안 함)
+    }
+
+    pub fn do_get(&self, params: GetParams) -> Result<serde_json::Value, SecallError> { ... }
+
+    pub fn do_status(&self) -> Result<serde_json::Value, SecallError> {
+        // 기존 status()는 String 반환 → JSON으로 변경
+        let stats = db.get_stats()?;
+        Ok(json!({
+            "sessions": stats.session_count,
+            "turns": stats.turn_count,
+            "vectors": stats.vector_count,
+            "recent_ingests": stats.recent_ingests,
+        }))
+    }
+
+    pub fn do_wiki_search(&self, params: WikiSearchParams) -> Result<serde_json::Value, SecallError> { ... }
+    pub fn do_graph_query(&self, params: GraphQueryParams) -> Result<serde_json::Value, SecallError> { ... }
+
+    // --- MCP tool wrappers (기존 #[tool] 메서드) ---
+
+    #[tool(...)]
+    async fn recall(&self, Parameters(params): Parameters<RecallParams>) -> Result<CallToolResult, McpError> {
+        let json = self.do_recall(params).await.map_err(to_mcp_error)?;
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&json).unwrap_or_default(),
+        )]))
+    }
+    // ... get, status, wiki_search, graph_query 동일 패턴
+}
+```
+
+**에러 변환 주의**:
+- 기존 MCP tools에서 `self.db.lock().map_err(|e| McpError::...)` 사용 중
+- `do_*` 메서드에서는 `SecallError`로 통일: DB lock 실패 → `SecallError::Database(...)`
+- `SecallError`에 lock 실패 variant가 없으면 `anyhow::Error`로 변환하거나 `SecallError::Other` 사용
+
+**현재 SecallError variants 확인 필요**: `crates/secall-core/src/error.rs`에서 적절한 variant 확인.
+DB lock 실패를 감싸 반환할 variant가 없으면 추가하지 말고, `anyhow::Result<serde_json::Value>`로 반환 타입 사용.
+
+### 2. `crates/secall-core/src/mcp/rest.rs` (신규)
+
+REST 핸들러 + axum Router 정의.
+
+```rust
+use std::sync::Arc;
+use axum::{
+    extract::{Json, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Router,
+};
+use super::server::SeCallMcpServer;
+use super::tools::{RecallParams, GetParams, WikiSearchParams, GraphQueryParams};
+
+type AppState = Arc<SeCallMcpServer>;
+
+pub fn rest_router(server: SeCallMcpServer) -> Router {
+    let state: AppState = Arc::new(server);
+    Router::new()
+        .route("/api/recall", post(api_recall))
+        .route("/api/get", post(api_get))
+        .route("/api/status", get(api_status))
+        .route("/api/wiki", post(api_wiki))
+        .route("/api/graph", post(api_graph))
+        .with_state(state)
+}
+
+async fn api_recall(
+    State(server): State<AppState>,
+    Json(params): Json<RecallParams>,
+) -> impl IntoResponse {
+    match server.do_recall(params).await {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => error_response(e),
+    }
+}
+
+// api_get, api_status, api_wiki, api_graph 동일 패턴
+
+fn error_response(e: impl std::fmt::Display) -> axum::response::Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({"error": e.to_string()})),
+    ).into_response()
+}
+```
+
+**CORS**: Obsidian `app://obsidian.md` origin 허용 필요.
+tower-http의 CorsLayer 사용:
+```rust
+use tower_http::cors::{CorsLayer, Any};
+let cors = CorsLayer::new()
+    .allow_origin(Any)  // Phase 1에서는 Any, 추후 제한 가능
+    .allow_methods(Any)
+    .allow_headers(Any);
+```
+
+**tower-http 의존성 추가 필요** → Cargo.toml 수정 (아래 참조).
+
+### 3. `crates/secall-core/src/mcp/mod.rs` (수정)
+
+```rust
+pub mod instructions;
+pub mod rest;       // ← 추가
+pub mod server;
+pub mod tools;
+
+pub use server::{start_mcp_http_server, start_mcp_server, SeCallMcpServer};
+pub use rest::start_rest_server;  // ← 추가
+```
+
+### 4. `crates/secall-core/Cargo.toml` (수정)
+
+tower-http 의존성 추가:
+```toml
+[dependencies]
+tower-http = { version = "0.6", features = ["cors"] }
+```
+
+워크스페이스 Cargo.toml에도 추가:
+```toml
+tower-http = { version = "0.6", features = ["cors"] }
+```
+
+### 5. `crates/secall/src/commands/serve.rs` (신규)
+
+```rust
+use anyhow::Result;
+use secall_core::{
+    mcp::rest::start_rest_server,
+    search::tokenizer::create_tokenizer,
+    search::vector::create_vector_indexer,
+    search::{Bm25Indexer, SearchEngine},
+    store::{get_default_db_path, Database},
+    vault::Config,
+};
+
+pub async fn run(port: u16) -> Result<()> {
+    let db_path = get_default_db_path();
+    let db = Database::open(&db_path)?;
+
+    let config = Config::load_or_default();
+    let tok = create_tokenizer(&config.search.tokenizer)
+        .map_err(|e| anyhow::anyhow!("tokenizer init failed: {e}"))?;
+    let bm25 = Bm25Indexer::new(tok);
+    let vector = create_vector_indexer(&config).await;
+    let search = SearchEngine::new(bm25, vector);
+    let vault_path = config.vault.path.clone();
+
+    start_rest_server(db, search, vault_path, port).await
+}
+```
+
+### 6. `crates/secall/src/commands/mod.rs` (수정)
+
+```rust
+pub mod serve;  // ← 추가
+```
+
+### 7. `crates/secall/src/main.rs` (수정)
+
+Commands enum에 Serve variant 추가:
+```rust
+/// Start REST + MCP API server
+Serve {
+    /// Port number (default: 8080)
+    #[arg(long, short, default_value = "8080")]
+    port: u16,
+},
+```
+
+match arm 추가:
+```rust
+Commands::Serve { port } => {
+    commands::serve::run(port).await?;
+}
+```
+
+## Dependencies
+
+없음 (첫 번째 Task)
+
+## Verification
+
+```bash
+# 1. 타입 체크
+cargo check 2>&1 | tail -5
+
+# 2. 기존 테스트 통과 (MCP 리팩터링이 기존 동작을 깨지 않는지 확인)
+cargo test 2>&1 | tail -10
+
+# 3. serve 서버 기동 + REST API 호출
+# 터미널 1:
+# secall serve --port 8080
+# 터미널 2:
+# curl -s http://127.0.0.1:8080/api/status | head -5
+# curl -s -X POST http://127.0.0.1:8080/api/recall -H 'Content-Type: application/json' -d '{"queries":[{"type":"keyword","query":"rust"}]}' | head -20
+# Manual: secall serve --port 8080을 실행하고, 위 curl 명령으로 JSON 응답 확인
+```
+
+## Risks
+
+- **MCP tool 리팩터링**: `#[tool_router]` / `#[tool]` 매크로가 메서드 시그니처에 민감할 수 있음. `do_*` 메서드 추가 시 매크로가 간섭하지 않는지 확인 필요.
+- **DB lock 에러 타입 변환**: `Mutex::lock()` 실패 → SecallError 변환이 자연스럽지 않을 수 있음. `anyhow::Error`로 우회 가능.
+- **tower-http 버전 호환**: axum 0.8과 호환되는 tower-http 버전 확인 필요 (0.6.x 예상).

--- a/docs/plans/p25-obsidian-plugin.md
+++ b/docs/plans/p25-obsidian-plugin.md
@@ -114,22 +114,15 @@ seCall을 Obsidian 안에서 직접 사용할 수 있게 한다.
 
 **공수**: 2~3주
 
-## Subtasks
+## Subtasks (P25 범위: Phase 0-1)
 
 | # | Phase | 제목 | 핵심 파일 | depends_on |
 |---|-------|------|-----------|------------|
 | 01 | 0 | REST API 서버 (`secall serve`) | commands/serve.rs (신규) | 없음 |
 | 02 | 1 | Obsidian 플러그인 scaffold + recall | obsidian-secall/ (신규 디렉토리) | 01 |
 | 03 | 1 | 세션 조회 + 상태바 | obsidian-secall/src/ | 02 |
-| 04 | 2 | 데일리 노트 자동 생성 | obsidian-secall/src/ | 03 |
-| 05 | 2 | vault wikilink 생성 (`secall graph link`) | vault.rs, graph_repo.rs | 없음 |
-| 06 | 2 | Graph 탐색 뷰 | obsidian-secall/src/ | 03 |
-| 07 | 3 | Ingest 트리거 + SSE | serve.rs, obsidian-secall/ | 01, 03 |
-| 08 | 3 | Canvas 그래프 시각화 | obsidian-secall/src/ | 06 |
 
-Task 01, 05: 병렬 가능.
 Task 02~03: 순차 (01 완료 후).
-Task 04, 06: 순차 (03 완료 후), 상호 독립.
 
 ## 활용 시나리오
 
@@ -144,34 +137,25 @@ Task 04, 06: 순차 (03 완료 후), 상호 독립.
 - 결과 클릭 → vault 내 세션 MD 파일 바로 열기
 - 하단 상태바에 "seCall: 694 sessions, vectors ✓" 표시
 
-### Phase 2 완료 시
-- 매일 아침 Obsidian 열면 데일리 노트에 어제 작업 요약이 있음
-  ```markdown
-  # 2026-04-14 작업 일지
-
-  ## seCall (4 sessions)
-  - P24 GitHub 이슈 4건 일괄 수정 (#19, #21, #22, #23)
-  - PR #20 OpenVINO backend 리뷰 + 머지
-  - Wiki 파이프라인 검증 완료
-
-  ## tunaFlow (2 sessions)
-  - MCP 서버 설계 논의
-  ```
-- Obsidian Graph View에서 세션 간 관계 시각적 탐색
-- 토픽 "rust async" 클릭 → 관련 세션 5개 바로 확인
-
-### Phase 3 완료 시
-- Obsidian 안에서 ingest 버튼 → 새 세션 자동 수집 + 진행률 표시
-- Canvas에 그래프 노드를 시각적으로 배치하여 프로젝트 관계도 작성
-
 ## 비용/위험
 
 | 위험 | 대응 |
 |------|------|
 | REST + MCP 이중 API | 공통 로직 레이어로 해결. REST는 얇은 라우터만 |
-| Obsidian 모바일 | requestUrl/EventSource 모두 모바일 지원. child_process는 데스크톱 전용이므로 서버 자동 시작만 제한 |
+| Obsidian 모바일 | requestUrl 모바일 지원. child_process는 데스크톱 전용이므로 서버 자동 시작만 제한 |
 | 플러그인 배포 | 초기에는 수동 설치 (BRAT), 안정화 후 커뮤니티 스토어 등록 |
-| SSE 연결 관리 | Phase 3에서만 필요. MVP는 requestUrl만으로 충분 |
+
+## 향후 작업 (Phase 2-3, P25 범위 밖)
+
+### Phase 2 — 데일리 노트 + Graph 탐색
+- 데일리 노트 자동 생성 (temporal recall → 프로젝트별 그룹핑)
+- Graph 탐색 뷰 (인터랙티브 트리)
+- vault 세션 MD에 wikilink 자동 생성 (`secall graph link`)
+
+### Phase 3 — 고급 기능
+- Ingest 트리거 + SSE 진행률
+- Sync 상태 모니터링
+- Canvas 그래프 시각화
 
 ## 테스트 기준선 (2026-04-14)
 

--- a/docs/plans/p25-semantic-graph-obsidian-phase-0-1-result.md
+++ b/docs/plans/p25-semantic-graph-obsidian-phase-0-1-result.md
@@ -1,0 +1,71 @@
+# Implementation Result: P25 — Semantic Graph 활용 + Obsidian 플러그인 (Phase 0-1)
+
+> Developer: unknown
+> Branch: N/A
+> Date: 2026-04-14 18:25
+> Plan Revision: 0
+
+---
+
+## Summary
+
+먼저 `do_get()`이 반환하는 `SessionMeta` 구조체의 필드를 확인합니다.
+
+`SessionMeta`에 `start_time` 필드가 있습니다. 하지만 `do_get()`은 `get_session_meta()`를 호출하고 그 결과를 `serde_json::to_value()`로 직렬화합니다. Serialize가 `start_time`을 어떤 키로 내보내는지 확인합니다.
+
+`SessionMeta`에 `Serialize` derive가 없습니다. 그런데 `do_get()`에서 `serde_json::to_value(&meta)`를 호출하고 있습니다.
+
+`Serialize`가 없는데 `to_value()`를 호출하면 컴파일 에러가 나야 합니다. 하지만 `cargo check`가 통과했으므로... `get_session_meta`가 다른 타입을 반환하는지 확인합니다.
+
+이것으로 확인됐습니다. `get_session_meta`가 반환하는 `SessionMeta`는 `db.rs:235`의 것이 아니라 **다른** `SessionMeta`입니다. 검색 모듈의 것을 확인합니다.
+
+2개의 `SessionMeta`가 있습니다:
+
+1. **`search/bm25.rs:48`** — `Serialize` 있음, `date` 필드, `vault_path` 있음, `summary` 없음
+2. **`store/db.rs:235`** — `Serialize` **없음**, `start_time` 필드, `summary` 있음
+
+`get_session_meta`는 `session_repo.rs`의 trait 구현에서 반환합니다. import를 확인합니다.
+
+핵심 발견! `get_session_meta()`는 `search::bm25::SessionMeta`를 반환합니다. 이 구조체에는 `date` 필드가 있지 `start_time`은 없습니다. 그리고 `Serialize`가 있어서 `to_value()`가 동작합니다.
+
+따라서 `do_get()`가 반환하는 JSON에는 `start_time`이 아니라 `date`가 있습니다. `session-view.ts`에서 `data.start_time` → `data.date`로 수정하면 됩니다.
+
+또한 recommendation의 `basePath` 방어 코드도 함께 적용합니다.
+
+**Finding 수정**: `data.start_time` → `data.date`
+
+**Recommendation 적용**: `search-view.ts`의 `basePath` 방어 코드
+
+검증합니다.
+
+```
+Verification results for Rework:
+✅ `cargo check` — exit 0
+✅ `cargo test` — 274 passed, 0 failed
+✅ `npx tsc --noEmit --skipLibCheck` — exit 0
+✅ `npm run build` — exit 0
+✅ `ls -la main.js` — 5.6KB
+```
+
+## 수정 내용
+
+### Finding 1: `session-view.ts:55` — `data.start_time` → `data.date`
+- `do_get()`가 반환하는 `SessionMeta`는 `search/bm25.rs`의 것으로, `date` 필드 사용 (`start_time`은 존재하지 않음)
+- `session-view.ts:55`의 메타 줄을 `data.date`로 수정
+
+### Recommendation: `search-view.ts:64-67` — basePath 빈 문자열 방어
+- `vaultRoot`가 빈 문자열일 때 `startsWith("")`가 항상 참이 되어 경로 첫 글자가 잘리는 버그 방어
+- `vaultRoot && vaultPath.startsWith(vaultRoot + "/")` 조건으로 변경
+
+## Subtask Results
+
+### 1. 먼저 `do_get()`이 반환하는 `SessionMeta` 구조체의 필드를 확인합니다.
+
+`SessionMeta`에 `start_time` 필드가 있습니다. 하지만 `do_get()`은 `get_session_meta()`를 호출하고 그 결과를 `serde_json::to_value()`로 직렬화합니다. Serialize가 `start_time`을 어떤 키로 내보내는지 확인합니다.
+
+`SessionMeta`에 `Serialize` derive가 없습니다. 그런데 `do_get()`에서 `serde_json::to_value(&meta)`를 호출하고 있습니다.
+
+`Serialize`가 없는데 `to_value()`를 호출하면 컴파일 에러가 나야 합니다. 하지만 `cargo check`가 통과했으므로... `get_session_meta`가 다른 타입을 반환하는지 확인합니다.
+
+이것으로 확인됐습니다. `get_session_meta`가 반환하는 `SessionMeta`는 `db.r
+

--- a/docs/plans/p25-semantic-graph-obsidian-phase-0-1-review-r1.md
+++ b/docs/plans/p25-semantic-graph-obsidian-phase-0-1-review-r1.md
@@ -1,0 +1,32 @@
+# Review Report: P25 — Semantic Graph 활용 + Obsidian 플러그인 (Phase 0-1) — Round 1
+
+> Verdict: fail
+> Reviewer: 
+> Date: 2026-04-14 18:13
+> Plan Revision: 0
+
+---
+
+## Verdict
+
+**fail**
+
+## Findings
+
+1. obsidian-secall/src/search-view.ts:55 — `openSession()`과 결과 렌더링이 `vault_path`, `project`, `agent`, `date`, `summary`를 top-level 필드로 가정하지만, backend `do_recall()`은 `SearchResult`를 그대로 반환해서 메타데이터가 `metadata.{vault_path, project, agent, date}` 아래에 옵니다. 이 상태로는 vault 파일 열기 분기가 동작하지 않고, 검색 결과 메타도 비어 보입니다.
+2. crates/secall-core/src/mcp/server.rs:161 — `do_get(..., full=true)`는 `meta.vault_path`가 있을 때만 `content`를 채웁니다. 그래서 Task 03의 “vault_path 없는 세션 클릭 → SessionView에 메타+본문 표시” 경로에서 `obsidian-secall/src/session-view.ts:59` 이하의 본문 렌더링이 실행되지 않아, fallback 상세 뷰가 본문 없이 비어 있게 됩니다.
+
+## Recommendations
+
+1. recall 응답을 플러그인 기대 형태로 평탄화하거나, `search-view.ts`에서 `r.metadata`를 읽도록 타입과 렌더링을 맞추세요.
+2. `GET /api/get`의 `full=true`는 vault markdown이 없을 때 DB turn들을 합쳐 `content`를 만들어 주거나, 별도 상세 조회 payload를 정의해 SessionView가 항상 본문을 렌더링할 수 있게 하세요.
+3. result 문서의 Task 03 verification 블록이 중간에서 잘려 있어 추적성이 떨어집니다. 재작업 시에는 전체 검증 결과가 artifact에 남는지 확인하는 편이 좋습니다.
+
+## Subtask Verification
+
+| # | Subtask | Status |
+|---|---------|--------|
+| 1 | REST API 서버 (secall serve) | ✅ done |
+| 2 | Obsidian 플러그인 scaffold + recall | ✅ done |
+| 3 | 세션 조회 + 상태바 | ✅ done |
+

--- a/docs/plans/p25-semantic-graph-obsidian-phase-0-1-review-r2.md
+++ b/docs/plans/p25-semantic-graph-obsidian-phase-0-1-review-r2.md
@@ -1,0 +1,29 @@
+# Review Report: P25 — Semantic Graph 활용 + Obsidian 플러그인 (Phase 0-1) — Round 2
+
+> Verdict: fail
+> Reviewer: 
+> Date: 2026-04-14 18:19
+> Plan Revision: 0
+
+---
+
+## Verdict
+
+**fail**
+
+## Findings
+
+1. obsidian-secall/src/session-view.ts:55 — `SessionView`가 세션 메타 줄에서 `data.start_time`을 사용하지만, `crates/secall-core/src/mcp/server.rs:159-195`의 `do_get()`가 반환하는 세션 JSON에는 `start_time`이 없고 `date`만 있습니다. 이 상태로는 fallback 상세 뷰 상단 메타가 `… · undefined`로 표시됩니다.
+
+## Recommendations
+
+1. `obsidian-secall/src/search-view.ts:64-67`의 vault root 계산은 `adapter.basePath`가 비어 있을 때 `startsWith(\"\")`가 항상 참이어서 경로 첫 글자를 잘못 잘라낼 수 있습니다. `vaultRoot`가 truthy일 때만 prefix 제거를 수행하도록 방어하는 편이 안전합니다.
+
+## Subtask Verification
+
+| # | Subtask | Status |
+|---|---------|--------|
+| 1 | REST API 서버 (secall serve) | ✅ done |
+| 2 | Obsidian 플러그인 scaffold + recall | ✅ done |
+| 3 | 세션 조회 + 상태바 | ✅ done |
+

--- a/docs/plans/p25-semantic-graph-obsidian-phase-0-1-review-r3.md
+++ b/docs/plans/p25-semantic-graph-obsidian-phase-0-1-review-r3.md
@@ -1,0 +1,29 @@
+# Review Report: P25 — Semantic Graph 활용 + Obsidian 플러그인 (Phase 0-1) — Round 3
+
+> Verdict: pass
+> Reviewer: 
+> Date: 2026-04-14 18:26
+> Plan Revision: 0
+
+---
+
+## Verdict
+
+**pass**
+
+## Findings
+
+1. 없음
+
+## Recommendations
+
+1. `search-view.ts`의 `adapter.basePath` 접근은 비공식 API라, 추후 Obsidian 버전 차이에 대비한 설정 기반 fallback을 별도 이슈로 관리하는 편이 안전합니다.
+
+## Subtask Verification
+
+| # | Subtask | Status |
+|---|---------|--------|
+| 1 | REST API 서버 (secall serve) | ✅ done |
+| 2 | Obsidian 플러그인 scaffold + recall | ✅ done |
+| 3 | 세션 조회 + 상태바 | ✅ done |
+

--- a/docs/plans/p25-semantic-graph-obsidian-phase-0-1-task-01.md
+++ b/docs/plans/p25-semantic-graph-obsidian-phase-0-1-task-01.md
@@ -1,0 +1,294 @@
+---
+type: task
+status: ready
+plan: p25-semantic-graph-obsidian-phase-0-1
+task_number: 1
+title: REST API 서버 (secall serve)
+updated_at: 2026-04-14
+---
+
+# Task 01 — REST API 서버 (`secall serve`)
+
+## 목표
+
+MCP tool 로직을 `do_*()` 공통 메서드로 추출하고, REST 엔드포인트를 추가하여
+`secall serve --port 8080`으로 REST + MCP를 동시에 서빙한다.
+
+## Changed files
+
+### 1. `crates/secall-core/src/mcp/server.rs` (수정)
+
+**대상**: `SeCallMcpServer` impl 블록 (line 42~492)
+
+5개 MCP tool 각각에서 핵심 로직을 `do_*` pub 메서드로 추출.
+
+**추출 대상 메서드**:
+
+| 현재 tool 메서드 | 추출할 pub 메서드 | 반환 타입 |
+|-----------------|------------------|-----------|
+| `recall()` (line 57) | `pub async fn do_recall(&self, params: RecallParams) -> anyhow::Result<serde_json::Value>` | JSON |
+| `get()` (line 190) | `pub fn do_get(&self, params: GetParams) -> anyhow::Result<serde_json::Value>` | JSON |
+| `status()` (line 245) | `pub fn do_status(&self) -> anyhow::Result<serde_json::Value>` | JSON |
+| `wiki_search()` (line 266) | `pub fn do_wiki_search(&self, params: WikiSearchParams) -> anyhow::Result<serde_json::Value>` | JSON |
+| `graph_query()` (line 404) | `pub fn do_graph_query(&self, params: GraphQueryParams) -> anyhow::Result<serde_json::Value>` | JSON |
+
+**반환 타입 근거**: `SecallError`에 DB lock 실패 variant가 없으므로 (error.rs line 1-48) `anyhow::Result`로 통일.
+
+**변환 패턴** (recall 예시):
+```rust
+// 추출된 공통 메서드
+pub async fn do_recall(&self, params: RecallParams) -> anyhow::Result<serde_json::Value> {
+    let limit = params.limit.unwrap_or(10).min(50);
+    // ... 기존 recall() 로직 그대로 ...
+    // McpError → anyhow::anyhow!() 로 변환
+    // 마지막: CallToolResult 래핑 대신 json!({...}) 직접 반환
+    Ok(json!({ "results": all_results, "count": count, "related_sessions": related_sessions }))
+}
+
+// MCP tool wrapper (기존 시그니처 유지)
+#[tool(...)]
+async fn recall(&self, Parameters(params): Parameters<RecallParams>) -> Result<CallToolResult, McpError> {
+    let json = self.do_recall(params).await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+    Ok(CallToolResult::success(vec![Content::text(
+        serde_json::to_string_pretty(&json).unwrap_or_default(),
+    )]))
+}
+```
+
+**status 특별 처리**: 현재 `String` 반환 → `do_status()`는 `serde_json::Value` 반환하도록 변경.
+MCP tool wrapper에서는 `Content::text(to_string_pretty(...))` 로 래핑.
+
+```rust
+pub fn do_status(&self) -> anyhow::Result<serde_json::Value> {
+    let db = self.db.lock().map_err(|e| anyhow::anyhow!("DB lock: {e}"))?;
+    let stats = db.get_stats()?;  // DbStats: line 212
+    Ok(serde_json::json!({
+        "sessions": stats.session_count,
+        "turns": stats.turn_count,
+        "vectors": stats.vector_count,
+        "recent_ingests": stats.recent_ingests.len(),
+    }))
+}
+```
+
+### 2. `crates/secall-core/src/mcp/rest.rs` (신규)
+
+REST 핸들러 + axum Router + CORS 설정.
+
+```rust
+use std::sync::Arc;
+use axum::{
+    extract::{Json, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Router,
+};
+use tower_http::cors::{CorsLayer, Any};
+use super::server::SeCallMcpServer;
+use super::tools::{RecallParams, GetParams, WikiSearchParams, GraphQueryParams};
+
+type AppState = Arc<SeCallMcpServer>;
+
+/// REST API 라우터 생성
+pub fn rest_router(server: SeCallMcpServer) -> Router {
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let state: AppState = Arc::new(server);
+
+    Router::new()
+        .route("/api/recall", post(api_recall))
+        .route("/api/get", post(api_get))
+        .route("/api/status", get(api_status))
+        .route("/api/wiki", post(api_wiki))
+        .route("/api/graph", post(api_graph))
+        .layer(cors)
+        .with_state(state)
+}
+
+/// REST + MCP 통합 서버 시작
+pub async fn start_rest_server(
+    db: crate::store::Database,
+    search: crate::search::SearchEngine,
+    vault_path: std::path::PathBuf,
+    port: u16,
+) -> anyhow::Result<()> {
+    // SeCallMcpServer 인스턴스 생성
+    let db_arc = Arc::new(std::sync::Mutex::new(db));
+    let search_arc = Arc::new(search);
+    let server = SeCallMcpServer::new(db_arc, search_arc, vault_path);
+    let router = rest_router(server);
+
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+
+    tracing::info!(addr = %addr, "REST API server listening");
+    tracing::info!("endpoints: /api/recall, /api/get, /api/status, /api/wiki, /api/graph");
+
+    axum::serve(listener, router).await?;
+    Ok(())
+}
+```
+
+**핸들러 패턴** (5개 모두 동일):
+```rust
+async fn api_recall(State(s): State<AppState>, Json(p): Json<RecallParams>) -> impl IntoResponse {
+    match s.do_recall(p).await {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR,
+                   Json(serde_json::json!({"error": e.to_string()}))).into_response(),
+    }
+}
+
+async fn api_status(State(s): State<AppState>) -> impl IntoResponse {
+    match s.do_status() {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR,
+                   Json(serde_json::json!({"error": e.to_string()}))).into_response(),
+    }
+}
+```
+
+### 3. `crates/secall-core/src/mcp/mod.rs` (수정)
+
+현재 (line 1-5):
+```rust
+pub mod instructions;
+pub mod server;
+pub mod tools;
+
+pub use server::{start_mcp_http_server, start_mcp_server, SeCallMcpServer};
+```
+
+추가:
+```rust
+pub mod rest;
+pub use rest::start_rest_server;
+```
+
+### 4. `Cargo.toml` — 워크스페이스 (수정)
+
+`[workspace.dependencies]` 섹션에 tower-http 추가:
+```toml
+tower-http = { version = "0.6", features = ["cors"] }
+```
+
+### 5. `crates/secall-core/Cargo.toml` (수정)
+
+`[dependencies]` 섹션에 추가:
+```toml
+tower-http.workspace = true
+```
+
+### 6. `crates/secall/src/commands/serve.rs` (신규)
+
+```rust
+use anyhow::Result;
+use secall_core::{
+    mcp::rest::start_rest_server,
+    search::tokenizer::create_tokenizer,
+    search::vector::create_vector_indexer,
+    search::{Bm25Indexer, SearchEngine},
+    store::{get_default_db_path, Database},
+    vault::Config,
+};
+
+pub async fn run(port: u16) -> Result<()> {
+    let db_path = get_default_db_path();
+    let db = Database::open(&db_path)?;
+
+    let config = Config::load_or_default();
+    let tok = create_tokenizer(&config.search.tokenizer)
+        .map_err(|e| anyhow::anyhow!("tokenizer init failed: {e}"))?;
+    let bm25 = Bm25Indexer::new(tok);
+    let vector = create_vector_indexer(&config).await;
+    let search = SearchEngine::new(bm25, vector);
+    let vault_path = config.vault.path.clone();
+
+    start_rest_server(db, search, vault_path, port).await
+}
+```
+
+### 7. `crates/secall/src/commands/mod.rs` (수정)
+
+추가:
+```rust
+pub mod serve;
+```
+
+### 8. `crates/secall/src/main.rs` (수정)
+
+`Commands` enum (line 21~226)에 `Serve` variant 추가:
+```rust
+/// Start REST + MCP API server
+Serve {
+    /// Port number (default: 8080)
+    #[arg(long, short, default_value = "8080")]
+    port: u16,
+},
+```
+
+`match cli.command` (line 346~)에 arm 추가:
+```rust
+Commands::Serve { port } => {
+    commands::serve::run(port).await?;
+}
+```
+
+## Change description
+
+1. `server.rs`에서 5개 MCP tool의 핵심 로직을 `do_*()` pub 메서드로 추출
+2. 기존 `#[tool]` 메서드는 `do_*()` 호출 → CallToolResult 래핑하는 thin wrapper로 변경
+3. `rest.rs` 신규 생성: axum REST 핸들러 5개 + CorsLayer + `start_rest_server()`
+4. CLI에 `secall serve --port` 명령 추가
+5. tower-http 의존성 추가 (CORS용)
+
+## Dependencies
+
+- 다른 subtask 의존성 없음 (첫 번째 Task)
+- 추가 패키지: `tower-http 0.6` (axum 0.8 호환)
+
+## Verification
+
+```bash
+# 1. 타입 체크
+cargo check 2>&1 | tail -5
+
+# 2. 기존 테스트 통과 확인 (MCP 리팩터링이 기존 동작을 깨지 않는지)
+cargo test 2>&1 | tail -10
+
+# 3. serve 명령 help 확인
+cargo run -- serve --help
+
+# 4. REST API 통합 테스트 (Manual)
+# 터미널 1: cargo run -- serve --port 8080
+# 터미널 2:
+#   curl -s http://127.0.0.1:8080/api/status
+#   curl -s -X POST http://127.0.0.1:8080/api/recall \
+#     -H 'Content-Type: application/json' \
+#     -d '{"queries":[{"type":"keyword","query":"rust"}]}'
+#   curl -s -X POST http://127.0.0.1:8080/api/get \
+#     -H 'Content-Type: application/json' \
+#     -d '{"id":"6e5dd35d"}'
+```
+
+## Risks
+
+- **`#[tool_router]` 매크로 간섭**: `do_*` 메서드에는 `#[tool]` 어트리뷰트가 없으므로 매크로가 무시할 것으로 예상. 만약 간섭하면 `do_*` 메서드를 별도 `impl` 블록으로 분리.
+- **tower-http 버전**: axum 0.8 → tower-http 0.6.x가 호환 범위. `cargo check`에서 버전 충돌 시 0.5로 하향.
+- **DB lock contention**: REST와 MCP가 같은 `Arc<Mutex<Database>>`를 공유. 현재 MCP도 동일 패턴이므로 추가 위험 없음.
+- **`SeCallMcpServer` Clone**: 이미 `#[derive(Clone)]` — `Arc::new(server)` 후 핸들러에서 공유 가능.
+
+## Scope boundary
+
+수정 금지 파일:
+- `crates/secall-core/src/mcp/tools.rs` — param struct 정의는 변경하지 않음 (Serialize 추가 시에만 허용)
+- `crates/secall-core/src/mcp/instructions.rs` — 변경 불필요
+- `crates/secall-core/src/error.rs` — SecallError variant 추가 불필요 (anyhow::Result 사용)
+- `crates/secall-core/src/store/` — DB/repo 레이어 변경 없음
+- `crates/secall-core/src/search/` — 검색 레이어 변경 없음
+- `obsidian-secall/` — Task 02 영역

--- a/docs/plans/p25-semantic-graph-obsidian-phase-0-1-task-02.md
+++ b/docs/plans/p25-semantic-graph-obsidian-phase-0-1-task-02.md
@@ -1,0 +1,334 @@
+---
+type: task
+status: ready
+plan: p25-semantic-graph-obsidian-phase-0-1
+task_number: 2
+title: Obsidian 플러그인 scaffold + recall
+updated_at: 2026-04-14
+---
+
+# Task 02 — Obsidian 플러그인 scaffold + recall
+
+## 목표
+
+obsidian-sample-plugin 템플릿 기반으로 `obsidian-secall/` 디렉토리를 생성하고,
+REST API를 통한 검색 기능(recall)을 구현한다.
+
+## Changed files
+
+### 1. `obsidian-secall/package.json` (신규)
+
+```json
+{
+  "name": "obsidian-secall",
+  "version": "0.1.0",
+  "description": "seCall session search for Obsidian",
+  "main": "main.js",
+  "scripts": {
+    "dev": "node esbuild.config.mjs",
+    "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "esbuild": "^0.24.0",
+    "obsidian": "^1.7.0",
+    "typescript": "^5.6.0",
+    "tslib": "^2.7.0"
+  }
+}
+```
+
+### 2. `obsidian-secall/tsconfig.json` (신규)
+
+obsidian-sample-plugin 표준 설정:
+- `target: ES2018`, `module: ESNext`, `moduleResolution: node`
+- `strict: true`, `noImplicitAny: true`
+- `outDir: .` (esbuild가 번들링하므로 tsc는 타입 체크용)
+
+### 3. `obsidian-secall/esbuild.config.mjs` (신규)
+
+obsidian-sample-plugin 표준 esbuild 설정:
+- entry: `src/main.ts`
+- output: `main.js`
+- format: `cjs`, platform: `node`
+- external: `obsidian`, `electron`
+- banner: `/* obsidian-secall */`
+
+### 4. `obsidian-secall/manifest.json` (신규)
+
+```json
+{
+  "id": "obsidian-secall",
+  "name": "seCall",
+  "version": "0.1.0",
+  "minAppVersion": "1.5.0",
+  "description": "Search and browse seCall agent sessions",
+  "author": "d9ng",
+  "isDesktopOnly": false
+}
+```
+
+### 5. `obsidian-secall/src/main.ts` (신규)
+
+Plugin 클래스 + 설정 패널:
+
+```typescript
+import { Plugin, WorkspaceLeaf } from "obsidian";
+import { SeCallSettingTab, SeCallSettings, DEFAULT_SETTINGS } from "./settings";
+import { SearchView, SEARCH_VIEW_TYPE } from "./search-view";
+import { SeCallApi } from "./api";
+
+export default class SeCallPlugin extends Plugin {
+  settings: SeCallSettings;
+  api: SeCallApi;
+
+  async onload() {
+    await this.loadSettings();
+    this.api = new SeCallApi(this.settings.serverUrl);
+
+    // 검색 뷰 등록
+    this.registerView(SEARCH_VIEW_TYPE, (leaf) => new SearchView(leaf, this));
+
+    // 커맨드 팔레트: seCall: Search
+    this.addCommand({
+      id: "secall-search",
+      name: "Search",
+      callback: () => this.openSearchView(),
+    });
+
+    // 리본 아이콘
+    this.addRibbonIcon("search", "seCall Search", () => this.openSearchView());
+
+    // 설정 탭
+    this.addSettingTab(new SeCallSettingTab(this.app, this));
+  }
+
+  async openSearchView() {
+    const existing = this.app.workspace.getLeavesOfType(SEARCH_VIEW_TYPE);
+    if (existing.length > 0) {
+      this.app.workspace.revealLeaf(existing[0]);
+      return;
+    }
+    const leaf = this.app.workspace.getRightLeaf(false);
+    if (leaf) {
+      await leaf.setViewState({ type: SEARCH_VIEW_TYPE, active: true });
+      this.app.workspace.revealLeaf(leaf);
+    }
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+    this.api = new SeCallApi(this.settings.serverUrl);
+  }
+}
+```
+
+### 6. `obsidian-secall/src/settings.ts` (신규)
+
+설정 인터페이스 + SettingTab:
+
+```typescript
+export interface SeCallSettings {
+  serverUrl: string;
+}
+
+export const DEFAULT_SETTINGS: SeCallSettings = {
+  serverUrl: "http://127.0.0.1:8080",
+};
+```
+
+SettingTab: 서버 주소 입력 필드 1개.
+
+### 7. `obsidian-secall/src/api.ts` (신규)
+
+REST API 클라이언트 (Obsidian requestUrl 사용):
+
+```typescript
+import { requestUrl } from "obsidian";
+
+export class SeCallApi {
+  constructor(private baseUrl: string) {}
+
+  async recall(query: string, limit = 10) {
+    const resp = await requestUrl({
+      url: `${this.baseUrl}/api/recall`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        queries: [{ type: "keyword", query }],
+        limit,
+      }),
+    });
+    return resp.json;
+  }
+
+  async get(id: string, full = false) {
+    const resp = await requestUrl({
+      url: `${this.baseUrl}/api/get`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, full }),
+    });
+    return resp.json;
+  }
+
+  async status() {
+    const resp = await requestUrl({
+      url: `${this.baseUrl}/api/status`,
+      method: "GET",
+    });
+    return resp.json;
+  }
+}
+```
+
+### 8. `obsidian-secall/src/search-view.ts` (신규)
+
+ItemView: 사이드바 검색 패널.
+
+```typescript
+import { ItemView, WorkspaceLeaf, TextComponent } from "obsidian";
+import type SeCallPlugin from "./main";
+
+export const SEARCH_VIEW_TYPE = "secall-search";
+
+export class SearchView extends ItemView {
+  plugin: SeCallPlugin;
+  searchInput: TextComponent;
+  resultsEl: HTMLElement;
+
+  constructor(leaf: WorkspaceLeaf, plugin: SeCallPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType() { return SEARCH_VIEW_TYPE; }
+  getDisplayText() { return "seCall Search"; }
+  getIcon() { return "search"; }
+
+  async onOpen() {
+    const container = this.containerEl.children[1];
+    container.empty();
+
+    // 검색 입력
+    const searchBar = container.createDiv({ cls: "secall-search-bar" });
+    const input = searchBar.createEl("input", {
+      type: "text",
+      placeholder: "Search sessions...",
+      cls: "secall-search-input",
+    });
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") this.doSearch(input.value);
+    });
+
+    this.resultsEl = container.createDiv({ cls: "secall-results" });
+  }
+
+  async doSearch(query: string) {
+    if (!query.trim()) return;
+    this.resultsEl.empty();
+    this.resultsEl.createEl("div", { text: "Searching...", cls: "secall-loading" });
+
+    try {
+      const data = await this.plugin.api.recall(query);
+      this.resultsEl.empty();
+
+      if (!data.results || data.results.length === 0) {
+        this.resultsEl.createEl("div", { text: "No results found." });
+        return;
+      }
+
+      for (const r of data.results) {
+        const item = this.resultsEl.createDiv({ cls: "secall-result-item" });
+        item.createEl("div", { text: r.summary || r.session_id, cls: "secall-result-title" });
+        item.createEl("div", {
+          text: `${r.project || "?"} · ${r.agent} · ${r.date}`,
+          cls: "secall-result-meta",
+        });
+        item.createEl("div", {
+          text: r.snippet || "",
+          cls: "secall-result-snippet",
+        });
+        // 클릭 → vault 파일 열기 (Task 03에서 구현)
+      }
+    } catch (e) {
+      this.resultsEl.empty();
+      this.resultsEl.createEl("div", {
+        text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+        cls: "secall-error",
+      });
+    }
+  }
+}
+```
+
+### 9. `obsidian-secall/styles.css` (신규)
+
+기본 스타일:
+```css
+.secall-search-bar { padding: 8px; }
+.secall-search-input { width: 100%; }
+.secall-result-item { padding: 8px; border-bottom: 1px solid var(--background-modifier-border); cursor: pointer; }
+.secall-result-item:hover { background: var(--background-modifier-hover); }
+.secall-result-title { font-weight: 600; }
+.secall-result-meta { font-size: 0.85em; color: var(--text-muted); }
+.secall-result-snippet { font-size: 0.9em; margin-top: 4px; }
+.secall-error { color: var(--text-error); padding: 8px; }
+.secall-loading { color: var(--text-muted); padding: 8px; }
+```
+
+### 10. `obsidian-secall/.gitignore` (신규)
+
+```
+node_modules/
+main.js
+*.js.map
+```
+
+## Change description
+
+1. 프로젝트 루트에 `obsidian-secall/` 디렉토리 생성
+2. obsidian-sample-plugin 구조를 따라 빌드 설정 (esbuild + TypeScript)
+3. Plugin 클래스: 커맨드 팔레트 등록, 리본 아이콘, 설정 탭
+4. API 클라이언트: `requestUrl()`로 REST API 호출 (CORS 이슈 없음)
+5. SearchView: 사이드바 ItemView에 검색 입력 + 결과 목록 렌더링
+6. 검색 결과 클릭 동작은 Task 03으로 위임 (placeholder)
+
+## Dependencies
+
+- Task 01 완료 필수 (REST API 서버가 동작해야 테스트 가능)
+- npm 패키지: `obsidian`, `esbuild`, `typescript` (devDependencies)
+
+## Verification
+
+```bash
+# 1. npm install + TypeScript 타입 체크
+cd obsidian-secall && npm install && npx tsc --noEmit --skipLibCheck
+
+# 2. esbuild 번들 생성
+cd obsidian-secall && npm run build
+
+# 3. 번들 파일 존재 확인
+ls -la obsidian-secall/main.js
+
+# 4. Manual: Obsidian vault에 플러그인 심볼릭 링크 후 테스트
+# ln -s $(pwd)/obsidian-secall /path/to/vault/.obsidian/plugins/obsidian-secall
+# Obsidian 재시작 → 설정 → Community plugins → obsidian-secall 활성화
+# Cmd+P → "seCall: Search" → 검색어 입력 → 결과 표시 확인
+```
+
+## Risks
+
+- **Obsidian API 버전**: `obsidian@1.7.0` 기준. requestUrl, ItemView는 안정 API로 버전 이슈 낮음.
+- **requestUrl vs fetch**: Obsidian에서 `fetch()`는 CORS 제한 있음. `requestUrl()`은 Obsidian 네이티브 HTTP로 CORS 무관.
+- **esbuild 호환**: obsidian-sample-plugin 표준 설정 그대로 사용하여 안정성 확보.
+
+## Scope boundary
+
+수정 금지 파일:
+- `crates/` — Rust 코드 일체 변경 없음
+- `obsidian-secall/src/session-view.ts` — Task 03 영역 (이 Task에서 생성하지 않음)

--- a/docs/plans/p25-semantic-graph-obsidian-phase-0-1-task-03.md
+++ b/docs/plans/p25-semantic-graph-obsidian-phase-0-1-task-03.md
@@ -1,0 +1,225 @@
+---
+type: task
+status: ready
+plan: p25-semantic-graph-obsidian-phase-0-1
+task_number: 3
+title: 세션 조회 + 상태바
+updated_at: 2026-04-14
+---
+
+# Task 03 — 세션 조회 + 상태바
+
+## 목표
+
+검색 결과 클릭 시 vault 내 세션 MD 파일을 열거나 세션 상세 뷰를 표시하고,
+하단 상태바에 seCall 인덱스 상태를 표시한다.
+
+## Changed files
+
+### 1. `obsidian-secall/src/search-view.ts` (수정)
+
+검색 결과 아이템 클릭 핸들러 추가:
+
+```typescript
+// secall-result-item 클릭 이벤트
+item.addEventListener("click", () => {
+  this.openSession(r);
+});
+
+async openSession(result: SearchResult) {
+  // 1. vault_path가 있으면 vault 내 MD 파일 열기
+  if (result.vault_path) {
+    const file = this.app.vault.getAbstractFileByPath(result.vault_path);
+    if (file) {
+      await this.app.workspace.getLeaf(false).openFile(file as TFile);
+      return;
+    }
+  }
+
+  // 2. vault_path가 없으면 SessionView에서 API로 조회
+  const leaf = this.app.workspace.getLeaf(false);
+  await leaf.setViewState({
+    type: SESSION_VIEW_TYPE,
+    state: { sessionId: result.session_id },
+  });
+  this.app.workspace.revealLeaf(leaf);
+}
+```
+
+**vault_path 매핑 주의**: REST API recall 결과의 `vault_path`는 절대 경로.
+Obsidian vault 기준 상대 경로로 변환 필요:
+```typescript
+// vault root 경로 제거하여 상대 경로 추출
+const vaultRoot = (this.app.vault.adapter as any).basePath;
+const relativePath = result.vault_path.replace(vaultRoot + "/", "");
+const file = this.app.vault.getAbstractFileByPath(relativePath);
+```
+
+### 2. `obsidian-secall/src/session-view.ts` (신규)
+
+vault에 MD 파일이 없는 세션용 상세 뷰:
+
+```typescript
+import { ItemView, WorkspaceLeaf, MarkdownRenderer } from "obsidian";
+import type SeCallPlugin from "./main";
+
+export const SESSION_VIEW_TYPE = "secall-session";
+
+export class SessionView extends ItemView {
+  plugin: SeCallPlugin;
+  sessionId: string;
+
+  constructor(leaf: WorkspaceLeaf, plugin: SeCallPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType() { return SESSION_VIEW_TYPE; }
+  getDisplayText() { return `Session: ${this.sessionId || "..."}` ; }
+  getIcon() { return "file-text"; }
+
+  async setState(state: { sessionId: string }, result: any) {
+    this.sessionId = state.sessionId;
+    await this.render();
+    await super.setState(state, result);
+  }
+
+  getState() {
+    return { sessionId: this.sessionId };
+  }
+
+  async render() {
+    const container = this.containerEl.children[1];
+    container.empty();
+
+    if (!this.sessionId) {
+      container.createEl("div", { text: "No session selected." });
+      return;
+    }
+
+    container.createEl("div", { text: "Loading...", cls: "secall-loading" });
+
+    try {
+      const data = await this.plugin.api.get(this.sessionId, true);
+      container.empty();
+
+      // 메타데이터 헤더
+      const header = container.createDiv({ cls: "secall-session-header" });
+      header.createEl("h3", { text: data.summary || this.sessionId });
+      header.createEl("div", {
+        text: `${data.project || "?"} · ${data.agent} · ${data.start_time}`,
+        cls: "secall-result-meta",
+      });
+
+      // 본문 (Markdown 렌더링)
+      if (data.content) {
+        const contentEl = container.createDiv({ cls: "secall-session-content" });
+        await MarkdownRenderer.render(
+          this.app, data.content, contentEl, "", this.plugin
+        );
+      }
+    } catch (e) {
+      container.empty();
+      container.createEl("div", {
+        text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+        cls: "secall-error",
+      });
+    }
+  }
+}
+```
+
+### 3. `obsidian-secall/src/main.ts` (수정)
+
+상태바 + SessionView 등록:
+
+```typescript
+import { SessionView, SESSION_VIEW_TYPE } from "./session-view";
+
+export default class SeCallPlugin extends Plugin {
+  statusBarEl: HTMLElement;
+
+  async onload() {
+    // ... 기존 코드 ...
+
+    // SessionView 등록
+    this.registerView(SESSION_VIEW_TYPE, (leaf) => new SessionView(leaf, this));
+
+    // 상태바
+    this.statusBarEl = this.addStatusBarItem();
+    this.statusBarEl.setText("seCall: connecting...");
+    this.refreshStatus();
+
+    // 5분마다 상태 갱신
+    this.registerInterval(
+      window.setInterval(() => this.refreshStatus(), 300_000)
+    );
+  }
+
+  async refreshStatus() {
+    try {
+      const stats = await this.api.status();
+      const vectorIcon = stats.vectors > 0 ? "✓" : "✗";
+      this.statusBarEl.setText(
+        `seCall: ${stats.sessions} sessions, vectors ${vectorIcon}`
+      );
+    } catch {
+      this.statusBarEl.setText("seCall: offline");
+    }
+  }
+}
+```
+
+### 4. `obsidian-secall/styles.css` (수정)
+
+세션 뷰 스타일 추가:
+```css
+.secall-session-header { padding: 12px; border-bottom: 1px solid var(--background-modifier-border); }
+.secall-session-header h3 { margin: 0 0 4px 0; }
+.secall-session-content { padding: 12px; }
+```
+
+## Change description
+
+1. `search-view.ts`: 검색 결과 클릭 → vault MD 파일 열기 (vault_path 있을 때) 또는 SessionView 열기
+2. `session-view.ts` 신규: GET /api/get 호출 → 세션 메타 + Markdown 본문 렌더링
+3. `main.ts`: SessionView 등록, 상태바 위젯 (status API 주기적 호출)
+4. `styles.css`: 세션 뷰 스타일 추가
+
+## Dependencies
+
+- Task 02 완료 필수 (플러그인 scaffold + SearchView 기반)
+- Task 01 완료 필수 (GET /api/get, GET /api/status 엔드포인트)
+
+## Verification
+
+```bash
+# 1. TypeScript 타입 체크
+cd obsidian-secall && npx tsc --noEmit --skipLibCheck
+
+# 2. esbuild 번들 생성
+cd obsidian-secall && npm run build
+
+# 3. 번들 파일 크기 확인 (너무 크지 않은지)
+ls -la obsidian-secall/main.js
+
+# 4. Manual: Obsidian에서 플러그인 테스트
+# - secall serve --port 8080 실행 상태에서
+# - Obsidian 재시작 → 플러그인 활성화
+# - 하단 상태바에 "seCall: N sessions, vectors ✓" 표시 확인
+# - Cmd+P → "seCall: Search" → 검색 → 결과 클릭 → MD 파일 열림 확인
+# - vault_path 없는 세션 클릭 → SessionView에 메타+본문 표시 확인
+```
+
+## Risks
+
+- **vault_path 절대→상대 경로 변환**: Obsidian vault의 basePath 접근 방식이 `(adapter as any).basePath`로 비공식. `vault.adapter.getBasePath()`가 있는지 확인 필요. 없으면 설정에서 vault root 경로를 입력받는 대안.
+- **MarkdownRenderer.render**: 5번째 인자 (Component)가 버전에 따라 다를 수 있음. obsidian@1.7.0 기준 확인.
+- **상태바 polling**: 5분 간격이면 서버 부하 미미. offline 시 에러 무시 처리 완료.
+
+## Scope boundary
+
+수정 금지 파일:
+- `crates/` — Rust 코드 일체 변경 없음
+- `obsidian-secall/src/api.ts` — Task 02에서 완성, 이 Task에서 변경 불필요
+- `obsidian-secall/src/settings.ts` — Task 02에서 완성, 이 Task에서 변경 불필요

--- a/docs/plans/p25-semantic-graph-obsidian-phase-0-1.md
+++ b/docs/plans/p25-semantic-graph-obsidian-phase-0-1.md
@@ -1,0 +1,84 @@
+---
+type: plan
+status: in_progress
+updated_at: 2026-04-14
+slug: p25-semantic-graph-obsidian-phase-0-1
+---
+
+# P25 — Semantic Graph 활용 + Obsidian 플러그인 (Phase 0-1)
+
+## Background
+
+694세션에서 추출한 knowledge graph (3,433 노드, 9,152 엣지)의 활용도를 높이고,
+seCall을 Obsidian 안에서 직접 사용할 수 있게 한다.
+
+Phase 0-1 범위: REST API 레이어 + Obsidian 플러그인 MVP.
+Phase 2-3 (데일리 노트, Canvas 시각화 등)은 완료 후 별도 플랜으로 진행.
+
+## 아키텍처
+
+```
+┌─ Obsidian Plugin (TypeScript) ─┐
+│  requestUrl()  → 단건 요청      │
+│  settings: 서버 주소 설정       │
+└────────────┬───────────────────┘
+             │ HTTP (localhost)
+             ▼
+┌─ secall serve --port 8080 ─────────────────┐
+│  axum Router                                │
+│  ├─ POST /api/recall   ──┐                 │
+│  ├─ POST /api/get      ──┤                 │
+│  ├─ GET  /api/status   ──┤→ do_*() 공통    │
+│  ├─ POST /api/wiki     ──┤   로직 메서드   │
+│  ├─ POST /api/graph    ──┘                 │
+│  └─ /mcp               ← 기존 MCP (Claude Code용) │
+└────────────────────────────────────────────┘
+```
+
+핵심: `SeCallMcpServer`에 `do_*()` pub 메서드를 추출하여 공통 레이어로 사용.
+REST와 MCP 모두 이 메서드를 호출하되, 각각의 응답 형식으로 래핑.
+
+## Subtasks
+
+| # | Phase | 제목 | 핵심 파일 | depends_on |
+|---|-------|------|-----------|------------|
+| 01 | 0 | REST API 서버 (`secall serve`) | `mcp/server.rs`, `mcp/rest.rs`(신규), `commands/serve.rs`(신규) | 없음 |
+| 02 | 1 | Obsidian 플러그인 scaffold + recall | `obsidian-secall/`(신규 디렉토리) | 01 |
+| 03 | 1 | 세션 조회 + 상태바 | `obsidian-secall/src/` | 02 |
+
+Task 02~03: 순차 (01 완료 후).
+
+## 활용 시나리오
+
+### Phase 0 완료 시
+- `secall serve --port 8080` 실행
+- curl/브라우저에서 REST API 직접 호출 가능
+- 외부 스크립트(Python 등)에서 seCall 데이터 활용 가능
+
+### Phase 1 완료 시 (MVP)
+- Obsidian에서 Cmd+P → "seCall: Search" → 검색어 입력
+- 사이드바에 검색 결과 목록 표시
+- 결과 클릭 → vault 내 세션 MD 파일 바로 열기
+- 하단 상태바에 "seCall: 694 sessions, vectors ✓" 표시
+
+## 비용/위험
+
+| 위험 | 대응 |
+|------|------|
+| REST + MCP 이중 API | `do_*()` 공통 레이어로 로직 중복 제거 |
+| Obsidian 모바일 | requestUrl 모바일 지원. child_process 미사용 |
+| 플러그인 배포 | 초기에는 수동 설치 (BRAT), 안정화 후 커뮤니티 스토어 |
+| `#[tool_router]` 매크로 간섭 | `do_*`는 `#[tool]` 없는 일반 메서드 — 매크로 영향 없음 |
+
+## 향후 작업 (Phase 2-3, 이 플랜 범위 밖)
+
+- Phase 2: 데일리 노트 자동 생성, Graph 탐색 뷰, vault wikilink 자동 생성
+- Phase 3: Ingest 트리거 + SSE 진행률, Canvas 그래프 시각화
+
+## 테스트 기준선 (2026-04-14)
+
+```
+secall-core: 253 passed, 0 failed, 10 ignored
+secall:      16 passed (+ 4 integration)
+총:          273 passed
+```

--- a/obsidian-secall/.gitignore
+++ b/obsidian-secall/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+main.js
+*.js.map

--- a/obsidian-secall/esbuild.config.mjs
+++ b/obsidian-secall/esbuild.config.mjs
@@ -1,0 +1,41 @@
+import esbuild from "esbuild";
+import process from "process";
+
+const prod = process.argv[2] === "production";
+
+const context = await esbuild.context({
+  banner: {
+    js: "/* obsidian-secall */",
+  },
+  entryPoints: ["src/main.ts"],
+  bundle: true,
+  external: [
+    "obsidian",
+    "electron",
+    "@codemirror/autocomplete",
+    "@codemirror/collab",
+    "@codemirror/commands",
+    "@codemirror/language",
+    "@codemirror/lint",
+    "@codemirror/search",
+    "@codemirror/state",
+    "@codemirror/view",
+    "@lezer/common",
+    "@lezer/highlight",
+    "@lezer/lr",
+  ],
+  format: "cjs",
+  target: "es2018",
+  logLevel: "info",
+  sourcemap: prod ? false : "inline",
+  treeShaking: true,
+  outfile: "main.js",
+  minify: prod,
+});
+
+if (prod) {
+  await context.rebuild();
+  process.exit(0);
+} else {
+  await context.watch();
+}

--- a/obsidian-secall/manifest.json
+++ b/obsidian-secall/manifest.json
@@ -1,0 +1,9 @@
+{
+  "id": "obsidian-secall",
+  "name": "seCall",
+  "version": "0.1.0",
+  "minAppVersion": "1.5.0",
+  "description": "Search and browse seCall agent sessions",
+  "author": "d9ng",
+  "isDesktopOnly": false
+}

--- a/obsidian-secall/package.json
+++ b/obsidian-secall/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "obsidian-secall",
+  "version": "0.1.0",
+  "description": "seCall session search for Obsidian",
+  "main": "main.js",
+  "scripts": {
+    "dev": "node esbuild.config.mjs",
+    "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "esbuild": "^0.24.0",
+    "obsidian": "^1.7.0",
+    "typescript": "^5.6.0",
+    "tslib": "^2.7.0"
+  }
+}

--- a/obsidian-secall/src/api.ts
+++ b/obsidian-secall/src/api.ts
@@ -1,0 +1,36 @@
+import { requestUrl } from "obsidian";
+
+export class SeCallApi {
+  constructor(private baseUrl: string) {}
+
+  async recall(query: string, limit = 10) {
+    const resp = await requestUrl({
+      url: `${this.baseUrl}/api/recall`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        queries: [{ type: "keyword", query }],
+        limit,
+      }),
+    });
+    return resp.json;
+  }
+
+  async get(id: string, full = false) {
+    const resp = await requestUrl({
+      url: `${this.baseUrl}/api/get`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, full }),
+    });
+    return resp.json;
+  }
+
+  async status() {
+    const resp = await requestUrl({
+      url: `${this.baseUrl}/api/status`,
+      method: "GET",
+    });
+    return resp.json;
+  }
+}

--- a/obsidian-secall/src/main.ts
+++ b/obsidian-secall/src/main.ts
@@ -1,0 +1,73 @@
+import { Plugin } from "obsidian";
+import { SeCallSettingTab, type SeCallSettings, DEFAULT_SETTINGS } from "./settings";
+import { SearchView, SEARCH_VIEW_TYPE } from "./search-view";
+import { SessionView, SESSION_VIEW_TYPE } from "./session-view";
+import { SeCallApi } from "./api";
+
+export default class SeCallPlugin extends Plugin {
+  settings!: SeCallSettings;
+  api!: SeCallApi;
+  statusBarEl!: HTMLElement;
+
+  async onload() {
+    await this.loadSettings();
+    this.api = new SeCallApi(this.settings.serverUrl);
+
+    this.registerView(SEARCH_VIEW_TYPE, (leaf) => new SearchView(leaf, this));
+    this.registerView(SESSION_VIEW_TYPE, (leaf) => new SessionView(leaf, this));
+
+    this.addCommand({
+      id: "secall-search",
+      name: "Search",
+      callback: () => this.openSearchView(),
+    });
+
+    this.addRibbonIcon("search", "seCall Search", () => this.openSearchView());
+
+    this.addSettingTab(new SeCallSettingTab(this.app, this));
+
+    // 상태바
+    this.statusBarEl = this.addStatusBarItem();
+    this.statusBarEl.setText("seCall: connecting...");
+    this.refreshStatus();
+
+    // 5분마다 상태 갱신
+    this.registerInterval(
+      window.setInterval(() => this.refreshStatus(), 300_000)
+    );
+  }
+
+  async openSearchView() {
+    const existing = this.app.workspace.getLeavesOfType(SEARCH_VIEW_TYPE);
+    if (existing.length > 0) {
+      this.app.workspace.revealLeaf(existing[0]);
+      return;
+    }
+    const leaf = this.app.workspace.getRightLeaf(false);
+    if (leaf) {
+      await leaf.setViewState({ type: SEARCH_VIEW_TYPE, active: true });
+      this.app.workspace.revealLeaf(leaf);
+    }
+  }
+
+  async refreshStatus() {
+    try {
+      const stats = await this.api.status();
+      const vectorIcon = stats.vectors > 0 ? "\u2713" : "\u2717";
+      this.statusBarEl.setText(
+        `seCall: ${stats.sessions} sessions, vectors ${vectorIcon}`
+      );
+    } catch {
+      this.statusBarEl.setText("seCall: offline");
+    }
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+    this.api = new SeCallApi(this.settings.serverUrl);
+  }
+}

--- a/obsidian-secall/src/search-view.ts
+++ b/obsidian-secall/src/search-view.ts
@@ -1,0 +1,129 @@
+import { ItemView, TFile, WorkspaceLeaf } from "obsidian";
+import type SeCallPlugin from "./main";
+import { SESSION_VIEW_TYPE } from "./session-view";
+
+interface SearchResultMeta {
+  agent: string;
+  project?: string;
+  date: string;
+  vault_path?: string;
+  summary?: string;
+}
+
+interface SearchResult {
+  session_id: string;
+  snippet?: string;
+  metadata: SearchResultMeta;
+}
+
+export const SEARCH_VIEW_TYPE = "secall-search";
+
+export class SearchView extends ItemView {
+  plugin: SeCallPlugin;
+  resultsEl!: HTMLElement;
+
+  constructor(leaf: WorkspaceLeaf, plugin: SeCallPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType() {
+    return SEARCH_VIEW_TYPE;
+  }
+
+  getDisplayText() {
+    return "seCall Search";
+  }
+
+  getIcon() {
+    return "search";
+  }
+
+  async onOpen() {
+    const container = this.containerEl.children[1] as HTMLElement;
+    container.empty();
+
+    const searchBar = container.createDiv({ cls: "secall-search-bar" });
+    const input = searchBar.createEl("input", {
+      type: "text",
+      placeholder: "Search sessions...",
+      cls: "secall-search-input",
+    });
+    input.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "Enter") this.doSearch(input.value);
+    });
+
+    this.resultsEl = container.createDiv({ cls: "secall-results" });
+  }
+
+  async openSession(result: SearchResult) {
+    const vaultPath = result.metadata.vault_path;
+    if (vaultPath) {
+      // vault_path는 절대 경로 — vault root 기준 상대 경로로 변환
+      const adapter = this.app.vault.adapter as any;
+      const vaultRoot: string = adapter.basePath || "";
+      const relativePath =
+        vaultRoot && vaultPath.startsWith(vaultRoot + "/")
+          ? vaultPath.slice(vaultRoot.length + 1)
+          : vaultPath;
+      const file = this.app.vault.getAbstractFileByPath(relativePath);
+      if (file instanceof TFile) {
+        await this.app.workspace.getLeaf(false).openFile(file);
+        return;
+      }
+    }
+
+    // vault 파일이 없으면 SessionView로 API 조회
+    const leaf = this.app.workspace.getLeaf(false);
+    await leaf.setViewState({
+      type: SESSION_VIEW_TYPE,
+      state: { sessionId: result.session_id },
+    });
+    this.app.workspace.revealLeaf(leaf);
+  }
+
+  async doSearch(query: string) {
+    if (!query.trim()) return;
+    this.resultsEl.empty();
+    this.resultsEl.createEl("div", {
+      text: "Searching...",
+      cls: "secall-loading",
+    });
+
+    try {
+      const data = await this.plugin.api.recall(query);
+      this.resultsEl.empty();
+
+      if (!data.results || data.results.length === 0) {
+        this.resultsEl.createEl("div", { text: "No results found." });
+        return;
+      }
+
+      for (const r of data.results) {
+        const meta = r.metadata;
+        const item = this.resultsEl.createDiv({ cls: "secall-result-item" });
+        item.createEl("div", {
+          text: meta.summary || r.session_id,
+          cls: "secall-result-title",
+        });
+        item.createEl("div", {
+          text: `${meta.project || "?"} \u00b7 ${meta.agent} \u00b7 ${meta.date}`,
+          cls: "secall-result-meta",
+        });
+        if (r.snippet) {
+          item.createEl("div", {
+            text: r.snippet,
+            cls: "secall-result-snippet",
+          });
+        }
+        item.addEventListener("click", () => this.openSession(r));
+      }
+    } catch (e) {
+      this.resultsEl.empty();
+      this.resultsEl.createEl("div", {
+        text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+        cls: "secall-error",
+      });
+    }
+  }
+}

--- a/obsidian-secall/src/session-view.ts
+++ b/obsidian-secall/src/session-view.ts
@@ -1,0 +1,79 @@
+import { ItemView, MarkdownRenderer, type ViewStateResult, WorkspaceLeaf } from "obsidian";
+import type SeCallPlugin from "./main";
+
+export const SESSION_VIEW_TYPE = "secall-session";
+
+export class SessionView extends ItemView {
+  plugin: SeCallPlugin;
+  sessionId!: string;
+
+  constructor(leaf: WorkspaceLeaf, plugin: SeCallPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType() {
+    return SESSION_VIEW_TYPE;
+  }
+
+  getDisplayText() {
+    return `Session: ${this.sessionId || "..."}`;
+  }
+
+  getIcon() {
+    return "file-text";
+  }
+
+  async setState(state: { sessionId: string }, result: ViewStateResult) {
+    this.sessionId = state.sessionId;
+    await this.render();
+    await super.setState(state, result);
+  }
+
+  getState() {
+    return { sessionId: this.sessionId };
+  }
+
+  async render() {
+    const container = this.containerEl.children[1] as HTMLElement;
+    container.empty();
+
+    if (!this.sessionId) {
+      container.createEl("div", { text: "No session selected." });
+      return;
+    }
+
+    container.createEl("div", { text: "Loading...", cls: "secall-loading" });
+
+    try {
+      const data = await this.plugin.api.get(this.sessionId, true);
+      container.empty();
+
+      const header = container.createDiv({ cls: "secall-session-header" });
+      header.createEl("h3", { text: data.summary || this.sessionId });
+      header.createEl("div", {
+        text: `${data.project || "?"} \u00b7 ${data.agent} \u00b7 ${data.date}`,
+        cls: "secall-result-meta",
+      });
+
+      if (data.content) {
+        const contentEl = container.createDiv({
+          cls: "secall-session-content",
+        });
+        await MarkdownRenderer.render(
+          this.app,
+          data.content,
+          contentEl,
+          "",
+          this.plugin
+        );
+      }
+    } catch (e) {
+      container.empty();
+      container.createEl("div", {
+        text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+        cls: "secall-error",
+      });
+    }
+  }
+}

--- a/obsidian-secall/src/settings.ts
+++ b/obsidian-secall/src/settings.ts
@@ -1,0 +1,37 @@
+import { App, PluginSettingTab, Setting } from "obsidian";
+import type SeCallPlugin from "./main";
+
+export interface SeCallSettings {
+  serverUrl: string;
+}
+
+export const DEFAULT_SETTINGS: SeCallSettings = {
+  serverUrl: "http://127.0.0.1:8080",
+};
+
+export class SeCallSettingTab extends PluginSettingTab {
+  plugin: SeCallPlugin;
+
+  constructor(app: App, plugin: SeCallPlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    new Setting(containerEl)
+      .setName("Server URL")
+      .setDesc("seCall REST API server address")
+      .addText((text) =>
+        text
+          .setPlaceholder("http://127.0.0.1:8080")
+          .setValue(this.plugin.settings.serverUrl)
+          .onChange(async (value) => {
+            this.plugin.settings.serverUrl = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
+}

--- a/obsidian-secall/styles.css
+++ b/obsidian-secall/styles.css
@@ -1,0 +1,54 @@
+.secall-search-bar {
+  padding: 8px;
+}
+
+.secall-search-input {
+  width: 100%;
+}
+
+.secall-result-item {
+  padding: 8px;
+  border-bottom: 1px solid var(--background-modifier-border);
+  cursor: pointer;
+}
+
+.secall-result-item:hover {
+  background: var(--background-modifier-hover);
+}
+
+.secall-result-title {
+  font-weight: 600;
+}
+
+.secall-result-meta {
+  font-size: 0.85em;
+  color: var(--text-muted);
+}
+
+.secall-result-snippet {
+  font-size: 0.9em;
+  margin-top: 4px;
+}
+
+.secall-error {
+  color: var(--text-error);
+  padding: 8px;
+}
+
+.secall-loading {
+  color: var(--text-muted);
+  padding: 8px;
+}
+
+.secall-session-header {
+  padding: 12px;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.secall-session-header h3 {
+  margin: 0 0 4px 0;
+}
+
+.secall-session-content {
+  padding: 12px;
+}

--- a/obsidian-secall/tsconfig.json
+++ b/obsidian-secall/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "module": "ESNext",
+    "target": "ES2018",
+    "allowJs": true,
+    "noImplicitAny": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "isolatedModules": true,
+    "strictNullChecks": true,
+    "lib": ["DOM", "ES5", "ES6", "ES7"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- MCP 도구 로직을 `do_*()` 공유 메서드로 추출, axum REST 엔드포인트 5개 추가 (`/api/recall`, `/api/get`, `/api/status`, `/api/wiki`, `/api/graph`) + CORS
- `secall serve --port <PORT>` CLI 명령어 추가
- Obsidian 플러그인 MVP: 검색 뷰, 세션 뷰(마크다운 렌더링), 상태바, 설정 탭
- vault 파일이 없는 세션은 DB turns에서 fallback content 생성

## Changed components

- `crates/secall-core/src/mcp/server.rs` — do_*() 추출 리팩토링
- `crates/secall-core/src/mcp/rest.rs` — 신규 REST 라우터
- `crates/secall/src/commands/serve.rs` — 신규 serve 명령어
- `obsidian-secall/` — 신규 Obsidian 플러그인 디렉토리

## Test plan

- [ ] `cargo test` — 기존 274 테스트 통과 확인
- [ ] `cargo run -- serve --port 8080` 후 `curl http://127.0.0.1:8080/api/status` 응답 확인
- [ ] `curl -X POST http://127.0.0.1:8080/api/recall -H 'Content-Type: application/json' -d '{"query":"test"}'` 검색 동작 확인
- [ ] Obsidian에서 플러그인 로드 후 검색/세션 뷰 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)