### PR TITLE
feat: add Codex backend for wiki update

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -111,7 +111,7 @@ vault/
     └── graph.json   # Node/edge data
 ```
 
-- **Wiki generation** via pluggable LLM backends (`secall wiki update --backend claude|ollama|lmstudio`)
+- **Wiki generation** via pluggable LLM backends (`secall wiki update --backend claude|codex|ollama|lmstudio`)
 - **Obsidian backlinks** (`[[]]`) connecting sessions ↔ wiki pages
 - Frontmatter metadata for Dataview queries (`summary` field for at-a-glance session identification)
 
@@ -300,6 +300,9 @@ session_type = "automated"
 # Use Claude Code (default)
 secall wiki update
 
+# Use Codex
+secall wiki update --backend codex
+
 # Use a local LLM backend
 secall wiki update --backend ollama
 secall wiki update --backend lmstudio
@@ -315,7 +318,7 @@ Configure the default backend in `config.toml`:
 
 ```toml
 [wiki]
-default_backend = "lmstudio"   # "claude" | "ollama" | "lmstudio"
+default_backend = "lmstudio"   # "claude" | "codex" | "ollama" | "lmstudio"
 
 [wiki.backends.lmstudio]
 api_url = "http://localhost:1234"
@@ -371,7 +374,7 @@ secall config path
 | `output.timezone` | Timezone (IANA) | `UTC` |
 | `ingest.classification.default` | Default session_type when no rule matches | `interactive` |
 | `ingest.classification.skip_embed_types` | Session types to skip vector embedding | `[]` |
-| `wiki.default_backend` | Wiki generation backend (`claude` / `ollama` / `lmstudio`) | `claude` |
+| `wiki.default_backend` | Wiki generation backend (`claude` / `codex` / `ollama` / `lmstudio`) | `claude` |
 | `wiki.backends.<name>.api_url` | Backend API endpoint | (default) |
 | `wiki.backends.<name>.model` | Model name for the backend | (default) |
 | `wiki.backends.<name>.max_tokens` | Max tokens to generate | `4096` |
@@ -398,7 +401,7 @@ Config file location:
 | `secall mcp [--http <addr>]` | Start MCP server |
 | `secall config show\|set\|path` | View/change settings |
 | `secall graph build\|stats\|export` | Knowledge graph management |
-| `secall wiki update [--backend claude\|ollama\|lmstudio]` | Wiki generation with backend selection |
+| `secall wiki update [--backend claude\|codex\|ollama\|lmstudio]` | Wiki generation with backend selection |
 | `secall wiki status` | Wiki status |
 | `secall model download\|info\|check` | ONNX model management |
 | `secall reindex --from-vault` | Rebuild DB from vault |
@@ -490,7 +493,7 @@ For auto-sync on session start/end:
 | ANN Index | usearch HNSW (macOS/Linux) |
 | MCP Server | rmcp (stdio + Streamable HTTP via axum) |
 | Vault | Obsidian-compatible Markdown |
-| Wiki Engine | Claude Code / Ollama / LM Studio (pluggable backends) |
+| Wiki Engine | Claude Code / Codex / Ollama / LM Studio (pluggable backends) |
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ vault/
     └── graph.json   # 노드/엣지 데이터
 ```
 
-- **위키 생성**: Claude Code 메타에이전트 기반 (`secall wiki update`)
+- **위키 생성**: pluggable LLM backend 기반 (`secall wiki update --backend claude|codex|ollama|lmstudio`)
 - **Obsidian 백링크** (`[[]]`)로 세션 ↔ 위키 페이지 연결
 - Dataview 쿼리를 위한 frontmatter 메타데이터 (`summary` 필드로 세션 내용 즉시 파악)
 
@@ -303,6 +303,9 @@ session_type = "automated"
 # Claude Code로 위키 업데이트 (기본값)
 secall wiki update
 
+# Codex로 위키 업데이트
+secall wiki update --backend codex
+
 # 로컬 LLM 백엔드 사용
 secall wiki update --backend ollama
 secall wiki update --backend lmstudio
@@ -318,7 +321,7 @@ secall wiki status
 
 ```toml
 [wiki]
