### PR TITLE
feat(web): P35 Phase 3 — /api/tags + 무한 스크롤 + code-split

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -142,6 +142,9 @@ secall serve --port 8080
 - Wiki body (Phase 1): `GET /api/wiki/{project}`
 - Session metadata (Phase 0): `/api/sessions`, `/api/projects`, `/api/agents`, `PATCH /api/sessions/{id}/{tags,favorite}`
 - Session notes (Phase 2): `PATCH /api/sessions/{id}/notes`
+- Tag listing (Phase 3): `GET /api/tags?with_counts={true|false}`
+  - `true` (default): `{ "tags": [{ "name": "rust", "count": 12 }, ...] }`
+  - `false`: `{ "tags": ["rust", "search", ...] }`
 - Commands (Phase 1): `POST /api/commands/{sync,ingest,wiki-update}`
 - Job management (Phase 1): `GET /api/jobs`, `GET /api/jobs/{id}`, `GET /api/jobs/{id}/stream` (SSE), `POST /api/jobs/{id}/cancel` (501, planned for v1.1)
 
@@ -326,6 +329,11 @@ secall serve --port 8080
 - Graph visualization upgrade — dagre auto-layout + per-type node colors / icons + edge label toggle + legend
 - Session metadata mini-chart — turn role distribution (user/assistant/system) + top 5 tool usage frequency
 - Per-session user notes — markdown editor (1s autosave, `PATCH /api/sessions/{id}/notes`)
+
+**Phase 3 features** (P35, performance + accuracy):
+- `/api/tags` endpoint — accurate full tag set with usage counts (replaces 100-session heuristic)
+- SessionList infinite scroll — IntersectionObserver-based auto-load (page_size=100)
+- Code-split — per-route + vendor (react/query/radix/viz) chunks, initial entry JS ≤ 250 kB (gzip)
 
 ### Keyboard shortcuts (Phase 2)
 
@@ -711,6 +719,7 @@ This project was developed using AI coding agents (Claude Code, Codex) orchestra
 
 | Date | Version | Changes |
 |------|---------|---------|
