### PR TITLE
fix(docs,init): hook 예시를 SessionStart/SessionEnd로 수정

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -474,12 +474,11 @@ For auto-sync on session start/end:
 ```json
 {
   "hooks": {
-    "PreToolUse": [{
-      "matcher": "Initialize",
+    "SessionStart": [{
+      "matcher": "startup|resume",
       "hooks": [{"type": "command", "command": "secall sync --local-only"}]
     }],
-    "PostToolUse": [{
-      "matcher": "Exit",
+    "SessionEnd": [{
       "hooks": [{"type": "command", "command": "secall sync"}]
     }]
   }

--- a/README.md
+++ b/README.md
@@ -480,12 +480,11 @@ Claude Code 설정 (`~/.claude/settings.json`)에 추가:
 ```json
 {
   "hooks": {
-    "PreToolUse": [{
-      "matcher": "Initialize",
+    "SessionStart": [{
+      "matcher": "startup|resume",
       "hooks": [{"type": "command", "command": "secall sync --local-only"}]
     }],
-    "PostToolUse": [{
-      "matcher": "Exit",
+    "SessionEnd": [{
       "hooks": [{"type": "command", "command": "secall sync"}]
     }]
   }

--- a/crates/secall/src/commands/init.rs
+++ b/crates/secall/src/commands/init.rs
@@ -261,8 +261,7 @@ fn print_completion_hints() {
     println!(
         r#"{{
   "hooks": {{
-    "PostToolUse": [{{
-      "matcher": "Exit",
+    "SessionEnd": [{{
       "hooks": [{{"type": "command", "command": "secall ingest --auto --cwd $PWD"}}]
     }}]
   }}

--- a/docs/reference/github-vault-sync.md
+++ b/docs/reference/github-vault-sync.md
@@ -65,15 +65,14 @@ secall sync
 ```json
 {
   "hooks": {
-    "PreToolUse": [{
-      "matcher": "Initialize",
+    "SessionStart": [{
+      "matcher": "startup|resume",
       "hooks": [{
         "type": "command",
         "command": "secall sync --local-only"
       }]
     }],
-    "PostToolUse": [{
-      "matcher": "Exit",
+    "SessionEnd": [{
       "hooks": [{
         "type": "command",
         "command": "secall sync"


### PR DESCRIPTION
## Summary
- README와 `docs/reference/github-vault-sync.md`, `secall init` 출력의 hook
  예시가 실제로 발동되지 않아 `SessionStart`/`SessionEnd`로 교체합니다.
- 안내 문자열·문서만 수정 — 동작 로직 변경 없음.

## Background
- `PreToolUse`/`PostToolUse`의 matcher는 **툴 이름**(`Bash`, `Edit` 등)을 받는
   필드입니다.
- 기존 예시의 `Initialize`/`Exit`는 내장 툴 목록에 없어 어떤 호출에도 매칭되지
   않습니다 → README대로 설정해도 `secall sync`가 한 번도 실행되지 않음.
- 의도가 세션 시작/종료이므로 `SessionStart`(matcher `startup|resume`) /
  `SessionEnd`(matcher 생략, 모든 종료 케이스) 가 맞다고 생각하였습니다.
- 변경 파일: `README.md`, `README.en.md`,
  `docs/reference/github-vault-sync.md`, `crates/secall/src/commands/init.rs`.

## Test plan
- [x] `cargo check -p secall` — pass
- [x] diff 검토 — 안내 문자열·문서 외 변경 없음
- [x] Claude Code 공식 문서의 matcher 표 / `SessionStart` / `SessionEnd`
  정의와 교차 검증

  ## 참고
  - Claude Code Hooks: https://docs.claude.com/en/docs/claude-code/hooks