-default_backend = "lmstudio"   # "claude" | "ollama" | "lmstudio"
+default_backend = "lmstudio"   # "claude" | "codex" | "ollama" | "lmstudio"
 
 [wiki.backends.lmstudio]
 api_url = "http://localhost:1234"
@@ -377,7 +380,7 @@ secall config path
 | `output.timezone` | 타임존 (IANA) | `UTC` |
 | `ingest.classification.default` | 분류 규칙 미매칭 시 기본 session_type | `interactive` |
 | `ingest.classification.skip_embed_types` | 임베딩을 스킵할 session_type 목록 | `[]` |
-| `wiki.default_backend` | 위키 생성 백엔드 (`claude` / `ollama` / `lmstudio`) | `claude` |
+| `wiki.default_backend` | 위키 생성 백엔드 (`claude` / `codex` / `ollama` / `lmstudio`) | `claude` |
 | `wiki.backends.<name>.api_url` | 백엔드 API 엔드포인트 | (기본값 사용) |
 | `wiki.backends.<name>.model` | 백엔드 모델 이름 | (기본값 사용) |
 | `wiki.backends.<name>.max_tokens` | 최대 생성 토큰 수 | `4096` |
@@ -404,7 +407,7 @@ secall config path
 | `secall mcp [--http <addr>]` | MCP 서버 시작 |
 | `secall config show\|set\|path` | 설정 확인/변경 |
 | `secall graph build\|stats\|export` | Knowledge Graph 관리 |
-| `secall wiki update [--backend claude\|ollama\|lmstudio]` | 위키 생성 (백엔드 선택 가능) |
+| `secall wiki update [--backend claude\|codex\|ollama\|lmstudio]` | 위키 생성 (백엔드 선택 가능) |
 | `secall wiki status` | 위키 상태 확인 |
 | `secall model download\|info\|check` | ONNX 모델 관리 |
 | `secall reindex --from-vault` | 볼트에서 DB 재구축 |
@@ -496,7 +499,7 @@ Claude Code 설정 (`~/.claude/settings.json`)에 추가:
 | ANN 인덱스 | usearch HNSW (macOS/Linux) |
 | MCP 서버 | rmcp (stdio + Streamable HTTP / axum) |
 | 볼트 | Obsidian 호환 Markdown |
-| 위키 엔진 | Claude Code / Ollama / LM Studio (플러그인 방식 백엔드) |
+| 위키 엔진 | Claude Code / Codex / Ollama / LM Studio (플러그인 방식 백엔드) |
 
 ## 출처
 
@@ -542,4 +545,3 @@ Claude Code 설정 (`~/.claude/settings.json`)에 추가:
 **Contact**: [d9ng@outlook.com](mailto:d9ng@outlook.com)
 
 </div>
-

--- a/crates/secall-core/Cargo.toml
+++ b/crates/secall-core/Cargo.toml
@@ -34,6 +34,7 @@ tracing.workspace = true
 gethostname.workspace = true
 serde_yaml.workspace = true
 zip.workspace = true
+tempfile = "3.27.0"
 openvino = { workspace = true, optional = true }
 libloading = { workspace = true, optional = true }
 
@@ -47,5 +48,4 @@ usearch.workspace = true
 openvino = ["dep:openvino", "dep:libloading"]
 
 [dev-dependencies]
-tempfile = "3.27.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }

--- a/crates/secall-core/src/wiki/codex.rs
+++ b/crates/secall-core/src/wiki/codex.rs
@@ -1,0 +1,61 @@
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+
+use super::WikiBackend;
+
+pub struct CodexBackend {
+    pub model: String,
+    pub vault_path: PathBuf,
+}
+
+#[async_trait]
+impl WikiBackend for CodexBackend {
+    fn name(&self) -> &'static str {
+        "codex"
+    }
+
+    async fn generate(&self, prompt: &str) -> anyhow::Result<String> {
+        use std::io::Write as _;
+        use std::process::Stdio;
+
+        if !crate::command_exists("codex") {
+            anyhow::bail!("Codex CLI not found in PATH. Install: https://github.com/openai/codex");
+        }
+
+        let output_file = tempfile::NamedTempFile::new()?;
+        let output_path = output_file.path().to_path_buf();
+
+        let mut child = std::process::Command::new("codex")
+            .args([
+                "exec",
+                "--skip-git-repo-check",
+                "--sandbox",
+                "workspace-write",
+                "-C",
+            ])
+            .arg(&self.vault_path)
+            .args(["-m", &self.model, "--output-last-message"])
+            .arg(&output_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(prompt.as_bytes())?;
+        }
+
+        let status = child.wait()?;
+        if !status.success() {
+            anyhow::bail!("codex exited with code {:?}", status.code());
+        }
+
+        let output = std::fs::read_to_string(&output_path)?;
+        if output.trim().is_empty() {
+            anyhow::bail!("codex returned empty output");
+        }
+
+        Ok(output)
+    }
+}

--- a/crates/secall-core/src/wiki/mod.rs
+++ b/crates/secall-core/src/wiki/mod.rs
@@ -1,4 +1,5 @@
 pub mod claude;
+pub mod codex;
 pub mod haiku;
 pub mod lint;
 pub mod lmstudio;
@@ -6,6 +7,7 @@ pub mod ollama;
 pub mod review;
 
 pub use claude::ClaudeBackend;
+pub use codex::CodexBackend;
 pub use haiku::HaikuBackend;
 pub use lmstudio::LmStudioBackend;
 pub use ollama::OllamaBackend;