+| 2026-05-02 | v0.6.0 | Web UI Phase 3 (P35): `/api/tags` endpoint (with_counts option, removes 100-session heuristic), SessionList infinite scroll (IntersectionObserver, page_size=100), Code-split (vendor react/query/radix/viz + per-route chunks, initial entry JS ≤ 250 kB gzip) |
 | 2026-05-02 | v0.5.0 | Web UI Phase 2 (P34): semantic search mode, search-term highlighting, multi-tag + date quick range, keyboard shortcuts (`?`/`/`/`j`/`k`/`[`/`]`/`g d/w/s/c/g`/`f`/`e`), related sessions panel, graph visualization upgrade (dagre + node colors/icons + legend), session metadata mini-chart, user notes editor (`PATCH /api/sessions/{id}/notes`), DB schema v7 |
 | 2026-05-02 | v0.4.0 | Web UI Phase 1 (P33): command triggers (Sync/Ingest/Wiki Update), SSE progress streaming (per phase), Job system (single queue + 7-day cleanup + interrupted recovery), global progress banner + toast, graph incremental (`secall ingest --auto-graph`, `secall sync --no-graph`), wiki body GET endpoint (`/api/wiki/{project}`), DB v6 (`jobs` table) |
 | 2026-04-15 | v0.3.2 | Gemini API backend (semantic graph + diary), Codex wiki backend (PR #29), REST API server (`secall serve`), Obsidian plugin (search/daily/graph views), daily work log (`secall log`), semantic edges (`fixes_bug`, `modifies_file`, `introduces_tech`, `discusses_topic`), auto-disable graph semantic in BM25-only mode (#25) |

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ secall serve --port 8080
 - 위키 본문 (Phase 1): `GET /api/wiki/{project}`
 - 세션 메타 (Phase 0): `/api/sessions`, `/api/projects`, `/api/agents`, `PATCH /api/sessions/{id}/{tags,favorite}`
 - 세션 노트 (Phase 2): `PATCH /api/sessions/{id}/notes`
+- 태그 목록 (Phase 3): `GET /api/tags?with_counts={true|false}`
+  - `true` (기본): `{ "tags": [{ "name": "rust", "count": 12 }, ...] }`
+  - `false`: `{ "tags": ["rust", "search", ...] }`
 - 명령 (Phase 1): `POST /api/commands/{sync,ingest,wiki-update}`
 - Job 관리 (Phase 1): `GET /api/jobs`, `GET /api/jobs/{id}`, `GET /api/jobs/{id}/stream` (SSE), `POST /api/jobs/{id}/cancel` (501, v1.1 예정)
 
@@ -325,6 +328,11 @@ secall serve --port 8080
 - 그래프 시각화 강화 — dagre 자동 레이아웃 + 노드 타입별 색상/아이콘 + 엣지 라벨 토글 + 범례
 - 세션 메타 mini-chart — turn role 분포 (user/assistant/system) + tool 사용 빈도 top 5
 - 사용자 노트 편집 — 세션별 markdown 노트 (autosave 1s, `PATCH /api/sessions/{id}/notes`)
+
+**Phase 3 기능** (P35, 성능 + 정확도):
+- `/api/tags` 엔드포인트 — 모든 태그 + 사용 빈도 정확 노출 (sessions 100건 휴리스틱 제거)
+- SessionList 무한 스크롤 — IntersectionObserver 기반 자동 로드 (page_size=100)
+- Code-split — 라우트별 + vendor (react/query/radix/viz) chunk 분리, 초기 진입 JS ≤ 250 kB (gzip)
 
 ### 키보드 단축키 (Phase 2)
 
@@ -717,6 +725,7 @@ Claude Code 설정 (`~/.claude/settings.json`)에 추가:
 
 | 날짜 | 버전 | 변경사항 |
 |------|------|---------|
+| 2026-05-02 | v0.6.0 | Web UI Phase 3 (P35): `/api/tags` 엔드포인트 (with_counts 옵션, 100세션 휴리스틱 제거), SessionList 무한 스크롤 (IntersectionObserver, page_size=100), Code-split (vendor react/query/radix/viz + per-route chunk, 초기 진입 JS ≤ 250 kB gzip) |
 | 2026-05-02 | v0.5.0 | Web UI Phase 2 (P34): 시맨틱 검색 모드 활성, 검색어 하이라이트, 다중 태그 + 날짜 quick range, 키보드 단축키 (`?`/`/`/`j`/`k`/`[`/`]`/`g d/w/s/c/g`/`f`/`e`), 관련 세션 패널, 그래프 시각화 강화 (dagre + 노드 색상/아이콘 + 범례), 세션 메타 mini-chart, 사용자 노트 편집 (`PATCH /api/sessions/{id}/notes`), DB 스키마 v7 |
 | 2026-05-02 | v0.4.0 | Web UI Phase 1 (P33): 명령 트리거 (Sync/Ingest/Wiki Update), SSE 진행 스트리밍 (phase별), Job 시스템 (단일 큐 + 7일 cleanup + interrupted 보정), 글로벌 진행 배너 + toast, 그래프 자동 증분 (`secall ingest --auto-graph`, `secall sync --no-graph`), 위키 본문 GET 엔드포인트 (`/api/wiki/{project}`), DB v6 (`jobs` 테이블) |
 | 2026-04-17 | v0.3.3 | LM Studio (OpenAI 호환) 시맨틱 백엔드 추가 (`--backend lmstudio`, #35), `secall sync --no-semantic` 플래그 추가 — GPU 메모리 경합 방지 (#34), Gemini Web ZIP ingest 지원 (#31), `graph semantic` CLI 백엔드 설정 옵션 (#30) |

--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -142,6 +142,7 @@ pub fn rest_router(server: SeCallMcpServer, executor: Arc<JobExecutor>) -> Route
         .route("/api/sessions", get(api_list_sessions))
         .route("/api/projects", get(api_list_projects))
         .route("/api/agents", get(api_list_agents))
+        .route("/api/tags", get(api_list_tags))
         .route("/api/sessions/{id}/tags", patch(api_set_tags))
         .route("/api/sessions/{id}/favorite", patch(api_set_favorite))
         .route("/api/sessions/{id}/notes", patch(api_set_notes))
@@ -365,6 +366,23 @@ async fn api_list_projects(State(s): State<Arc<SeCallMcpServer>>) -> impl IntoRe
 
 async fn api_list_agents(State(s): State<Arc<SeCallMcpServer>>) -> impl IntoResponse {
     match s.do_list_agents() {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => error_response(e),
+    }
+}
+
+/// P35 Task 00: `/api/tags` 쿼리 파라미터.
+/// `with_counts` 미지정 시 기본 `true`.
+#[derive(Debug, Deserialize, Default)]
+struct TagsListQuery {
+    with_counts: Option<bool>,
+}
+
+async fn api_list_tags(
+    State(s): State<Arc<SeCallMcpServer>>,
+    Query(q): Query<TagsListQuery>,
+) -> impl IntoResponse {
+    match s.do_list_tags(q.with_counts.unwrap_or(true)) {
         Ok(json) => (StatusCode::OK, Json(json)).into_response(),
         Err(e) => error_response(e),
     }

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -579,6 +579,23 @@ impl SeCallMcpServer {
         Ok(serde_json::json!({ "agents": db.list_agents()? }))
     }
 
+    /// P35 Task 00: 전체 태그 목록 (빈도 포함/미포함).
+    /// `with_counts=true` (기본): `{ "tags": [{ "name": "rust", "count": 12 }, ...] }`
+    /// `with_counts=false`: `{ "tags": ["rust", "search", ...] }`
+    pub fn do_list_tags(&self, with_counts: bool) -> anyhow::Result<serde_json::Value> {
+        let db = self
+            .db
+            .lock()
+            .map_err(|_| anyhow::anyhow!("db lock poisoned"))?;
+        let tags = db.list_all_tags()?;
+        if with_counts {
+            Ok(serde_json::json!({ "tags": tags }))
+        } else {
+            let names: Vec<&str> = tags.iter().map(|t| t.name.as_str()).collect();
+            Ok(serde_json::json!({ "tags": names }))
+        }
+    }
+
     pub fn do_set_tags(
         &self,
         session_id: &str,

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -235,6 +235,27 @@ impl Database {
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
+    /// 전체 세션의 태그를 빈도 기준으로 집계.
+    /// `sessions.tags`는 JSON 배열 문자열(`'["rust","search"]'`). `json_each`로 펼친 뒤
+    /// COUNT(*) 내림차순, 동률이면 태그명 알파벳 오름차순으로 정렬.
+    /// `tags`가 NULL이거나 빈 배열인 세션은 결과에 포함되지 않음.
+    pub fn list_all_tags(&self) -> Result<Vec<TagCount>> {
+        let mut stmt = self.conn().prepare(
+            "SELECT json_each.value AS tag, COUNT(*) AS cnt
+             FROM sessions, json_each(sessions.tags)
+             WHERE sessions.tags IS NOT NULL AND json_valid(sessions.tags)
+             GROUP BY tag
+             ORDER BY cnt DESC, tag ASC",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok(TagCount {
+                name: r.get(0)?,
+                count: r.get(1)?,
+            })
+        })?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
     // ─── Lint helpers ────────────────────────────────────────────────────────
 
     /// Return vault_path for a single session
@@ -1055,4 +1076,12 @@ pub struct SessionStats {
     pub system_turns: i64,
     /// 상위 빈도 tool name → count (내림차순, 최대 8개)
     pub tool_counts: Vec<(String, i64)>,
+}
+
+/// P35 Task 00: 태그 + 사용 빈도. `/api/tags` 응답 및
+/// `Database::list_all_tags`의 반환 타입.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TagCount {
+    pub name: String,
+    pub count: i64,
 }

--- a/crates/secall-core/tests/rest_listing.rs
+++ b/crates/secall-core/tests/rest_listing.rs
@@ -204,3 +204,35 @@ fn tag_normalize_helpers_match_rest_endpoint_behavior() {
         vec!["a", "b"]
     );
 }
+
+#[test]
+fn rest_list_all_tags_with_counts_desc_then_alpha() {
+    let db = Database::open_memory().unwrap();
+    db.insert_session(&make_session("s1", "p", 0)).unwrap();
+    db.insert_session(&make_session("s2", "p", 1)).unwrap();
+    db.insert_session(&make_session("s3", "p", 2)).unwrap();
+
+    db.update_session_tags("s1", &["rust".into(), "alpha".into()])
+        .unwrap();
+    db.update_session_tags("s2", &["rust".into(), "search".into()])
+        .unwrap();
+    db.update_session_tags("s3", &["rust".into()]).unwrap();
+
+    let tags = db.list_all_tags().unwrap();
+    // rust(3) > alpha(1)/search(1) (alpha < search 알파벳)
+    assert_eq!(tags.len(), 3);
+    assert_eq!(tags[0].name, "rust");
+    assert_eq!(tags[0].count, 3);
+    assert_eq!(tags[1].name, "alpha");
+    assert_eq!(tags[2].name, "search");
+}
+
+#[test]
+fn rest_list_all_tags_excludes_null_and_empty_arrays() {
+    let db = Database::open_memory().unwrap();
+    db.insert_session(&make_session("s-null", "p", 0)).unwrap();
+    db.insert_session(&make_session("s-empty", "p", 1)).unwrap();
+    db.update_session_tags("s-empty", &[]).unwrap(); // 빈 배열 저장 가정
+    let tags = db.list_all_tags().unwrap();
+    assert!(tags.is_empty());
+}

--- a/docs/plans/p35-secall-web-phase-3-task-00.md
+++ b/docs/plans/p35-secall-web-phase-3-task-00.md
@@ -1,0 +1,174 @@
+---
+type: task
+status: draft
+updated_at: 2026-05-02
+plan_slug: p35-secall-web-phase-3
+task_id: 00
+parallel_group: A
+depends_on: []
+---
+
+# Task 00 — 백엔드 `/api/tags` 엔드포인트
+
+## Changed files
+
+수정:
+- `crates/secall-core/src/store/session_repo.rs:236` — `list_agents` 다음 줄에 `list_all_tags() -> Result<Vec<TagCount>>` 추가, 같은 파일 상단 적당한 위치에 `#[derive(Debug, Clone, Serialize)] pub struct TagCount { pub name: String, pub count: i64 }` 정의 (혹은 `mcp/dto.rs`가 있으면 거기에)
+- `crates/secall-core/src/mcp/server.rs:580` — `do_list_agents` 다음 줄에 `do_list_tags(&self, with_counts: bool) -> Result<serde_json::Value>` 추가
+- `crates/secall-core/src/mcp/rest.rs:144` — `/api/agents` 라우트 다음 줄에 `.route("/api/tags", get(api_list_tags))` 추가, 핸들러는 `api_list_agents`(rest.rs:366) 패턴을 그대로 따라 `query: Query<TagsListQuery>` 받아 `do_list_tags(query.with_counts.unwrap_or(true))` 호출
+
+신규: 없음 (기존 파일들에 추가만)
+
+## Change description
+
+### 1. `list_all_tags` (DB 레이어)
+
+`session_repo.rs`의 `list_agents` 바로 아래에 추가:
+
+```rust
+pub fn list_all_tags(&self) -> Result<Vec<TagCount>> {
+    // sessions.tags는 JSON 배열 ('["rust","search"]' 형태). json_each로 펼침.
+    // tags가 NULL이거나 빈 배열이면 결과에 안 잡힘 → 안전.
+    let mut stmt = self.conn().prepare(
+        "SELECT json_each.value AS tag, COUNT(*) AS cnt
+         FROM sessions, json_each(sessions.tags)
+         WHERE sessions.tags IS NOT NULL AND json_valid(sessions.tags)
+         GROUP BY tag
+         ORDER BY cnt DESC, tag ASC",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok(TagCount {
+            name: r.get(0)?,
+            count: r.get(1)?,
+        })
+    })?;
+    Ok(rows.filter_map(|r| r.ok()).collect())
+}
+```
+
+`TagCount` 구조체는 같은 파일 상단(예: 기존 `SessionListFilter` 구조체 근처)에 `#[derive(Debug, Clone, Serialize)] pub struct TagCount { pub name: String, pub count: i64 }`로 정의. `serde::Serialize` import는 이미 있음 (확인).
+
+### 2. `do_list_tags` (MCP 서버)
+
+`server.rs`의 `do_list_agents` 바로 아래에 추가:
+
+```rust
+pub fn do_list_tags(&self, with_counts: bool) -> anyhow::Result<serde_json::Value> {
+    let db = self
+        .db
+        .lock()
+        .map_err(|_| anyhow::anyhow!("db lock poisoned"))?;
+    let tags = db.list_all_tags()?;
+    if with_counts {
+        Ok(serde_json::json!({ "tags": tags }))
+    } else {
+        let names: Vec<&str> = tags.iter().map(|t| t.name.as_str()).collect();
+        Ok(serde_json::json!({ "tags": names }))
+    }
+}
+```
+
+- `with_counts=true` (기본값): `{ "tags": [{ "name": "rust", "count": 12 }, ...] }`
+- `with_counts=false`: `{ "tags": ["rust", "search", ...] }` — string 배열만
+
+### 3. REST 라우트 + 핸들러
+
+`rest.rs:143-144` 근처에 다음 라우트 추가:
+
+```rust
+.route("/api/tags", get(api_list_tags))
+```
+
+`SessionListQuery` 정의 근처에 `TagsListQuery` 추가 + 핸들러:
+
+```rust
+#[derive(Debug, Deserialize, Default)]
+struct TagsListQuery {
+    with_counts: Option<bool>,
+}
+
+async fn api_list_tags(
+    State(s): State<Arc<SeCallMcpServer>>,
+    Query(q): Query<TagsListQuery>,
+) -> impl IntoResponse {
+    match s.do_list_tags(q.with_counts.unwrap_or(true)) {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => error_response(e),
+    }
+}
+```
+
+`Query` import는 axum::extract::Query (rest.rs:1-15에 이미 있음).
+
+### 4. 통합 테스트 추가
+
+`crates/secall-core/tests/rest_listing.rs` 끝에 다음 테스트 추가:
+
+```rust
+#[test]
+fn rest_list_all_tags_with_counts_desc_then_alpha() {
+    let db = Database::open_memory().unwrap();
+    db.insert_session(&make_session("s1", "p", 0)).unwrap();
+    db.insert_session(&make_session("s2", "p", 1)).unwrap();
+    db.insert_session(&make_session("s3", "p", 2)).unwrap();
+
+    db.update_session_tags("s1", &["rust".into(), "alpha".into()])
+        .unwrap();
+    db.update_session_tags("s2", &["rust".into(), "search".into()])
+        .unwrap();
+    db.update_session_tags("s3", &["rust".into()]).unwrap();
+
+    let tags = db.list_all_tags().unwrap();
+    // rust(3) > alpha(1)/search(1) (alpha < search 알파벳)
+    assert_eq!(tags.len(), 3);
+    assert_eq!(tags[0].name, "rust");
+    assert_eq!(tags[0].count, 3);
+    assert_eq!(tags[1].name, "alpha");
+    assert_eq!(tags[2].name, "search");
+}
+
+#[test]
+fn rest_list_all_tags_excludes_null_and_empty_arrays() {
+    let db = Database::open_memory().unwrap();
+    db.insert_session(&make_session("s-null", "p", 0)).unwrap();
+    db.insert_session(&make_session("s-empty", "p", 1)).unwrap();
+    db.update_session_tags("s-empty", &[]).unwrap(); // 빈 배열 저장 가정
+    let tags = db.list_all_tags().unwrap();
+    assert!(tags.is_empty());
+}
+```
+
+## Dependencies
+
+- 외부 crate: 없음 (rusqlite + JSON1 extension은 bundled feature에 포함)
+- 내부 task: 없음
+
+## Verification
+
+```bash
+cargo check --all-targets
+cargo clippy --all-targets --all-features
+cargo fmt --all -- --check
+cargo test -p secall-core --test rest_listing rest_list_all_tags
+
+# 라이브 (선택, 서버 실행 필요):
+# secall serve --bind 127.0.0.1:8080 &
+# curl -s http://127.0.0.1:8080/api/tags | jq '.tags[0]'
+# curl -s 'http://127.0.0.1:8080/api/tags?with_counts=false' | jq '.tags | length'
+```
+
+## Risks
+
+- **JSON1 SQLite extension**: `json_each`는 SQLite JSON1 확장 필요. rusqlite의 `bundled` feature가 JSON1 포함하므로 OK (workspace Cargo.toml `rusqlite = { version = "0.31", features = ["bundled"] }`로 확인됨).
+- **빈 태그 배열 저장**: `update_session_tags`가 `[]`를 어떻게 저장하는지 확인 필요. NULL이면 json_each 통과, `'[]'` 문자열이면 json_each가 0행 반환 → 둘 다 안전.
+- **태그 정규화**: P32 task에서 `normalize_tag` (소문자 + `-` 변환)가 저장 시점에 적용됨 → list_all_tags는 정규화된 형태만 반환 → 클라 측 추가 정규화 불필요.
+- **count = i64 vs usize**: SQLite COUNT는 INTEGER → i64. JSON 직렬화에서 number로 감.
+- **성능**: sessions 1만 건 + 평균 3 태그 = 3만 행 grouping. 인덱스 없어도 100ms 이내. 더 커지면 materialized view 또는 별도 tags 테이블 (Phase 4+).
+
+## Scope boundary
+
+수정 금지:
+- `web/` 전체 — Task 01 영역
+- `crates/secall-core/src/store/{db,schema,jobs_repo,tag_normalize}.rs` — 본 task와 무관
+- `crates/secall-core/src/jobs/`, `crates/secall-core/src/web/` — 무관
+- `crates/secall/`, `.github/`, `README*` — 무관

--- a/docs/plans/p35-secall-web-phase-3-task-01.md
+++ b/docs/plans/p35-secall-web-phase-3-task-01.md
@@ -1,0 +1,132 @@
+---
+type: task
+status: draft
+updated_at: 2026-05-02
+plan_slug: p35-secall-web-phase-3
+task_id: 01
+parallel_group: B
+depends_on: [00]
+---
+
+# Task 01 — web `useAllTags`를 `/api/tags`로 전환
+
+## Changed files
+
+수정:
+- `web/src/lib/types.ts` — `TagCount` 타입 추가 (`/api/tags` 응답)
+- `web/src/lib/api.ts` — `listTags(withCounts?)` 메서드 추가 (api 객체 안)
+- `web/src/lib/allTags.ts:1-25` — sessions 100건 휴리스틱 제거하고 `api.listTags()` 호출로 전면 교체. 함수 시그니처(반환 `string[]`)는 유지하여 TagEditor/SessionFilters는 무수정.
+
+신규: 없음
+
+## Change description
+
+### 1. `TagCount` 타입 (types.ts)
+
+`SearchMode` 정의 근처에 추가:
+
+```ts
+/** `/api/tags?with_counts=true` 응답의 한 항목. 백엔드 `TagCount` 직렬화 형태. */
+export interface TagCount {
+  name: string;
+  count: number;
+}
+
+/** `/api/tags` 응답. with_counts 분기에 따라 결과 형태가 다름. */
+export interface TagsResponse {
+  tags: TagCount[] | string[];
+}
+```
+
+### 2. `api.listTags` (api.ts)
+
+`api` 객체의 `listAgents` 다음에 추가:
+
+```ts
+listTags: (withCounts: boolean = true) =>
+  jfetch<TagsResponse>(
+    `/api/tags?with_counts=${withCounts ? "true" : "false"}`,
+  ),
+```
+
+import에 `TagsResponse` 추가 (types.ts에서).
+
+### 3. `useAllTags` 전면 교체 (allTags.ts)
+
+기존 25줄을 다음으로 교체:
+
+```ts
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type { TagCount } from "@/lib/types";
+
+/**
+ * 백엔드 `/api/tags` (P35 Task 01)에서 정규화된 전체 태그를 가져온다.
+ *
+ * - 카운트 포함 — `useTagCounts()`에서 사용. UI 우선순위/뱃지에 활용 가능.
+ * - 정렬: 백엔드가 count DESC, name ASC로 정렬하여 반환.
+ * - `useSetTags` mutation의 onSuccess가 ["allTags"] 캐시를 invalidate.
+ *   (P35: 키 호환을 위해 ["allTags"] 그대로 사용)
+ */
+function useAllTagsRaw() {
+  return useQuery({
+    queryKey: ["allTags"],
+    queryFn: () => api.listTags(true),
+    staleTime: 5 * 60_000, // 5분 — 태그가 자주 변하지 않음
+  });
+}
+
+/** TagEditor/SessionFilters용 — 이름 배열만 반환 (정렬 보존). */
+export function useAllTags(): string[] {
+  const { data } = useAllTagsRaw();
+  if (!data) return [];
+  return (data.tags as TagCount[]).map((t) => t.name);
+}
+
+/** 사용 빈도까지 필요한 호출처용. */
+export function useTagCounts(): TagCount[] {
+  const { data } = useAllTagsRaw();
+  if (!data) return [];
+  return data.tags as TagCount[];
+}
+```
+
+기존 `useAllTags(): string[]` 시그니처가 그대로 유지되므로 TagEditor / SessionFilters는 수정 불필요.
+
+### 4. mutation invalidate 키 확인
+
+`web/src/hooks/useTagMutations.ts`에서 `useSetTags`의 onSuccess가 `["allTags"]`를 invalidate하는지 확인. 본 task에서는 같은 키 그대로 사용하므로 자동으로 동작. invalidate 누락이 있으면 본 task에서 수정 가능.
+
+## Dependencies
+
+- 외부 npm: 없음
+- 내부 task: **Task 00 완료 필수** — `/api/tags` endpoint가 있어야 함
+
+## Verification
+
+```bash
+cd /Users/d9ng/privateProject/seCall/web && pnpm typecheck
+cd /Users/d9ng/privateProject/seCall/web && pnpm build
+
+# 라이브 (Task 00 + Task 01 둘 다 완료 후, 서버 실행 필요):
+# secall serve --bind 127.0.0.1:8080 &
+# 브라우저 → /sessions → SessionFilters의 태그 chip autocomplete가 100건 한계 너머 태그도 표시
+# DevTools Network → /api/tags 호출 1회만 (5분 캐시)
+```
+
+## Risks
+
+- **Task 00 미완료 시**: `/api/tags`가 404 → useQuery error → useAllTags가 빈 배열 반환. UI는 깨지지 않지만 자동완성 제안 안 보임.
+- **응답 형태 분기**: `with_counts=true`가 기본이므로 `TagsResponse.tags`는 `TagCount[]`만 사용. `string[]`은 `as TagCount[]` 캐스팅 시 런타임 에러 가능 → 본 코드는 항상 `withCounts=true`로 호출하므로 OK. `as` 캐스팅보다 안전한 방식 원하면 두 hook을 별도 fetcher로 분리.
+- **invalidate 키 호환**: 기존 `useTagMutations.ts`가 `["allTags"]` 키 invalidate한다고 가정. 다르면 본 task에서 수정 필요 — 코드 확인 후 fix.
+- **staleTime 5분**: 다른 사용자가 태그 추가해도 5분간 자동완성에 안 보임. invalidate는 본인 mutation에서만 트리거됨. 타 사용자 동기화 필요하면 SSE 구독 (Phase 4+).
+
+## Scope boundary
+
+수정 금지:
+- `crates/` 전체 — Task 00 영역
+- `web/src/components/{TagEditor,SessionFilters}.tsx` — `useAllTags`의 호출만 사용, 시그니처 그대로 유지하므로 무수정
+- `web/src/components/SessionList.tsx` — Task 02 영역
+- `web/src/routes/router.tsx`, `web/vite.config.ts` — Task 03 영역
+- `web/src/hooks/{useSessions,useDaily,useWiki,useJob*,useGraph,useGlobalHotkeys,useListHotkeys,useRelated,useDebounce}.ts` — 무관
+- `.github/`, `README*` — Task 04 영역

--- a/docs/plans/p35-secall-web-phase-3-task-02.md
+++ b/docs/plans/p35-secall-web-phase-3-task-02.md
@@ -1,0 +1,218 @@
+---
+type: task
+status: draft
+updated_at: 2026-05-02
+plan_slug: p35-secall-web-phase-3
+task_id: 02
+parallel_group: A
+depends_on: []
+---
+
+# Task 02 — SessionList 무한 스크롤
+
+## Changed files
+
+수정:
+- `web/src/hooks/useSessions.ts` — `useInfiniteSessions(params)` 신규 추가 (`useInfiniteQuery` 기반). 기존 `useSessionsList`는 `useAllTags` 등 다른 호출처가 사용 중이므로 유지.
+- `web/src/components/SessionList.tsx:62-67, 174-188` — keyword 모드를 `useSessionsList` → `useInfiniteSessions`로 교체. 기존 페이지네이션 안내(`{data.items.length} / {data.total} (페이지네이션 Phase 1)`)를 sentinel + 자동 로딩 표시로 교체. semantic 모드는 그대로.
+
+신규:
+- `web/src/hooks/useInfiniteScroll.ts` — IntersectionObserver 래퍼 훅. sentinel ref가 viewport에 들어오면 callback 호출.
+
+## Change description
+
+### 1. `useInfiniteScroll` (신규 hook)
+
+```ts
+import { useEffect, useRef } from "react";
+
+/**
+ * sentinel 엘리먼트가 viewport 안에 들어오면 onIntersect 호출.
+ *
+ * - rootMargin "200px": 끝에서 200px 전에 미리 fetch (체감 끊김 감소)
+ * - hasMore=false면 observer 미설정 → 마지막 페이지 도달 후 호출 안 됨
+ * - enabled=false (예: isFetching 중)면 일시 중단
+ */
+export function useInfiniteScroll(opts: {
+  onIntersect: () => void;
+  hasMore: boolean;
+  enabled?: boolean;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const { onIntersect, hasMore, enabled = true } = opts;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !hasMore || !enabled) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            onIntersect();
+            break;
+          }
+        }
+      },
+      { rootMargin: "200px 0px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [onIntersect, hasMore, enabled]);
+
+  return ref;
+}
+```
+
+### 2. `useInfiniteSessions` (useSessions.ts에 추가)
+
+기존 `useSessionsList` 아래에 추가:
+
+```ts
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+
+/**
+ * 무한 스크롤 — `/api/sessions?page=N&page_size=...`.
+ *
+ * - 백엔드는 `{ items, total, page, page_size }` 반환 (P32).
+ * - getNextPageParam: `items.length < page_size` 또는 누적 >= total이면 더 없음.
+ * - keyword 모드 전용. semantic 모드는 do_recall이 페이지네이션 없으므로 useSemanticRecall 그대로.
+ */
+export function useInfiniteSessions(
+  params: Omit<SessionsListParams, "page" | "page_size">,
+  pageSize: number = 50,
+) {
+  return useInfiniteQuery({
+    queryKey: ["sessions", "infinite", params, pageSize],
+    queryFn: ({ pageParam }) =>
+      api.listSessions({ ...params, page: pageParam, page_size: pageSize }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      const fetchedSoFar = lastPage.page * lastPage.page_size;
+      if (lastPage.items.length < lastPage.page_size) return undefined;
+      if (fetchedSoFar >= lastPage.total) return undefined;
+      return lastPage.page + 1;
+    },
+    placeholderData: (prev) => prev,
+  });
+}
+```
+
+### 3. `SessionList` 교체 (keyword 모드)
+
+`web/src/components/SessionList.tsx`:
+
+```tsx
+// imports에 추가:
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+// useSessionsList 대신:
+import { useInfiniteSessions, useSemanticRecall } from "@/hooks/useSessions";
+
+// keywordList 부분 교체:
+const keywordList = useInfiniteSessions(
+  {
+    q: trimmed === "" ? undefined : trimmed,
+    ...filters,
+  },
+  pageSize,
+);
+
+// 모든 페이지의 items를 평탄화
+const allItems: Session[] = (keywordList.data?.pages ?? []).flatMap((p) => p.items);
+const total = keywordList.data?.pages[0]?.total ?? 0;
+
+// hotkeyItems 계산 — semantic이면 변환, keyword면 allItems
+const hotkeyItems: Session[] = useSemantic
+  ? semanticList.data ? recallToSessions(semanticList.data.results) : []
+  : allItems;
+
+// 기존 useListHotkeys 호출 그대로 유지
+
+// keyword render 부분:
+const sentinelRef = useInfiniteScroll({
+  onIntersect: () => keywordList.fetchNextPage(),
+  hasMore: keywordList.hasNextPage ?? false,
+  enabled: !keywordList.isFetchingNextPage,
+});
+
+if (keywordList.isLoading) { /* 기존 그대로 */ }
+if (keywordList.isError)   { /* 기존 그대로 (error 객체 위치가 keywordList.error) */ }
+if (allItems.length === 0) { /* 기존 그대로 */ }
+
+return (
+  <div>
+    {keywordList.isFetching && !keywordList.isFetchingNextPage && (
+      <div className="px-3 py-1 text-[10px] text-muted-foreground border-b border-border">
+        업데이트 중…
+      </div>
+    )}
+    <div className="divide-y divide-border">
+      {allItems.map((s) => (
+        <SessionListItem
+          key={s.id}
+          session={s}
+          query={query}
+          selected={s.id === id}
+          onSelect={() => navigate(`/sessions/${encodeURIComponent(s.id)}`)}
+        />
+      ))}
+    </div>
+
+    {/* sentinel — IntersectionObserver 타겟 */}
+    <div ref={sentinelRef} className="h-10" aria-hidden />
+
+    {keywordList.isFetchingNextPage && (
+      <div className="p-3 text-[11px] text-muted-foreground text-center border-t border-border flex items-center justify-center gap-2">
+        <Loader2 className="size-3 animate-spin" /> 추가 로드 중…
+      </div>
+    )}
+
+    {!keywordList.hasNextPage && allItems.length > 0 && allItems.length === total && (
+      <div className="p-3 text-[10px] text-muted-foreground text-center border-t border-border">
+        끝 — 총 {total} 세션
+      </div>
+    )}
+  </div>
+);
+```
+
+### 4. semantic 모드 무수정
+
+semantic 모드는 `useSemanticRecall` 그대로 사용. 백엔드 `do_recall`이 페이지네이션 미지원이므로 단발 결과만 표시. 본 task의 무한 스크롤은 keyword 모드 한정.
+
+## Dependencies
+
+- 외부 npm: `@tanstack/react-query` (이미 사용 중) — `useInfiniteQuery`는 v5 정식 API
+- 내부 task: 없음 (Task 00/01/03과 독립)
+
+## Verification
+
+```bash
+cd /Users/d9ng/privateProject/seCall/web && pnpm typecheck
+cd /Users/d9ng/privateProject/seCall/web && pnpm build
+
+# 라이브 (서버 실행 + 100건 이상 세션 필요):
+# secall serve --bind 127.0.0.1:8080 &
+# 브라우저 /sessions → 스크롤 끝 도달 시 자동 로드, 마지막 페이지 도달 시 "끝 — 총 N 세션" 표시
+# DevTools Network → /api/sessions?page=2 자동 호출 확인
+# `]` 단축키로 page 2 이상 항목으로도 이동 가능 확인 (useListHotkeys가 allItems를 dep로 받으므로 자동)
+```
+
+## Risks
+
+- **`useSessionsList` 호출처 영향**: 기존 `useSessionsList`는 `useAllTags`와 `useRelated`에서 사용 중. 본 task에서는 SessionList만 교체하므로 다른 호출처는 영향 없음. (`useAllTags`는 Task 01에서 별도로 `/api/tags`로 전환됨.)
+- **filters 변경 시 캐시**: `queryKey`에 params 포함됨 → filters 변경 시 새 infinite query 생성 → 페이지 1부터 재조회. OK.
+- **placeholderData prev**: 검색어 디바운스 입력 중에도 이전 페이지가 잠시 보임. UX 부드러움.
+- **단축키 j/k 다음 페이지 끝 도달**: useListHotkeys가 hotkeyItems 끝 도달 시 더 이상 이동 안 함. 자동 fetchNextPage 트리거는 본 task 외 (Phase 4+).
+- **rootMargin 200px**: 화면 최하단 200px 전에 미리 페치 시작 → 모바일에서 약간 일찍 로드. 적절.
+- **IntersectionObserver 미지원 브라우저**: 모던 브라우저는 모두 지원. 폴백 불필요.
+
+## Scope boundary
+
+수정 금지:
+- `crates/` 전체 — 백엔드와 무관
+- `web/src/lib/{api,types,store,allTags,tagColor,utils,queryClient,graphStartNode,highlight,graphStyle}.ts` — 본 task와 무관 (api/types는 Task 01에서 변경)
+- `web/src/components/*` — `SessionList.tsx` 외 모든 컴포넌트
+- `web/src/routes/*` — Task 03 영역
+- `web/vite.config.ts` — Task 03 영역
+- `web/src/hooks/*` — `useSessions.ts` + 신규 `useInfiniteScroll.ts` 외
+- `.github/`, `README*` — Task 04 영역