--- a/crates/secall/src/commands/sync.rs
+++ b/crates/secall/src/commands/sync.rs
@@ -99,7 +99,7 @@ pub async fn run(local_only: bool, dry_run: bool, no_wiki: bool) -> Result<()> {
             }
             eprintln!("Updating wiki for {} new session(s)...", count);
             for sid in &ingest_result.new_session_ids {
-                match wiki::run_update("sonnet", None, None, Some(sid.as_str()), false, false, None)
+                match wiki::run_update(None, None, None, Some(sid.as_str()), false, false, None)
                     .await
                 {
                     Ok(()) => eprintln!("  ✓ wiki updated for {}", &sid[..sid.len().min(8)]),

--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -7,7 +7,7 @@ use secall_core::{
 };
 
 pub async fn run_update(
-    model: &str,
+    model: Option<&str>,
     backend: Option<&str>,
     since: Option<&str>,
     session: Option<&str>,
@@ -26,6 +26,7 @@ pub async fn run_update(
     let backend_name = backend
         .map(|s| s.to_string())
         .unwrap_or_else(|| config.wiki.default_backend.clone());
+    let resolved_model = resolve_backend_model(&config, &backend_name, model);
 
     // 2. Load prompt — haiku 백엔드는 세션 데이터를 직접 주입
     let prompt = if backend_name == "haiku" {
@@ -80,13 +81,17 @@ pub async fn run_update(
                 max_tokens: cfg.max_tokens,
             })
         }
+        "codex" => Box::new(secall_core::wiki::CodexBackend {
+            model: resolved_model.clone(),
+            vault_path: config.vault.path.clone(),
+        }),
         "claude" => Box::new(secall_core::wiki::ClaudeBackend {
-            model: model.to_string(),
+            model: resolved_model.clone(),
             vault_path: config.vault.path.clone(),
         }),
         _ => {
             anyhow::bail!(
-                "Unknown backend '{}'. Supported: claude, haiku, ollama, lmstudio",
+                "Unknown backend '{}'. Supported: claude, codex, haiku, ollama, lmstudio",
                 backend_name
             );
         }
@@ -324,6 +329,22 @@ pub async fn run_update(
     }
 
     Ok(())
+}
+
+fn resolve_backend_model(config: &Config, backend_name: &str, cli_model: Option<&str>) -> String {
+    if let Some(model) = cli_model {
+        return model.to_string();
+    }
+
+    if let Some(model) = config.wiki_backend_config(backend_name).model {
+        return model;
+    }
+
+    match backend_name {
+        "claude" => "sonnet".to_string(),
+        "codex" => "gpt-5.4".to_string(),
+        _ => String::new(),
+    }
 }
 
 pub fn run_status() -> Result<()> {

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -201,7 +201,7 @@ enum Commands {
         from_vault: bool,
     },
 
-    /// Manage wiki generation via Claude Code meta-agent
+    /// Manage wiki generation via pluggable LLM backends
     Wiki {
         #[command(subcommand)]
         action: WikiAction,
@@ -264,13 +264,13 @@ enum ModelAction {
 
 #[derive(Subcommand)]
 enum WikiAction {
-    /// Run wiki update using Claude Code as meta-agent
+    /// Run wiki update using a configurable LLM backend
     Update {
-        /// Model: opus or sonnet (Claude 백엔드 전용)
-        #[arg(long, default_value = "sonnet")]
-        model: String,
+        /// Model name (backend-dependent). Claude defaults to sonnet, Codex defaults to gpt-5.4
+        #[arg(long)]
+        model: Option<String>,
 
-        /// Backend: claude | haiku | ollama | lmstudio (기본값: config wiki.default_backend)
+        /// Backend: claude | codex | haiku | ollama | lmstudio (기본값: config wiki.default_backend)
         #[arg(long)]
         backend: Option<String>,
 
@@ -282,7 +282,7 @@ enum WikiAction {
         #[arg(long)]
         session: Option<String>,
 
-        /// Print the prompt without executing Claude Code
+        /// Print the prompt without executing the selected backend
         #[arg(long)]
         dry_run: bool,
 
@@ -462,7 +462,7 @@ async fn main() -> anyhow::Result<()> {
                 review_model,
             } => {
                 commands::wiki::run_update(
-                    &model,
+                    model.as_deref(),
                     backend.as_deref(),
                     since.as_deref(),
                     session.as_deref(),


### PR DESCRIPTION
## 배경

Codex를 메인으로 사용하는 경우, seCall의 ingest / search 흐름은 잘 맞지만 `wiki update`에서는 Codex를 선택할 수 없어 워크플로우가 끊깁니다. 이 PR은 그 간극을 줄이기 위해 `codex`를 `wiki update`의 선택 가능한 backend로 추가합니다.

## 변경 내용

- `wiki update`에 `--backend codex` 추가
- Codex backend 구현 추가
- backend별 기본 모델 처리 추가
  - `claude` -> `sonnet`
  - `codex` -> `gpt-5.4`
- `sync` 경로에서 Claude 모델을 하드코딩하지 않도록 조정
- README / README.en에 Codex wiki backend 지원 반영

## 구현 메모

Codex backend는 다음 방식으로 동작합니다.

```bash
codex exec --sandbox workspace-write --output-last-message <tmpfile>
```

이렇게 한 이유는 두 가지입니다.

1. `workspace-write`

`wiki update`는 실제 vault의 `wiki/` 파일을 생성하거나 수정해야 하므로 `read-only`로는 충분하지 않았습니다.

2. `--output-last-message`

`codex exec` stdout에는 최종 응답 외에도 배너, 세션 정보, 토큰 사용량 같은 메타 출력이 섞입니다. 그래서 stdout 파싱 대신 최종 응답만 안정적으로 얻을 수 있는 `--output-last-message`를 사용했습니다.

## 문서 반영 범위

- README / README.en에는 Codex backend 지원을 명시했습니다.
- `docs/reference/wiki-setup.md`는 Claude Code + 로컬 backend 중심 톤을 유지했습니다.

## 🔗 Related Issue
Closes #26 