--- a/docs/plans/p35-secall-web-phase-3-task-03.md
+++ b/docs/plans/p35-secall-web-phase-3-task-03.md
@@ -1,0 +1,191 @@
+---
+type: task
+status: draft
+updated_at: 2026-05-02
+plan_slug: p35-secall-web-phase-3
+task_id: 03
+parallel_group: A
+depends_on: []
+---
+
+# Task 03 — Code-split (라우트 + vendor)
+
+## Changed files
+
+수정:
+- `web/src/routes/router.tsx:1-30` — 5개 라우트 컴포넌트 (`SessionsRoute`, `SessionDetailRoute`, `DailyRoute`, `WikiRoute`, `CommandsRoute`)를 `React.lazy()`로 dynamic import. `Layout`은 모든 라우트의 부모이므로 eager 유지. `<Suspense fallback={<RouteFallback/>}>` 으로 감쌈.
+- `web/vite.config.ts:16-19` — `build.rollupOptions.output.manualChunks` 추가 — vendor chunks 분리.
+
+신규:
+- `web/src/components/RouteFallback.tsx` — 라우트 lazy load 중 표시할 작은 스피너.
+
+## Change description
+
+### 1. `RouteFallback` (신규 — UX 일관성)
+
+```tsx
+import { Loader2 } from "lucide-react";
+
+/**
+ * React.lazy로 코드 분할된 라우트 컴포넌트의 chunk fetch 동안 표시.
+ * 다른 로딩 표시(`SessionDetailRoute`의 "세션 불러오는 중…" 등)와 구분되도록 단순한 형태.
+ */
+export function RouteFallback() {
+  return (
+    <div className="p-8 flex items-center justify-center text-muted-foreground text-sm">
+      <Loader2 className="size-4 animate-spin mr-2" /> 화면 로드 중…
+    </div>
+  );
+}
+```
+
+### 2. `router.tsx` 전면 교체
+
+```tsx
+import { lazy, Suspense } from "react";
+import { createBrowserRouter, Navigate } from "react-router";
+import Layout from "./Layout";
+import { RouteFallback } from "@/components/RouteFallback";
+import { SessionEmptyState } from "./SessionsRoute"; // 작은 컴포넌트 — eager OK
+
+// 라우트 단위 lazy chunks
+const SessionsRoute = lazy(() => import("./SessionsRoute"));
+const SessionDetailRoute = lazy(() => import("./SessionDetailRoute"));
+const DailyRoute = lazy(() => import("./DailyRoute"));
+const WikiRoute = lazy(() => import("./WikiRoute"));
+const CommandsRoute = lazy(() => import("./CommandsRoute"));
+
+const lazyEl = (Comp: React.LazyExoticComponent<React.ComponentType>) => (
+  <Suspense fallback={<RouteFallback />}>
+    <Comp />
+  </Suspense>
+);
+
+export const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <Layout />,
+    children: [
+      { index: true, element: <Navigate to="/sessions" replace /> },
+      {
+        path: "sessions",
+        element: lazyEl(SessionsRoute),
+        children: [
+          { index: true, element: <SessionEmptyState /> },
+          { path: ":id", element: lazyEl(SessionDetailRoute) },
+        ],
+      },
+      { path: "daily", element: lazyEl(DailyRoute) },
+      { path: "daily/:date", element: lazyEl(DailyRoute) },
+      { path: "wiki", element: lazyEl(WikiRoute) },
+      { path: "wiki/:project", element: lazyEl(WikiRoute) },
+      { path: "commands", element: lazyEl(CommandsRoute) },
+    ],
+  },
+]);
+```
+
+`SessionEmptyState`는 named export로 그대로 가져옴 (sessions 라우트 index가 lazyless로 즉시 렌더). `SessionsRoute`의 default export는 lazy로 가져오고 `SessionEmptyState`만 eager 가져오는 패턴. **검증 필요**: SessionsRoute.tsx가 `export default function ... + export function SessionEmptyState`로 두 개를 동시 export하는 형태인지 — `web/src/routes/router.tsx:3` 기존 import 형태가 `import SessionsRoute, { SessionEmptyState } from "./SessionsRoute"`이므로 이미 그런 구조. 다만 lazy 분리 시 SessionEmptyState도 같은 chunk에 들어가는지 확인. 만약 vite가 split 시 named export가 같이 묶이면 OK. 아니면 SessionEmptyState를 별도 파일 `web/src/components/SessionEmptyState.tsx`로 분리 (본 task 범위 내).
+
+**실행 방안**: 먼저 기본 lazy split 시도 → `pnpm build` 결과 확인. SessionEmptyState가 main chunk에 있으면 OK, 별도 chunk면 SessionsRoute lazy로 같이 묶기 위해 SessionEmptyState를 별도 모듈로 분리.
+
+### 3. Vite manualChunks (vite.config.ts)
+
+```ts
+import path from "node:path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "./src") },
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": "http://127.0.0.1:8080",
+    },
+  },
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          "vendor-react": ["react", "react-dom", "react-router"],
+          "vendor-query": ["@tanstack/react-query"],
+          "vendor-radix": [
+            "@radix-ui/react-dialog",
+            "@radix-ui/react-scroll-area",
+            "@radix-ui/react-select",
+            "@radix-ui/react-separator",
+            "@radix-ui/react-slot",
+          ],
+          "vendor-viz": ["@dagrejs/dagre", "lucide-react"],
+        },
+      },
+    },
+    // 분리 후 각 chunk가 500 kB 이하 — warning limit 유지 (분할이 무너지면 경고)
+    chunkSizeWarningLimit: 500,
+  },
+});
+```
+
+vendor 그룹은 `web/package.json`의 dependencies 기준. 실제 dep 이름은 `pnpm list --depth=0` 또는 `package.json` 직접 확인:
+- React 그룹: react, react-dom, react-router
+- TanStack Query: @tanstack/react-query
+- shadcn 기반 Radix: @radix-ui/* (실제 설치된 것만 — 빌드 시 일치 안하면 무시됨)
+- 시각화: @dagrejs/dagre, lucide-react
+
+설치되지 않은 모듈명은 Vite가 무시 → 안전. 실제 검증은 빌드 결과 chunk 파일명으로.
+
+### 4. `App.tsx` / `main.tsx` 영향
+
+`main.tsx`가 `RouterProvider` 사용하는지 확인. `<RouterProvider router={router} />` 하나면 본 task 변경 영향 없음.
+
+## Dependencies
+
+- 외부 npm: 없음 (모두 기존 의존성 활용)
+- 내부 task: 없음 (Task 00/01/02와 독립)
+
+## Verification
+
+```bash
+cd /Users/d9ng/privateProject/seCall/web && pnpm typecheck
+cd /Users/d9ng/privateProject/seCall/web && pnpm build 2>&1 | tee /tmp/p35_build.log
+
+# chunk 크기 분리 검증 — 500 kB 초과 chunk 없으면 OK
+grep -E "dist/assets/.*\.js" /tmp/p35_build.log
+# 기대 출력: vendor-react, vendor-query, vendor-radix, vendor-viz, index 등 여러 chunk
+# 단일 978 kB → 다중 (각 < 500 kB)
+
+# warning 사라졌는지 확인 (있으면 manualChunks 보완 필요)
+grep -E "chunks are larger than" /tmp/p35_build.log && echo "WARNING REMAINS" || echo "OK"
+
+# 라이브 (서버 실행 필요):
+# secall serve --bind 127.0.0.1:8080 &
+# 브라우저 /sessions → DevTools Network → 초기 진입 시 sessions chunk만 로드
+# /commands 클릭 → commands chunk lazy 로드 (<200 kB)
+```
+
+## Risks
+
+- **lazy + react-router v7 호환**: react-router v7는 `<Suspense>` 자동 처리 안 함 → 수동 wrap 필요. 본 task의 `lazyEl` 헬퍼가 처리. OR react-router v7의 `lazy` route option 사용도 가능 (`{ path: ..., lazy: () => import(...) }` 형식). 기존 `createBrowserRouter` 그대로 쓰면 Suspense wrapper 방식이 더 단순.
+- **SessionEmptyState 위치**: SessionsRoute가 lazy인데 SessionEmptyState는 eager로 같은 파일에서 가져오면, vite가 SessionsRoute chunk를 항상 같이 로드 → lazy 효과 없음. 검증 후 필요하면 SessionEmptyState를 별도 컴포넌트 파일로 분리.
+- **vendor manualChunks 매칭 실패**: 패키지명이 정확히 일치 안 하면 그 모듈은 main chunk로 떨어짐 → 분리 효과 부분적. 빌드 결과 chunk 파일명으로 검증.
+- **chunkSizeWarningLimit 500**: 분할이 효과적이면 경고 없음. 효과적이지 않으면 경고로 알림 → 본 task 내에서 manualChunks 보완.
+- **Suspense fallback 깜빡임**: 라우트 진입 시 짧은 스피너 노출. UX 약간 영향 있지만 단축키/캐시로 첫 진입 후 즉시 로드.
+- **prefetch**: 라우트 hover 시 prefetch는 본 task 외 (Phase 4+). 단순 lazy로 시작.
+
+## Scope boundary
+
+수정 금지:
+- `crates/` 전체 — 백엔드와 무관
+- `web/src/lib/*` — Task 01 영역의 일부와 무관
+- `web/src/components/SessionList.tsx` — Task 02 영역
+- `web/src/components/SessionEmptyState 분리 시 신규 파일은 본 task 내에서 OK
+- `web/src/hooks/*` — 무관
+- `web/src/routes/{Layout,SessionsRoute,SessionDetailRoute,DailyRoute,WikiRoute,CommandsRoute,GraphRoute}.tsx` — lazy 대상이지만 컴포넌트 자체 코드는 무수정 (router.tsx의 import 형태만 변경)
+- `web/package.json` — 새 dep 추가 안 함
+- `.github/`, `README*` — Task 04 영역

--- a/docs/plans/p35-secall-web-phase-3-task-04.md
+++ b/docs/plans/p35-secall-web-phase-3-task-04.md
@@ -1,0 +1,114 @@
+---
+type: task
+status: draft
+updated_at: 2026-05-02
+plan_slug: p35-secall-web-phase-3
+task_id: 04
+parallel_group: C
+depends_on: [00, 01, 02, 03]
+---
+
+# Task 04 — README + CI 업데이트
+
+## Changed files
+
+수정:
+- `README.md` — Phase 3 섹션 추가 (성능 + 정확도), `/api/tags` 엔드포인트 추가, changelog 행 추가
+- `README.en.md` — 동일 영문판
+- (선택) `.github/workflows/ci.yml` — 변경 없음 (기존 web-build job이 typecheck + build로 자동 검증)
+
+신규: 없음
+
+## Change description
+
+### 1. README — Phase 3 섹션 추가
+
+기존 Phase 0/1/2 다음에 추가:
+
+```markdown
+**Phase 3** (P35, 성능 + 정확도):
+- `/api/tags` 엔드포인트 — 모든 태그 + 사용 빈도 정확 노출 (sessions 100건 휴리스틱 제거)
+- SessionList 무한 스크롤 — IntersectionObserver 기반 자동 로드
+- Code-split — 라우트별 + vendor(react/query/radix/viz) chunk 분리, 초기 번들 ≤ 350 kB (gzip)
+```
+
+### 2. README — 엔드포인트 목록 갱신
+
+기존 엔드포인트 섹션에 추가:
+
+```markdown
+- 태그 목록 (Phase 3): GET /api/tags?with_counts={true|false}
+  - true (기본): { "tags": [{ "name": "rust", "count": 12 }, ...] }
+  - false: { "tags": ["rust", "search", ...] }
+```
+
+### 3. README — changelog 행
+
+기존 changelog 표 상단에 추가:
+
+```markdown
+| 2026-XX-XX | v0.6.0 | Web UI Phase 3 (P35): /api/tags 엔드포인트, SessionList 무한 스크롤, Code-split (vendor + per-route chunk, 초기 번들 ≤ 350 kB gzip) |
+```
+
+날짜는 머지 시점으로 갱신. Cargo.toml 버전 bump는 별도 release tagging 시.
+
+### 4. README.en.md 동기화
+
+위 한글 섹션을 영문으로 동등하게 추가:
+
+```markdown
+**Phase 3** (P35, performance + accuracy):
+- `/api/tags` endpoint — accurate full tag set with usage counts (replaces 100-session heuristic)
+- SessionList infinite scroll — IntersectionObserver-based auto-load
+- Code-split — per-route + vendor (react/query/radix/viz) chunks, initial bundle ≤ 350 kB (gzip)
+```
+
+엔드포인트와 changelog도 동일하게 영문으로 추가.
+
+### 5. CI 변경 없음
+
+기존 `.github/workflows/ci.yml`의 `web-build` job:
+- `pnpm install --frozen-lockfile`
+- `pnpm typecheck`
+- `pnpm build`
+
+이 자동으로 다음을 검증:
+- Task 03 무한 스크롤 코드 → typecheck 통과
+- Task 04 manualChunks 설정 → build 성공
+- chunk 분리는 빌드 산출물로만 확인 가능 (CI 출력에 chunk 파일 크기 표시됨)
+
+별도 검증 스크립트 추가는 본 task 외.
+
+## Dependencies
+
+- 외부: 없음
+- 내부 task: Task 00 (`/api/tags` 엔드포인트), Task 01 (`useAllTags` 전환), Task 02 (무한 스크롤), Task 03 (code-split) 모두 완료 후 정확한 정보 반영 가능
+
+## Verification
+
+```bash
+grep -q "Phase 3" /Users/d9ng/privateProject/seCall/README.md && echo "ko Phase 3 OK"
+grep -q "Phase 3" /Users/d9ng/privateProject/seCall/README.en.md && echo "en Phase 3 OK"
+grep -q "/api/tags" /Users/d9ng/privateProject/seCall/README.md && echo "tags endpoint listed"
+grep -q "/api/tags" /Users/d9ng/privateProject/seCall/README.en.md && echo "tags endpoint listed (en)"
+grep -q "무한 스크롤\|infinite scroll" /Users/d9ng/privateProject/seCall/README.md && echo "infinite scroll mentioned"
+grep -q "Code-split\|code-split\|코드 분할" /Users/d9ng/privateProject/seCall/README.md && echo "code-split mentioned"
+
+# CI 변경 없음 확인 (P34 task 09에서 추가된 web-build job 그대로)
+git diff --stat .github/workflows/ | head -3 && echo "CI workflow unchanged"
+```
+
+## Risks
+
+- **README 일관성**: 사용자가 보는 동작과 README 설명이 어긋나면 신뢰 저하. Task 00~03 검증 통과 후 본 task 진행.
+- **chunk 크기 350 kB**: README에 "초기 번들 ≤ 350 kB gzip" 표기. Task 03의 실제 빌드 결과가 다르면 README 수치 갱신 필요.
+- **버전 bump**: 본 task에서 Cargo.toml 버전 변경 안 함. release tagging은 별도.
+- **changelog 날짜 placeholder**: `2026-XX-XX`는 머지 시점에 정확한 날짜로 갱신.
+
+## Scope boundary
+
+수정 금지:
+- `crates/`, `web/src/` 코드 — Task 00~03 완료 후 본 task는 문서만
+- `web/vite.config.ts` — Task 03 영역
+- DB 스키마 — 본 phase에 변경 없음
+- `.github/workflows/*` — 변경 없음 (단, 필요 시 본 task 범위 내에서 chunk 검증 추가는 OK)

--- a/docs/plans/p35-secall-web-phase-3.md
+++ b/docs/plans/p35-secall-web-phase-3.md
@@ -1,0 +1,61 @@
+---
+type: plan
+status: draft
+updated_at: 2026-05-02
+slug: p35-secall-web-phase-3
+version: 1
+---
+
+# P35 — secall-web Phase 3 (성능 + 정확도)
+
+## Description
+
+P34에서 의도적으로 분리한 3가지 항목 — **번들 크기 축소(code-split)**, **세션 리스트 무한 스크롤**, **`/api/tags` 정확한 전체 태그 목록** — 을 한 Phase로 묶어 처리. 기능 추가가 아닌 "현재 한계 해소" 성격.
+
+## 현재 한계
+
+- Vite 단일 chunk 978 kB (warning) — 초기 로드 비용 큼. 변경 시 전체 캐시 무효화.
+- `web/src/components/SessionList.tsx`는 page_size=100 단발 호출 — 100개 초과 세션 미표시.
+- `web/src/lib/allTags.ts`의 `useAllTags`는 sessions 100건의 `tags` 합집합 휴리스틱 — 100건 너머 태그 누락 → TagEditor/SessionFilters 자동완성 부정확.
+
+## Expected Outcome
+
+- 초기 진입 시 다운로드 ≤ 350 kB (gzip), `vendor-react` / `vendor-query` / `vendor-radix` / `vendor-viz` / per-route chunk로 분리.
+- SessionList: 스크롤 끝 도달 시 자동으로 다음 페이지 로드, 모든 세션 접근 가능.
+- `useAllTags`: 백엔드 `/api/tags` 호출 (sessions 테이블 전체 스캔 + json_each) — 모든 태그 + 사용 빈도 정확.
+
+## Subtasks
+
+| # | Title | Parallel group | Depends on |
+|---|---|---|---|
+| 00 | 백엔드 `/api/tags` 엔드포인트 | A | — |
+| 01 | web `useAllTags`를 `/api/tags`로 전환 | B | 00 |
+| 02 | SessionList 무한 스크롤 | A | — |
+| 03 | Code-split (라우트 + vendor) | A | — |
+| 04 | README + CI 업데이트 | C | 00, 01, 02, 03 |
+
+병렬 실행 전략:
+- Phase A — Task 00 + 02 + 03 동시 dispatch (서로 다른 파일군)
+- Phase B — Task 01 (Task 00의 endpoint 필요)
+- Phase C — Task 04 (모든 task 완료 후 정확한 정보 반영)
+
+## Constraints
+
+- **수정 금지**: P32~34 완료 코드의 동작 변경. 본 phase는 추가 또는 동치 교체만.
+- **무한 스크롤은 keyword 모드 한정**. semantic 모드(`do_recall`)는 서버가 페이지네이션 제공 안 함 → 단발 유지.
+- `/api/tags`는 sessions 테이블 전체 스캔. 현재 규모(수만 건)에서 OK. 향후 더 커지면 별도 tags 테이블은 Phase 4+.
+
+## Non-goals
+
+- 가상 스크롤 (react-window 등): 무한 스크롤로 충분, 가상화는 별도 phase.
+- cursor 기반 페이지네이션: 현재 offset/limit 방식 유지.
+- semantic 모드 페이지네이션: do_recall 변경 필요 → 별도 phase.
+- 태그 관리 UI (rename / merge / bulk delete): 별도 phase.
+- `/api/tags` 검색 fuzzy 매칭: 클라 측 substring 필터로 충분.
+
+## Success criteria
+
+- `pnpm build` chunk size warning 사라짐 (모든 chunk ≤ 500 kB)
+- `cargo test --all` 통과 + 신규 `/api/tags` 통합 테스트 통과
+- `useAllTags` 결과가 sessions 100건 한계와 무관 (DB의 모든 tags 노출)
+- SessionList 무한 스크롤이 IntersectionObserver로 작동, 마지막 페이지 도달 시 sentinel 사라짐

--- a/web/src/components/RouteFallback.tsx
+++ b/web/src/components/RouteFallback.tsx
@@ -1,0 +1,13 @@
+import { Loader2 } from "lucide-react";
+
+/**
+ * React.lazy로 코드 분할된 라우트 컴포넌트의 chunk fetch 동안 표시.
+ * 다른 로딩 표시(`SessionDetailRoute`의 "세션 불러오는 중…" 등)와 구분되도록 단순한 형태.
+ */
+export function RouteFallback() {
+  return (
+    <div className="p-8 flex items-center justify-center text-muted-foreground text-sm">
+      <Loader2 className="size-4 animate-spin mr-2" /> 화면 로드 중…
+    </div>
+  );
+}

--- a/web/src/components/SessionEmptyState.tsx
+++ b/web/src/components/SessionEmptyState.tsx
@@ -1,0 +1,8 @@
+/** index 라우트 — 세션이 선택되지 않았을 때 우측 pane 안내. */
+export function SessionEmptyState() {
+  return (
+    <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+      좌측에서 세션을 선택하세요
+    </div>
+  );
+}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,8 +1,9 @@
 import { Loader2 } from "lucide-react";
 import { useNavigate, useParams } from "react-router";
 import { SessionListItem } from "./SessionListItem";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { useListHotkeys } from "@/hooks/useListHotkeys";
-import { useSemanticRecall, useSessionsList } from "@/hooks/useSessions";
+import { useInfiniteSessions, useSemanticRecall } from "@/hooks/useSessions";
 import type {
   RecallResultItem,
   SearchMode,
@@ -58,14 +59,21 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
   // 시맨틱 모드 + 비어있지 않은 query에서만 recall 호출. 그 외엔 keyword 리스트.
   const useSemantic = mode === "semantic" && trimmed.length > 0;
 
-  // useSessionsList는 항상 enabled (기존 시그니처 유지). semantic 모드에서는 그 결과를 사용 안 함.
-  // 별도 enabled 토글이 필요하면 Task 03에서 useSessionsList 시그니처 확장 시 정리.
-  const keywordList = useSessionsList({
-    q: trimmed === "" ? undefined : trimmed,
-    page: 1,
-    page_size: pageSize,
-    ...filters,
-  });
+  // P35 Task 02 — keyword 모드는 무한 스크롤 (`useInfiniteSessions`).
+  // semantic 모드에서는 결과를 사용하지 않지만, Rules of Hooks 때문에 항상 호출.
+  const keywordList = useInfiniteSessions(
+    {
+      q: trimmed === "" ? undefined : trimmed,
+      ...filters,
+    },
+    pageSize,
+  );
+
+  // 모든 페이지의 items 평탄화. total은 첫 페이지 메타에서 가져온다.
+  const allItems: Session[] = (keywordList.data?.pages ?? []).flatMap(
+    (p) => p.items,
+  );
+  const total = keywordList.data?.pages[0]?.total ?? 0;
 
   const semanticList = useSemanticRecall(query, filters, {
     enabled: useSemantic,
@@ -78,10 +86,18 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
     ? semanticList.data
       ? recallToSessions(semanticList.data.results)
       : []
-    : (keywordList.data?.items ?? []);
+    : allItems;
   useListHotkeys(hotkeyItems, id, (sid) =>
     navigate(`/sessions/${encodeURIComponent(sid)}`),
   );
+
+  // P35 Task 02 — sentinel(= 리스트 끝) 진입 시 다음 페이지 prefetch.
+  // hasNextPage가 false면 observer 자체가 attach되지 않는다.
+  const sentinelRef = useInfiniteScroll({
+    onIntersect: () => keywordList.fetchNextPage(),
+    hasMore: keywordList.hasNextPage ?? false,
+    enabled: !keywordList.isFetchingNextPage,
+  });
 
   if (useSemantic) {
     if (semanticList.isLoading) {
@@ -149,10 +165,8 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
     );
   }
 
-  // ── keyword 모드 (기존 흐름) ───────────────────────────────
-  const { data, isLoading, isError, error, isFetching } = keywordList;
-
-  if (isLoading) {
+  // ── keyword 모드 (P35 Task 02 — 무한 스크롤) ───────────────
+  if (keywordList.isLoading) {
     return (
       <div className="flex items-center justify-center p-8 text-muted-foreground text-sm">
         <Loader2 className="size-4 animate-spin mr-2" /> 불러오는 중…
@@ -160,15 +174,16 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
     );
   }
 
-  if (isError) {
+  if (keywordList.isError) {
+    const err = keywordList.error;
     return (
       <div className="p-6 text-rose-400 text-sm whitespace-pre-wrap">
-        세션 로드 실패: {error instanceof Error ? error.message : String(error)}
+        세션 로드 실패: {err instanceof Error ? err.message : String(err)}
       </div>
     );
   }
 
-  if (!data || data.items.length === 0) {
+  if (allItems.length === 0) {
     return (
       <div className="p-8 text-muted-foreground text-sm text-center">
         조건에 맞는 세션이 없습니다.
@@ -178,13 +193,13 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
 
   return (
     <div>
-      {isFetching && (
+      {keywordList.isFetching && !keywordList.isFetchingNextPage && (
         <div className="px-3 py-1 text-[10px] text-muted-foreground border-b border-border">
           업데이트 중…
         </div>
       )}
       <div className="divide-y divide-border">
-        {data.items.map((s) => (
+        {allItems.map((s) => (
           <SessionListItem
             key={s.id}
             session={s}
@@ -194,11 +209,23 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
           />
         ))}
       </div>
-      {data.total > data.items.length && (
-        <div className="p-3 text-[11px] text-muted-foreground text-center border-t border-border">
-          {data.items.length} / {data.total} (페이지네이션 Phase 1)
+
+      {/* sentinel — IntersectionObserver 타겟. hasNextPage=false면 hook이 attach 안 함. */}
+      <div ref={sentinelRef} className="h-10" aria-hidden />
+
+      {keywordList.isFetchingNextPage && (
+        <div className="p-3 text-[11px] text-muted-foreground text-center border-t border-border flex items-center justify-center gap-2">
+          <Loader2 className="size-3 animate-spin" /> 추가 로드 중…
         </div>
       )}
+
+      {!keywordList.hasNextPage &&
+        allItems.length > 0 &&
+        allItems.length === total && (
+          <div className="p-3 text-[10px] text-muted-foreground text-center border-t border-border">
+            끝 — 총 {total} 세션
+          </div>
+        )}
     </div>
   );
 }

--- a/web/src/hooks/useInfiniteScroll.ts
+++ b/web/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * sentinel 엘리먼트가 viewport 안에 들어오면 onIntersect 호출.
+ *
+ * - rootMargin "200px 0px": 끝에서 200px 전에 미리 fetch (체감 끊김 감소)
+ * - hasMore=false면 observer 미설정 → 마지막 페이지 도달 후 호출 안 됨
+ * - enabled=false (예: isFetching 중)면 일시 중단
+ *
+ * 모던 브라우저는 IntersectionObserver를 모두 지원하므로 폴백 불필요.
+ */
+export function useInfiniteScroll(opts: {
+  onIntersect: () => void;
+  hasMore: boolean;
+  enabled?: boolean;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const { onIntersect, hasMore, enabled = true } = opts;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !hasMore || !enabled) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            onIntersect();
+            break;
+          }
+        }
+      },
+      { rootMargin: "200px 0px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [onIntersect, hasMore, enabled]);
+
+  return ref;
+}

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import type { SessionFilterState, SessionsListParams } from "@/lib/types";
 
@@ -15,6 +15,32 @@ export function useSessionsList(params: SessionsListParams) {
   return useQuery({
     queryKey: ["sessions", "list", params],
     queryFn: () => api.listSessions(params),
+    placeholderData: (prev) => prev,
+  });
+}
+
+/**
+ * 무한 스크롤 — `/api/sessions?page=N&page_size=...`.
+ *
+ * - 백엔드는 `{ items, total, page, page_size }` 반환 (P32).
+ * - getNextPageParam: `items.length < page_size` 또는 누적 >= total이면 더 없음.
+ * - keyword 모드 전용. semantic 모드는 do_recall이 페이지네이션 없으므로 useSemanticRecall 그대로.
+ */
+export function useInfiniteSessions(
+  params: Omit<SessionsListParams, "page" | "page_size">,
+  pageSize: number = 50,
+) {
+  return useInfiniteQuery({
+    queryKey: ["sessions", "infinite", params, pageSize],
+    queryFn: ({ pageParam }) =>
+      api.listSessions({ ...params, page: pageParam, page_size: pageSize }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      const fetchedSoFar = lastPage.page * lastPage.page_size;
+      if (lastPage.items.length < lastPage.page_size) return undefined;
+      if (fetchedSoFar >= lastPage.total) return undefined;
+      return lastPage.page + 1;
+    },
     placeholderData: (prev) => prev,
   });
 }

--- a/web/src/lib/allTags.ts
+++ b/web/src/lib/allTags.ts
@@ -1,25 +1,33 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import type { TagCount } from "@/lib/types";
 
 /**
- * TagEditor 자동완성용 태그 사전.
+ * 백엔드 `/api/tags` (P35 Task 01)에서 정규화된 전체 태그를 가져온다.
  *
- * 단순 구현: 첫 페이지 100개 세션의 태그 합집합.
- * Phase 1에서 정확도가 필요하면 `/api/tags` 전용 엔드포인트로 교체한다.
- *
- * `useSetTags` mutation의 onSuccess가 ["allTags"] 캐시를 invalidate하므로
- * 신규 태그 추가 직후에도 자동완성 결과가 갱신된다.
+ * - 카운트 포함 — `useTagCounts()`에서 사용. UI 우선순위/뱃지에 활용 가능.
+ * - 정렬: 백엔드가 count DESC, name ASC로 정렬하여 반환.
+ * - `useSetTags` mutation의 onSuccess가 ["allTags"] 캐시를 invalidate.
+ *   (P35: 키 호환을 위해 ["allTags"] 그대로 사용)
  */
-export function useAllTags(): string[] {
-  const { data } = useQuery({
+function useAllTagsRaw() {
+  return useQuery({
     queryKey: ["allTags"],
-    queryFn: () => api.listSessions({ page: 1, page_size: 100 }),
-    staleTime: 30_000,
+    queryFn: () => api.listTags(true),
+    staleTime: 5 * 60_000, // 5분 — 태그가 자주 변하지 않음
   });
+}
+
+/** TagEditor/SessionFilters용 — 이름 배열만 반환 (정렬 보존). */
+export function useAllTags(): string[] {
+  const { data } = useAllTagsRaw();
   if (!data) return [];
-  const set = new Set<string>();
-  for (const item of data.items) {
-    for (const tag of item.tags) set.add(tag);
-  }
-  return Array.from(set).sort();
+  return (data.tags as TagCount[]).map((t) => t.name);
+}
+
+/** 사용 빈도까지 필요한 호출처용. */
+export function useTagCounts(): TagCount[] {
+  const { data } = useAllTagsRaw();
+  if (!data) return [];
+  return data.tags as TagCount[];
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   SessionDetail,
   SessionListPage,
   SyncArgs,
+  TagsResponse,
   WikiPage,
   WikiUpdateArgs,
 } from "@/lib/types";
@@ -72,6 +73,11 @@ export const api = {
 
   listProjects: () => jfetch<{ projects: string[] }>("/api/projects"),
   listAgents: () => jfetch<{ agents: string[] }>("/api/agents"),
+
+  listTags: (withCounts: boolean = true) =>
+    jfetch<TagsResponse>(
+      `/api/tags?with_counts=${withCounts ? "true" : "false"}`,
+    ),
 
   setTags: (id: string, tags: string[]) =>
     jfetch<{ session_id: string; tags: string[] }>(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -69,6 +69,17 @@ export interface WikiPage {
 
 export type SearchMode = "keyword" | "semantic";
 
+/** `/api/tags?with_counts=true` 응답의 한 항목. 백엔드 `TagCount` 직렬화 형태. */
+export interface TagCount {
+  name: string;
+  count: number;
+}
+
+/** `/api/tags` 응답. with_counts 분기에 따라 결과 형태가 다름. */
+export interface TagsResponse {
+  tags: TagCount[] | string[];
+}
+
 /**
  * `/api/recall` 결과 항목 — turn 단위.
  * 백엔드 `SearchResult` (crates/secall-core/src/search/bm25.rs):

--- a/web/src/routes/SessionsRoute.tsx
+++ b/web/src/routes/SessionsRoute.tsx
@@ -51,12 +51,3 @@ export interface SessionsOutletContext {
   query: string;
   mode: SearchMode;
 }
-
-/** index 라우트 — 세션이 선택되지 않았을 때 우측 pane 안내. */
-export function SessionEmptyState() {
-  return (
-    <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
-      좌측에서 세션을 선택하세요
-    </div>
-  );
-}

--- a/web/src/routes/router.tsx
+++ b/web/src/routes/router.tsx
@@ -1,10 +1,21 @@
+import { lazy, Suspense } from "react";
 import { createBrowserRouter, Navigate } from "react-router";
 import Layout from "./Layout";
-import SessionsRoute, { SessionEmptyState } from "./SessionsRoute";
-import SessionDetailRoute from "./SessionDetailRoute";
-import DailyRoute from "./DailyRoute";
-import WikiRoute from "./WikiRoute";
-import CommandsRoute from "./CommandsRoute";
+import { RouteFallback } from "@/components/RouteFallback";
+import { SessionEmptyState } from "@/components/SessionEmptyState";
+
+// 라우트 단위 lazy chunks
+const SessionsRoute = lazy(() => import("./SessionsRoute"));
+const SessionDetailRoute = lazy(() => import("./SessionDetailRoute"));
+const DailyRoute = lazy(() => import("./DailyRoute"));
+const WikiRoute = lazy(() => import("./WikiRoute"));
+const CommandsRoute = lazy(() => import("./CommandsRoute"));
+
+const lazyEl = (Comp: React.LazyExoticComponent<React.ComponentType>) => (
+  <Suspense fallback={<RouteFallback />}>
+    <Comp />
+  </Suspense>
+);
 
 export const router = createBrowserRouter([
   {
@@ -14,17 +25,17 @@ export const router = createBrowserRouter([
       { index: true, element: <Navigate to="/sessions" replace /> },
       {
         path: "sessions",
-        element: <SessionsRoute />,
+        element: lazyEl(SessionsRoute),
         children: [
           { index: true, element: <SessionEmptyState /> },
-          { path: ":id", element: <SessionDetailRoute /> },
+          { path: ":id", element: lazyEl(SessionDetailRoute) },
         ],
       },
-      { path: "daily", element: <DailyRoute /> },
-      { path: "daily/:date", element: <DailyRoute /> },
-      { path: "wiki", element: <WikiRoute /> },
-      { path: "wiki/:project", element: <WikiRoute /> },
-      { path: "commands", element: <CommandsRoute /> },
+      { path: "daily", element: lazyEl(DailyRoute) },
+      { path: "daily/:date", element: lazyEl(DailyRoute) },
+      { path: "wiki", element: lazyEl(WikiRoute) },
+      { path: "wiki/:project", element: lazyEl(WikiRoute) },
+      { path: "commands", element: lazyEl(CommandsRoute) },
     ],
   },
 ]);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,5 +16,23 @@ export default defineConfig({
   build: {
     outDir: "dist",
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          "vendor-react": ["react", "react-dom", "react-router"],
+          "vendor-query": ["@tanstack/react-query"],
+          "vendor-radix": [
+            "@radix-ui/react-dialog",
+            "@radix-ui/react-scroll-area",
+            "@radix-ui/react-select",
+            "@radix-ui/react-separator",
+            "@radix-ui/react-slot",
+          ],
+          "vendor-viz": ["@dagrejs/dagre", "lucide-react"],
+        },
+      },
+    },
+    // 분리 후 각 chunk가 500 kB 이하 — warning limit 유지 (분할이 무너지면 경고)
+    chunkSizeWarningLimit: 500,
   },
 });


### PR DESCRIPTION
## Summary

P34에서 의도적으로 분리한 3가지 항목 (성능 + 정확도) 처리. **PR #38(P32+P33+P34)의 후속**으로, 같은 브랜치 베이스로 분기. PR #38 머지 후 자동 rebase됩니다.

- **/api/tags 엔드포인트** — 전체 태그 + 사용 빈도 정확 노출 (sessions 100건 휴리스틱 제거)
- **SessionList 무한 스크롤** — IntersectionObserver 기반 자동 로드, page_size=100
- **Code-split** — 라우트별 + vendor 4종 chunk 분리

## Highlights

### 백엔드
- `GET /api/tags?with_counts={bool}` — `json_each(sessions.tags)` + COUNT, 빈도 DESC + 알파벳 ASC
- `Database::list_all_tags() -> Vec<TagCount>` (`session_repo.rs:242`)
- `do_list_tags(with_counts)` (`server.rs:585`)
- 통합 테스트 2건 (count 정렬 + NULL/빈 배열 제외)

### 프론트엔드
- `useAllTags`: sessions 100건 → `/api/tags` 직접. `useTagCounts` helper 추가 (시그니처 호환 유지로 TagEditor/SessionFilters 무수정)
- `useInfiniteSessions` (`useInfiniteQuery`) + `useInfiniteScroll` (rootMargin 200px 0px)
- semantic 모드는 `do_recall` 페이지네이션 미지원으로 단발 유지

### Code-split 결과
| Chunk | Before | After |
|---|---|---|
| 단일 번들 | 978 kB | — |
| index | — | 265 kB |
| vendor-radix | — | 216 kB |
| vendor-react | — | 89 kB |
| vendor-query | — | 51 kB |
| vendor-viz | — | 51 kB |
| 라우트별 chunk | 포함 | 12~94 kB 분리 |
| **초기 진입 (gzip)** | **307 kB** | **~206 kB** (33%↓) |

## Test plan

- [x] `cargo test --test rest_listing` — 12 passed (신규 2개 + 기존 10개)
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] `pnpm typecheck` (web/)
- [x] `pnpm build` — 16 chunks, max 265 kB, chunk warning 없음
- [ ] **수동 확인 필요**: `secall serve` → `/sessions` 100건 이상 스크롤 시 자동 다음 페이지 로드
- [ ] **수동 확인 필요**: 태그 자동완성에 100건 한계 너머 태그도 표시
- [ ] **수동 확인 필요**: `/commands` 진입 시 commands chunk lazy 로드 (DevTools Network)

## 머지 순서

1. PR #38 (P32+P33+P34) 머지 → main
2. 본 PR base가 자동 rebase → 본 PR 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)