### PR TITLE
feat: P37 시맨틱 Graph Sync 자동화 — DB v8 + CLI/REST/web rebuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,6 +3238,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/README.en.md
+++ b/README.en.md
@@ -146,6 +146,10 @@ secall serve --port 8080
   - `true` (default): `{ "tags": [{ "name": "rust", "count": 12 }, ...] }`
   - `false`: `{ "tags": ["rust", "search", ...] }`
 - Commands (Phase 1): `POST /api/commands/{sync,ingest,wiki-update}`
+- Graph rebuild (P37): `POST /api/commands/graph-rebuild`
+  - body: `{ since?, session?, all?, retry_failed? }`
+  - response: `{ job_id, status: "started" }`
+  - Single-queue policy: returns `409 Conflict` if another mutating job is running
 - Job management (Phase 1): `GET /api/jobs`, `GET /api/jobs/{id}`, `GET /api/jobs/{id}/stream` (SSE)
 - Job cancellation (P36): `POST /api/jobs/{id}/cancel`
   - 200: `{ "cancelled": true, "job_id": "..." }` — successful cancel of an active job (idempotent: same response for already-completed/cancelled jobs)
@@ -347,6 +351,14 @@ secall serve --port 8080
 - REST: `POST /api/jobs/{id}/cancel` — 200 active, 200 idempotent, 404 unknown/evicted
 - Web UI: a **Cancel** button in `JobBanner` and the active `JobItem`, gated by `window.confirm` (`useCancelJob` mutation hook)
 
+**Graph Sync automation** (P37, semantic graph rebuild):
+- Rebuild the semantic graph for already-ingested sessions out-of-band — backfill sessions that only have embeddings, or reprocess everything after swapping the model/prompt
+- DB schema v8: `sessions.semantic_extracted_at` column tracks semantic extraction state (NULL = not yet processed)
+- CLI: `secall graph rebuild [--since DATE] [--session ID] [--all] [--retry-failed]`
+- REST: `POST /api/commands/graph-rebuild` — integrated with the P33 Job system + P36 cancellation
+- Web UI: 4th card "Graph Rebuild" on the Commands page + options dialog (since / session / all / retry-failed)
+- Priority: `--session` > `--all` > `--retry-failed` > `--since` (when multiple are set, the highest-priority option wins) — consistent across CLI / REST / Web UI
+
 ### Keyboard shortcuts (Phase 2)
 
 | Key | Action |
@@ -374,6 +386,13 @@ secall sync --local-only --dry-run
 secall sync --no-graph         # disable graph incremental during sync (default: enabled)
 secall ingest --auto --auto-graph   # enable graph incremental during ingest (default: disabled)
 secall wiki update --backend claude
+
+# P37 — semantic graph rebuild (tracks semantic_extracted_at state)
+secall graph rebuild --retry-failed              # backfill all unprocessed (NULL) sessions
+secall graph rebuild --since 2026-04-01          # sessions on/after a date
+secall graph rebuild --session abc12345          # a single session
+secall graph rebuild --all                       # rebuild everything (overwrites existing results)
+# Priority: --session > --all > --retry-failed > --since (when set together, highest priority wins)
 ```
 
 ### Job System
@@ -616,6 +635,7 @@ Config file location:
 | `secall mcp [--http <addr>]` | Start MCP server |
 | `secall config show\|set\|path` | View/change settings |
 | `secall graph build\|stats\|export` | Knowledge graph management |
+| `secall graph rebuild [--since <date>\|--session <id>\|--all\|--retry-failed]` | Rebuild semantic graph (P37) — priority: `--session` > `--all` > `--retry-failed` > `--since` |
 | `secall wiki update [--backend claude\|codex\|ollama\|lmstudio\|gemini]` | Wiki generation with backend selection |
 | `secall wiki status` | Wiki status |
 | `secall log [YYYY-MM-DD]` | Generate daily work diary |
@@ -731,6 +751,7 @@ This project was developed using AI coding agents (Claude Code, Codex) orchestra
 
 | Date | Version | Changes |
 |------|---------|---------|
+| 2026-05-03 | v0.8.0 | Graph Sync automation (P37): DB schema v8 (`sessions.semantic_extracted_at` column tracks semantic-extraction state), `secall graph rebuild [--since\|--session\|--all\|--retry-failed]` CLI (with `extract_one_session_semantic` helper extracted, priority: `--session` > `--all` > `--retry-failed` > `--since`), `POST /api/commands/graph-rebuild` REST (`JobKind::GraphRebuild`, integrated with the P33 single-queue + P36 cancellation), 4th "Graph Rebuild" card on the web UI Commands page + options dialog |
 | 2026-05-02 | v0.7.0 | Job Cancellation (P36): `tokio_util::sync::CancellationToken` integration (`JobRegistry`/`JobExecutor`/`BroadcastSink`), `ProgressSink::is_cancelled()` trait method, sync/ingest/wiki adapter safe-point polling (between phases, file/session loop tops, before LLM calls), partial-result preservation, `POST /api/jobs/{id}/cancel` activated (200 idempotent / 404 unknown, final event `Failed { error: "cancelled by user" }` + status=`Interrupted`), web UI cancel button (`JobBanner`/`JobItem`, `useCancelJob` + `window.confirm`) |
 | 2026-05-02 | v0.6.0 | Web UI Phase 3 (P35): `/api/tags` endpoint (with_counts option, removes 100-session heuristic), SessionList infinite scroll (IntersectionObserver, page_size=100), Code-split (vendor react/query/radix/viz + per-route chunks, initial entry JS ≤ 250 kB gzip) |
 | 2026-05-02 | v0.5.0 | Web UI Phase 2 (P34): semantic search mode, search-term highlighting, multi-tag + date quick range, keyboard shortcuts (`?`/`/`/`j`/`k`/`[`/`]`/`g d/w/s/c/g`/`f`/`e`), related sessions panel, graph visualization upgrade (dagre + node colors/icons + legend), session metadata mini-chart, user notes editor (`PATCH /api/sessions/{id}/notes`), DB schema v7 |

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ secall serve --port 8080
   - `true` (기본): `{ "tags": [{ "name": "rust", "count": 12 }, ...] }`
   - `false`: `{ "tags": ["rust", "search", ...] }`
 - 명령 (Phase 1): `POST /api/commands/{sync,ingest,wiki-update}`
+- 그래프 재구축 (P37): `POST /api/commands/graph-rebuild`
+  - body: `{ since?, session?, all?, retry_failed? }`
+  - 응답: `{ job_id, status: "started" }`
+  - 단일 큐 정책: 다른 mutating job 실행 중이면 `409 Conflict`
 - Job 관리 (Phase 1): `GET /api/jobs`, `GET /api/jobs/{id}`, `GET /api/jobs/{id}/stream` (SSE)
 - Job 취소 (P36): `POST /api/jobs/{id}/cancel`
   - 200: `{ "cancelled": true, "job_id": "..." }` — 활성 job 취소 성공 (이미 완료/취소된 job 도 동일 응답으로 idempotent)
@@ -346,6 +350,14 @@ secall serve --port 8080
 - REST: `POST /api/jobs/{id}/cancel` — 활성 200, idempotent 200, 미등록/evict 404
 - Web UI: `JobBanner` 와 활성 `JobItem` 에 **취소** 버튼 + `window.confirm` 다이얼로그 (`useCancelJob` mutation hook)
 
+**Graph Sync 자동화** (P37, 시맨틱 그래프 재구축):
+- 이미 ingest 된 세션의 시맨틱 그래프를 별도로 재구축 가능 — embedding 만 끝낸 세션 backfill, 모델/프롬프트 교체 후 일괄 재처리 등
+- DB 스키마 v8: `sessions.semantic_extracted_at` 컬럼으로 시맨틱 추출 상태 추적 (NULL = 미처리)
+- CLI: `secall graph rebuild [--since DATE] [--session ID] [--all] [--retry-failed]`
+- REST: `POST /api/commands/graph-rebuild` — P33 Job 시스템 + P36 cancel 통합
+- Web UI: Commands 페이지 4번째 카드 "Graph Rebuild" + 옵션 다이얼로그 (since / session / all / retry-failed)
+- 우선순위: `--session` > `--all` > `--retry-failed` > `--since` (동시 지정 시 위 순서로 적용) — CLI / REST / Web UI 모두 동일
+
 ### 키보드 단축키 (Phase 2)
 
 | 키 | 동작 |
@@ -373,6 +385,13 @@ secall sync --local-only --dry-run
 secall sync --no-graph         # graph 자동 증분 비활성 (sync 기본은 활성)
 secall ingest --auto --auto-graph   # ingest 시 graph 자동 증분 활성 (기본 비활성)
 secall wiki update --backend claude
+
+# P37 — 시맨틱 그래프 재구축 (semantic_extracted_at 상태 추적)
+secall graph rebuild --retry-failed              # 미처리(NULL) 세션 일괄 backfill
+secall graph rebuild --since 2026-04-01          # 특정 날짜 이후 세션
+secall graph rebuild --session abc12345          # 단일 세션
+secall graph rebuild --all                       # 전체 재구축 (기존 결과 덮어쓰기)
+# 우선순위: --session > --all > --retry-failed > --since (동시 지정 시 위 순서로 적용)
 ```
 
 ### Job 시스템
@@ -622,6 +641,7 @@ secall config path
 | `secall mcp [--http <addr>]` | MCP 서버 시작 |
 | `secall config show\|set\|path` | 설정 확인/변경 |
 | `secall graph build\|stats\|export` | Knowledge Graph 관리 |
+| `secall graph rebuild [--since <date>\|--session <id>\|--all\|--retry-failed]` | 시맨틱 그래프 재구축 (P37) — 우선순위: `--session` > `--all` > `--retry-failed` > `--since` |
 | `secall wiki update [--backend claude\|codex\|ollama\|lmstudio\|gemini]` | 위키 생성 (백엔드 선택 가능) |
 | `secall wiki status` | 위키 상태 확인 |
 | `secall log [YYYY-MM-DD]` | 날짜별 작업 일기 생성 |
@@ -737,6 +757,7 @@ Claude Code 설정 (`~/.claude/settings.json`)에 추가:
 
 | 날짜 | 버전 | 변경사항 |
 |------|------|---------|
+| 2026-05-03 | v0.8.0 | Graph Sync 자동화 (P37): DB 스키마 v8 (`sessions.semantic_extracted_at` 컬럼으로 시맨틱 추출 상태 추적), `secall graph rebuild [--since\|--session\|--all\|--retry-failed]` CLI (`extract_one_session_semantic` helper 분리, 우선순위: `--session` > `--all` > `--retry-failed` > `--since`), `POST /api/commands/graph-rebuild` REST (`JobKind::GraphRebuild`, P33 단일 큐 + P36 cancel 통합), web UI Commands 페이지 4번째 카드 "Graph Rebuild" + 옵션 다이얼로그 |
 | 2026-05-02 | v0.7.0 | Job Cancellation (P36): `tokio_util::sync::CancellationToken` 통합 (`JobRegistry`/`JobExecutor`/`BroadcastSink`), `ProgressSink::is_cancelled()` 추가, sync/ingest/wiki 어댑터 safe-point polling (phase 사이·file/session 루프·LLM 호출 직전), 부분 결과 보존, `POST /api/jobs/{id}/cancel` 활성화 (200 idempotent / 404 unknown, 최종 이벤트 `Failed { error: "cancelled by user" }` + status=`Interrupted`), web UI 취소 버튼 (`JobBanner`/`JobItem`, `useCancelJob` + `window.confirm`) |
 | 2026-05-02 | v0.6.0 | Web UI Phase 3 (P35): `/api/tags` 엔드포인트 (with_counts 옵션, 100세션 휴리스틱 제거), SessionList 무한 스크롤 (IntersectionObserver, page_size=100), Code-split (vendor react/query/radix/viz + per-route chunk, 초기 진입 JS ≤ 250 kB gzip) |
 | 2026-05-02 | v0.5.0 | Web UI Phase 2 (P34): 시맨틱 검색 모드 활성, 검색어 하이라이트, 다중 태그 + 날짜 quick range, 키보드 단축키 (`?`/`/`/`j`/`k`/`[`/`]`/`g d/w/s/c/g`/`f`/`e`), 관련 세션 패널, 그래프 시각화 강화 (dagre + 노드 색상/아이콘 + 범례), 세션 메타 mini-chart, 사용자 노트 편집 (`PATCH /api/sessions/{id}/notes`), DB 스키마 v7 |

--- a/crates/secall-core/src/jobs/adapters/graph_rebuild_adapter.rs
+++ b/crates/secall-core/src/jobs/adapters/graph_rebuild_adapter.rs
@@ -1,0 +1,38 @@
+//! P37 Task 02 — graph rebuild 어댑터 시그니처.
+//!
+//! 실제 클로저 인스턴스는 `secall::commands::serve`에서 다음 패턴으로 조립된다:
+//!
+//! ```ignore
+//! let graph_rebuild_fn: GraphRebuildAdapterFn = Box::new(|val, sink| {
+//!     Box::pin(async move {
+//!         let args: secall::commands::graph::GraphRebuildArgs = serde_json::from_value(val)?;
+//!         let outcome = secall::commands::graph::run_rebuild(args, &sink).await?;
+//!         Ok(serde_json::to_value(outcome)?)
+//!     })
+//! });
+//! ```
+//!
+//! ## Args 사양 (`GraphRebuildArgs`)
+//! - `since: Option<String>` — `YYYY-MM-DD` 이후 세션만 (`semantic_extracted_at IS NULL` 또는 `< since`)
+//! - `session: Option<String>` — 단일 세션 id 만 처리
+//! - `all: bool` — 모든 세션 강제 재처리
+//! - `retry_failed: bool` — `semantic_extracted_at IS NULL` 인 세션만 (실패/미처리 재시도)
+//!
+//! 우선순위: `session` > `all` > `retry_failed` > `since`. 모두 비활성이면 빈 결과.
+//!
+//! ## Outcome 사양 (`GraphRebuildOutcome`)
+//! - `processed: usize`
+//! - `succeeded: usize`
+//! - `failed: usize`
+//! - `skipped: usize`
+//! - `edges_added: usize`
+//!
+//! ## Phase 흐름
+//! 단일 phase. 매 세션 시작 지점에서 `is_cancelled()` 폴링 후 부분 outcome 으로
+//! early return — P36 cancel 패턴이 그대로 적용된다. partial outcome 은 executor 의
+//! `was_cancelled` 게이팅이 `result_json` / SSE `Failed.partial_result` 에 보존한다.
+
+use super::AdapterFn;
+
+/// graph rebuild 어댑터 클로저 타입. `AdapterFn`의 의미적 alias.
+pub type GraphRebuildAdapterFn = AdapterFn;

--- a/crates/secall-core/src/jobs/adapters/mod.rs
+++ b/crates/secall-core/src/jobs/adapters/mod.rs
@@ -23,10 +23,12 @@ use std::pin::Pin;
 
 use crate::jobs::BroadcastSink;
 
+pub mod graph_rebuild_adapter;
 pub mod ingest_adapter;
 pub mod sync_adapter;
 pub mod wiki_adapter;
 
+pub use graph_rebuild_adapter::GraphRebuildAdapterFn;
 pub use ingest_adapter::IngestAdapterFn;
 pub use sync_adapter::SyncAdapterFn;
 pub use wiki_adapter::WikiUpdateAdapterFn;
@@ -35,6 +37,7 @@ pub use wiki_adapter::WikiUpdateAdapterFn;
 pub type SyncArgsValue = serde_json::Value;
 pub type IngestArgsValue = serde_json::Value;
 pub type WikiUpdateArgsValue = serde_json::Value;
+pub type GraphRebuildArgsValue = serde_json::Value;
 
 /// 단일 어댑터 클로저 시그니처.
 ///
@@ -64,4 +67,7 @@ pub struct CommandAdapters {
     /// `secall::commands::wiki::run_with_progress(WikiUpdateArgs, &BroadcastSink)`의 wrapper.
     /// 자세한 사양은 [`wiki_adapter`] 참조.
     pub wiki_update_fn: WikiUpdateAdapterFn,
+    /// `secall::commands::graph::run_rebuild(GraphRebuildArgs, &BroadcastSink)`의 wrapper.
+    /// 자세한 사양은 [`graph_rebuild_adapter`] 참조.
+    pub graph_rebuild_fn: GraphRebuildAdapterFn,
 }

--- a/crates/secall-core/src/jobs/types.rs
+++ b/crates/secall-core/src/jobs/types.rs
@@ -12,6 +12,8 @@ pub enum JobKind {
     Sync,
     Ingest,
     WikiUpdate,
+    /// P37 Task 02 — `graph rebuild` (시맨틱 엣지 재추출).
+    GraphRebuild,
 }
 
 impl JobKind {
@@ -20,6 +22,7 @@ impl JobKind {
             JobKind::Sync => "sync",
             JobKind::Ingest => "ingest",
             JobKind::WikiUpdate => "wiki_update",
+            JobKind::GraphRebuild => "graph_rebuild",
         }
     }
 
@@ -29,6 +32,7 @@ impl JobKind {
             "sync" => Some(JobKind::Sync),
             "ingest" => Some(JobKind::Ingest),
             "wiki_update" => Some(JobKind::WikiUpdate),
+            "graph_rebuild" => Some(JobKind::GraphRebuild),
             _ => None,
         }
     }

--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -150,6 +150,11 @@ pub fn rest_router(server: SeCallMcpServer, executor: Arc<JobExecutor>) -> Route
         .route("/api/commands/sync", post(api_command_sync))
         .route("/api/commands/ingest", post(api_command_ingest))
         .route("/api/commands/wiki-update", post(api_command_wiki_update))
+        // P37 Task 02 — graph rebuild
+        .route(
+            "/api/commands/graph-rebuild",
+            post(api_command_graph_rebuild),
+        )
         .route("/api/jobs", get(api_list_jobs))
         .route("/api/jobs/{id}", get(api_get_job))
         .route("/api/jobs/{id}/stream", get(api_job_stream))
@@ -182,7 +187,7 @@ pub async fn start_rest_server(
     tracing::info!(addr = %addr, "REST API server listening");
     tracing::info!(
         "endpoints: /api/recall, /api/get, /api/status, /api/wiki, /api/graph, /api/daily, \
-         /api/commands/{{sync,ingest,wiki-update}}, /api/jobs, /api/jobs/:id, \
+         /api/commands/{{sync,ingest,wiki-update,graph-rebuild}}, /api/jobs, /api/jobs/:id, \
          /api/jobs/:id/stream, /api/jobs/:id/cancel"
     );
 
@@ -459,6 +464,7 @@ async fn spawn_command_job(
                     JobKind::Sync => (adapters.sync_fn)(args_value, sink),
                     JobKind::Ingest => (adapters.ingest_fn)(args_value, sink),
                     JobKind::WikiUpdate => (adapters.wiki_update_fn)(args_value, sink),
+                    JobKind::GraphRebuild => (adapters.graph_rebuild_fn)(args_value, sink),
                 };
                 fut.await
             }
@@ -511,6 +517,17 @@ async fn api_command_wiki_update(
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     spawn_command_job(executor, JobKind::WikiUpdate, body).await
+}
+
+/// P37 Task 02 — `POST /api/commands/graph-rebuild`.
+///
+/// 단일 mutating job 정책상 다른 sync/ingest/wiki/graph_rebuild 가 진행 중이면 409.
+/// body 는 `GraphRebuildArgs` (`{since, session, all, retry_failed}`) 의 JSON 형태.
+async fn api_command_graph_rebuild(
+    State(executor): State<Arc<JobExecutor>>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    spawn_command_job(executor, JobKind::GraphRebuild, body).await
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/crates/secall-core/src/store/db.rs
+++ b/crates/secall-core/src/store/db.rs
@@ -114,6 +114,12 @@ impl Database {
             self.conn
                 .execute("ALTER TABLE sessions ADD COLUMN notes TEXT", [])?;
         }
+        if current < 8 && !self.column_exists("sessions", "semantic_extracted_at")? {
+            self.conn.execute(
+                "ALTER TABLE sessions ADD COLUMN semantic_extracted_at INTEGER",
+                [],
+            )?;
+        }
         if current < CURRENT_SCHEMA_VERSION {
             self.conn.execute(
                 "INSERT OR REPLACE INTO config(key, value) VALUES ('schema_version', ?1)",
@@ -1224,5 +1230,180 @@ mod tests {
         assert_eq!(stats.assistant_turns, 0);
         assert_eq!(stats.system_turns, 0);
         assert!(stats.tool_counts.is_empty());
+    }
+
+    // ─── P37 Task 00: semantic_extracted_at 컬럼 (v8) ────────────────────────
+
+    use crate::store::session_repo::GraphRebuildFilter;
+
+    #[test]
+    fn test_v8_semantic_extracted_at_column_exists() {
+        let db = Database::open_memory().unwrap();
+        assert!(db
+            .column_exists("sessions", "semantic_extracted_at")
+            .unwrap());
+    }
+
+    #[test]
+    fn test_v8_migrates_v6_db() {
+        // v6 raw 스키마(notes/semantic_extracted_at 없음)에서 마이그레이션이
+        // 두 컬럼을 모두 추가하고 기존 row 보존하는지
+        use rusqlite::Connection;
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, agent TEXT NOT NULL, model TEXT, project TEXT,
+                cwd TEXT, git_branch TEXT, start_time TEXT NOT NULL, end_time TEXT,
+                turn_count INTEGER DEFAULT 0, tokens_in INTEGER DEFAULT 0,
+                tokens_out INTEGER DEFAULT 0, tools_used TEXT, tags TEXT,
+                vault_path TEXT, host TEXT, summary TEXT, ingested_at TEXT NOT NULL,
+                status TEXT DEFAULT 'raw', session_type TEXT DEFAULT 'interactive',
+                is_favorite INTEGER DEFAULT 0
+            );
+            CREATE TABLE turns (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL, turn_index INTEGER NOT NULL, role TEXT NOT NULL, timestamp TEXT, content TEXT NOT NULL, has_tool INTEGER DEFAULT 0, tool_names TEXT, thinking TEXT, tokens_in INTEGER DEFAULT 0, tokens_out INTEGER DEFAULT 0, UNIQUE(session_id, turn_index));
+            CREATE TABLE jobs (id TEXT PRIMARY KEY, kind TEXT NOT NULL, status TEXT NOT NULL, started_at TEXT NOT NULL, completed_at TEXT, error TEXT, result TEXT, metadata TEXT);
+            CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT);
+            INSERT INTO config(key, value) VALUES ('schema_version', '6');
+            INSERT INTO sessions(id, agent, start_time, ingested_at) VALUES ('preserve-1', 'claude-code', '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z');",
+        )
+        .unwrap();
+        let db = Database::from_connection(conn);
+        db.migrate().unwrap();
+
+        // v7 + v8 컬럼 모두 추가됨
+        assert!(db.column_exists("sessions", "notes").unwrap());
+        assert!(db
+            .column_exists("sessions", "semantic_extracted_at")
+            .unwrap());
+        assert_eq!(
+            db.schema_version().unwrap(),
+            crate::store::schema::CURRENT_SCHEMA_VERSION
+        );
+
+        // 기존 row 보존 확인 — id가 살아있고 semantic_extracted_at은 NULL
+        let (id, sem): (String, Option<i64>) = db
+            .conn()
+            .query_row(
+                "SELECT id, semantic_extracted_at FROM sessions WHERE id = 'preserve-1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(id, "preserve-1");
+        assert!(sem.is_none(), "기존 row의 semantic_extracted_at은 NULL");
+    }
+
+    #[test]
+    fn test_update_semantic_extracted_at_sets_value() {
+        let db = Database::open_memory().unwrap();
+        db.insert_session(&make_test_session("sem-1")).unwrap();
+
+        db.update_semantic_extracted_at("sem-1", 1234).unwrap();
+
+        let value: Option<i64> = db
+            .conn()
+            .query_row(
+                "SELECT semantic_extracted_at FROM sessions WHERE id = 'sem-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(value, Some(1234));
+    }
+
+    #[test]
+    fn test_update_semantic_extracted_at_missing_session_no_op() {
+        let db = Database::open_memory().unwrap();
+        // 미존재 세션 업데이트는 에러 없이 통과 (0 affected)
+        let res = db.update_semantic_extracted_at("nonexistent", 9999);
+        assert!(res.is_ok(), "미존재 세션은 에러 안 남");
+    }
+
+    #[test]
+    fn test_list_sessions_for_graph_rebuild_session_only() {
+        let db = Database::open_memory().unwrap();
+        db.insert_session(&make_test_session("s-1")).unwrap();
+        db.insert_session(&make_test_session("s-2")).unwrap();
+        db.insert_session(&make_test_session("s-3")).unwrap();
+
+        let filter = GraphRebuildFilter {
+            session: Some("s-2".to_string()),
+            // 다른 필드는 무시되어야 함
+            all: true,
+            retry_failed: true,
+            since: Some("2026-01-01".to_string()),
+        };
+        let ids = db.list_sessions_for_graph_rebuild(filter).unwrap();
+        assert_eq!(ids, vec!["s-2"]);
+
+        // 미존재 ID는 빈 결과
+        let filter_missing = GraphRebuildFilter {
+            session: Some("nonexistent".to_string()),
+            ..Default::default()
+        };
+        let empty = db.list_sessions_for_graph_rebuild(filter_missing).unwrap();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_list_sessions_for_graph_rebuild_all_overrides_filters() {
+        let db = Database::open_memory().unwrap();
+        // 3개 세션 — start_time 순서대로
+        for (id, day) in [("a-1", 1u32), ("a-2", 2u32), ("a-3", 3u32)] {
+            let mut s = make_test_session(id);
+            s.start_time = chrono::Utc.with_ymd_and_hms(2026, 4, day, 0, 0, 0).unwrap();
+            db.insert_session(&s).unwrap();
+        }
+        // a-1만 추출 완료 표시 — retry_failed라면 제외되어야 하나, all=true로 포함되어야 함
+        db.update_semantic_extracted_at("a-1", 100).unwrap();
+
+        let filter = GraphRebuildFilter {
+            all: true,
+            retry_failed: true,                    // 무시
+            since: Some("2030-01-01".to_string()), // 무시 (정상이라면 0 결과)
+            session: None,
+        };
+        let mut ids = db.list_sessions_for_graph_rebuild(filter).unwrap();
+        ids.sort();
+        assert_eq!(ids, vec!["a-1", "a-2", "a-3"]);
+    }
+
+    #[test]
+    fn test_list_sessions_for_graph_rebuild_retry_failed_only_null() {
+        let db = Database::open_memory().unwrap();
+        for id in ["r-1", "r-2", "r-3"] {
+            db.insert_session(&make_test_session(id)).unwrap();
+        }
+        // r-1, r-3만 추출 완료 — r-2만 NULL 상태 유지
+        db.update_semantic_extracted_at("r-1", 111).unwrap();
+        db.update_semantic_extracted_at("r-3", 333).unwrap();
+
+        let filter = GraphRebuildFilter {
+            retry_failed: true,
+            ..Default::default()
+        };
+        let ids = db.list_sessions_for_graph_rebuild(filter).unwrap();
+        assert_eq!(ids, vec!["r-2"]);
+    }
+
+    #[test]
+    fn test_list_sessions_for_graph_rebuild_since_filters_by_date() {
+        let db = Database::open_memory().unwrap();
+
+        // 4/1, 4/5, 4/10 세션
+        for (id, day) in [("d-1", 1u32), ("d-5", 5u32), ("d-10", 10u32)] {
+            let mut s = make_test_session(id);
+            s.start_time = chrono::Utc.with_ymd_and_hms(2026, 4, day, 0, 0, 0).unwrap();
+            db.insert_session(&s).unwrap();
+        }
+
+        // since=2026-04-05 → d-5, d-10 매칭 (start_time은 RFC3339 "2026-04-05T..." 등)
+        // ORDER BY start_time DESC → d-10 먼저
+        let filter = GraphRebuildFilter {
+            since: Some("2026-04-05".to_string()),
+            ..Default::default()
+        };
+        let ids = db.list_sessions_for_graph_rebuild(filter).unwrap();
+        assert_eq!(ids, vec!["d-10", "d-5"]);
     }
 }

--- a/crates/secall-core/src/store/schema.rs
+++ b/crates/secall-core/src/store/schema.rs
@@ -1,4 +1,4 @@
-pub const CURRENT_SCHEMA_VERSION: u32 = 7;
+pub const CURRENT_SCHEMA_VERSION: u32 = 8;
 
 pub const CREATE_SESSIONS: &str = "
 CREATE TABLE IF NOT EXISTS sessions (
@@ -22,7 +22,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     status        TEXT DEFAULT 'raw',
     session_type  TEXT DEFAULT 'interactive',
     is_favorite   INTEGER DEFAULT 0,
-    notes         TEXT
+    notes         TEXT,
+    semantic_extracted_at INTEGER
 );
 ";
 

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -972,6 +972,78 @@ impl Database {
         Ok(())
     }
 
+    /// P37 Task 00: 단일 세션의 `semantic_extracted_at` timestamp 갱신.
+    /// 미존재 세션은 0 affected — 호출자가 결과 무시 가능 (에러 안 남).
+    pub fn update_semantic_extracted_at(
+        &self,
+        session_id: &str,
+        ts: i64,
+    ) -> crate::error::Result<()> {
+        self.conn().execute(
+            "UPDATE sessions SET semantic_extracted_at = ?1 WHERE id = ?2",
+            rusqlite::params![ts, session_id],
+        )?;
+        Ok(())
+    }
+
+    /// P37 Task 00: graph rebuild 처리 대상 세션 ID 목록 반환.
+    ///
+    /// 우선순위 (위에서 부터 평가하고 첫 매칭만 사용):
+    /// 1. `filter.session.is_some()` → 해당 ID만 (단일 row)
+    /// 2. `filter.all == true` → 모든 sessions
+    /// 3. `filter.retry_failed == true` → `WHERE semantic_extracted_at IS NULL`
+    /// 4. `filter.since.is_some()` → `WHERE start_time >= ?`
+    /// 5. 기본값 (모든 필드 비활성) → 빈 Vec
+    ///
+    /// 정렬: `ORDER BY start_time DESC` 일관 적용.
+    pub fn list_sessions_for_graph_rebuild(
+        &self,
+        filter: GraphRebuildFilter,
+    ) -> crate::error::Result<Vec<String>> {
+        // 1. session ID 단건 조회
+        if let Some(id) = filter.session {
+            let mut stmt = self
+                .conn()
+                .prepare("SELECT id FROM sessions WHERE id = ?1")?;
+            let rows = stmt.query_map([id], |row| row.get::<_, String>(0))?;
+            return Ok(rows.filter_map(|r| r.ok()).collect());
+        }
+
+        // 2. all=true → 모든 sessions
+        if filter.all {
+            let mut stmt = self
+                .conn()
+                .prepare("SELECT id FROM sessions ORDER BY start_time DESC")?;
+            let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+            return Ok(rows.filter_map(|r| r.ok()).collect());
+        }
+
+        // 3. retry_failed → semantic_extracted_at IS NULL
+        if filter.retry_failed {
+            let mut stmt = self.conn().prepare(
+                "SELECT id FROM sessions
+                 WHERE semantic_extracted_at IS NULL
+                 ORDER BY start_time DESC",
+            )?;
+            let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+            return Ok(rows.filter_map(|r| r.ok()).collect());
+        }
+
+        // 4. since (date 비교, ISO format)
+        if let Some(since) = filter.since {
+            let mut stmt = self.conn().prepare(
+                "SELECT id FROM sessions
+                 WHERE start_time >= ?1
+                 ORDER BY start_time DESC",
+            )?;
+            let rows = stmt.query_map([since], |row| row.get::<_, String>(0))?;
+            return Ok(rows.filter_map(|r| r.ok()).collect());
+        }
+
+        // 5. 모든 필드 비활성 → 빈 Vec
+        Ok(Vec::new())
+    }
+
     /// 단일 세션의 리스트 아이템 메타 — `do_get` 응답에 tags/is_favorite/notes 등 보강에 사용.
     pub fn get_session_list_item(&self, session_id: &str) -> crate::error::Result<SessionListItem> {
         self.conn()
@@ -1084,4 +1156,20 @@ pub struct SessionStats {
 pub struct TagCount {
     pub name: String,
     pub count: i64,
+}
+
+/// P37 Task 00: graph rebuild 대상 세션 필터.
+///
+/// 우선순위: `session` > `all` > `retry_failed` > `since`.
+/// 모든 필드 비활성이면 빈 결과 반환 (CLI/REST가 "처리할 세션 없음" 안내).
+#[derive(Debug, Default, Clone)]
+pub struct GraphRebuildFilter {
+    /// "YYYY-MM-DD" 또는 RFC3339. 이 시각 이후 시작된 세션만. None 이면 무시.
+    pub since: Option<String>,
+    /// 단일 세션 ID. 다른 필터 무시.
+    pub session: Option<String>,
+    /// true 면 모든 세션 (since/retry_failed 무시). session 보다 우선순위 낮음.
+    pub all: bool,
+    /// true 면 `semantic_extracted_at IS NULL` 인 세션만.
+    pub retry_failed: bool,
 }

--- a/crates/secall-core/tests/jobs_rest.rs
+++ b/crates/secall-core/tests/jobs_rest.rs
@@ -13,7 +13,10 @@ use secall_core::jobs::{
 use secall_core::store::Database;
 
 /// 테스트용 어댑터: sync_fn은 `delay_ms`만큼 대기 후 echo 결과 반환.
-/// ingest_fn/wiki_update_fn은 즉시 Ok 반환.
+/// ingest_fn/wiki_update_fn/graph_rebuild_fn 은 즉시 Ok 반환.
+///
+/// P37 Task 02 — `graph_rebuild_fn` 은 `delay_ms` 만큼 대기 후 outcome 반환하며,
+/// 매 50ms 단위로 `is_cancelled()` 폴링하여 cancel 시 부분 outcome 으로 early return.
 fn make_adapters(delay_ms: u64) -> CommandAdapters {
     CommandAdapters {
         sync_fn: Box::new(move |val, sink: BroadcastSink| {
@@ -32,6 +35,36 @@ fn make_adapters(delay_ms: u64) -> CommandAdapters {
         }),
         wiki_update_fn: Box::new(|_val, _sink| {
             Box::pin(async move { Ok(serde_json::json!({ "pages_written": 0 })) })
+        }),
+        graph_rebuild_fn: Box::new(move |val, sink: BroadcastSink| {
+            Box::pin(async move {
+                use secall_core::jobs::ProgressSink;
+                // delay_ms 를 50ms 슬라이스로 쪼개서 cancel 폴링.
+                let slices = (delay_ms / 50).max(1);
+                for _ in 0..slices {
+                    if sink.is_cancelled() {
+                        // 부분 outcome 보존 (P36 패턴).
+                        return Ok(serde_json::json!({
+                            "processed": 0,
+                            "succeeded": 0,
+                            "failed": 0,
+                            "skipped": 0,
+                            "edges_added": 0,
+                            "cancelled": true,
+                            "args": val,
+                        }));
+                    }
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+                Ok(serde_json::json!({
+                    "processed": 0,
+                    "succeeded": 0,
+                    "failed": 0,
+                    "skipped": 0,
+                    "edges_added": 0,
+                    "args": val,
+                }))
+            })
         }),
     }
 }
@@ -227,6 +260,111 @@ async fn list_recent_jobs_returns_persisted_rows() {
     let r = rows.iter().find(|r| r.id == id).unwrap();
     assert_eq!(r.kind, "ingest");
     assert_eq!(r.status, "completed");
+}
+
+// ─── P37 Task 02 — graph rebuild adapter 통합 ───────────────────────────────
+
+/// REST `/api/commands/graph-rebuild` 엔트리포인트가 실제로 호출하는 흐름:
+/// `try_spawn(JobKind::GraphRebuild, args, |tx, token| (graph_rebuild_fn)(args, sink))`.
+/// 200 + job_id 반환 후 GET /api/jobs/{id} 동등 경로 (registry/db) 로 status 추적이 가능한지 검증.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_graph_rebuild_endpoint_starts_job() {
+    let (exec, _dir) = make_executor(0);
+    let adapters = exec.adapters.clone().expect("adapters configured");
+
+    let args = serde_json::json!({ "retry_failed": true });
+    let args_for_spawn = args.clone();
+    let (id, _tx) = exec
+        .try_spawn(
+            JobKind::GraphRebuild,
+            Some(args.clone()),
+            move |tx, cancel_token| {
+                let adapters = adapters.clone();
+                let args_for_spawn = args_for_spawn.clone();
+                async move {
+                    let sink = BroadcastSink::new(tx, cancel_token);
+                    (adapters.graph_rebuild_fn)(args_for_spawn, sink).await
+                }
+            },
+        )
+        .await
+        .expect("first spawn must succeed (graph_rebuild)");
+
+    // 잠시 후 registry 에 Started/Running 으로 등장 (GET /api/jobs/{id} 동등).
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let state = exec
+        .registry
+        .get(&id)
+        .await
+        .expect("graph_rebuild job must be registered");
+    assert_eq!(state.kind, JobKind::GraphRebuild);
+
+    // 완료까지 대기 → DB persist 검증.
+    for _ in 0..40 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let row = exec.db.lock().unwrap().get_job(&id).expect("get_job ok");
+        if let Some(r) = row {
+            if r.status == "completed" || r.status == "failed" {
+                assert_eq!(r.kind, "graph_rebuild");
+                assert_eq!(r.status, "completed", "expected completed, got: {r:?}");
+                assert!(r.result.is_some(), "result must be persisted");
+                return;
+            }
+        }
+    }
+    panic!("graph_rebuild job did not complete within 2s");
+}
+
+/// P36 cancel 통합: graph_rebuild 실행 중 cancel 호출 → status=interrupted.
+/// adapter 가 폴링 후 부분 outcome 을 반환하면 partial_result 도 보존된다.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_graph_rebuild_cancel_interrupts_job() {
+    // 충분히 긴 delay 로 폴링 루프 진입을 보장.
+    let (exec, _dir) = make_executor(2000);
+    let adapters = exec.adapters.clone().expect("adapters configured");
+
+    let args = serde_json::json!({ "all": true });
+    let args_for_spawn = args.clone();
+    let (id, _tx) = exec
+        .try_spawn(
+            JobKind::GraphRebuild,
+            Some(args.clone()),
+            move |tx, cancel_token| {
+                let adapters = adapters.clone();
+                let args_for_spawn = args_for_spawn.clone();
+                async move {
+                    let sink = BroadcastSink::new(tx, cancel_token);
+                    (adapters.graph_rebuild_fn)(args_for_spawn, sink).await
+                }
+            },
+        )
+        .await
+        .expect("first spawn must succeed");
+
+    // Running 진입 대기.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // POST /api/jobs/{id}/cancel 동등 경로.
+    assert!(exec.registry.cancel(&id).await, "cancel must succeed");
+
+    // executor select 루프가 status 를 Interrupted 로 확정할 때까지 대기.
+    let mut final_status = None;
+    for _ in 0..40 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let row = exec.db.lock().unwrap().get_job(&id).expect("get_job ok");
+        if let Some(r) = row {
+            if r.status == "interrupted" || r.status == "completed" || r.status == "failed" {
+                final_status = Some(r);
+                break;
+            }
+        }
+    }
+    let row = final_status.expect("job did not finalize within 2s");
+    assert_eq!(
+        row.status, "interrupted",
+        "cancel must yield interrupted status, got {row:?}"
+    );
+    assert_eq!(row.kind, "graph_rebuild");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/secall/Cargo.toml
+++ b/crates/secall/Cargo.toml
@@ -30,3 +30,6 @@ kiwi-rs.workspace = true
 default = ["web-ui"]
 web-ui = ["secall-core/web-ui"]
 openvino = ["secall-core/openvino"]
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/crates/secall/src/commands/graph.rs
+++ b/crates/secall/src/commands/graph.rs
@@ -2,9 +2,15 @@ use anyhow::Result;
 use secall_core::{
     graph::{build::build_graph, export::export_graph_json, semantic::extract_and_store},
     ingest::markdown::{extract_body_text, parse_session_frontmatter},
-    store::{get_default_db_path, Database},
+    jobs::ProgressSink,
+    store::{get_default_db_path, session_repo::GraphRebuildFilter, Database},
     vault::Config,
 };
+
+use super::ingest::{
+    extract_one_session_semantic, unload_embedding_model_if_needed, ExtractOneResult,
+};
+use super::NoopSink;
 
 /// 전체 세션에 대해 시맨틱 엣지만 재추출. 임베딩은 건드리지 않음.
 pub async fn run_semantic(
@@ -184,4 +190,220 @@ pub fn run_export() -> Result<()> {
 
     eprintln!("Exported to {}", output_path.display());
     Ok(())
+}
+
+// ─── P37 Task 01: graph rebuild ─────────────────────────────────────────────
+
+/// `graph rebuild` 명령 인자 — REST DTO/Job 어댑터(Task 02)에서 동일 구조 사용.
+///
+/// 우선순위는 `GraphRebuildFilter` 와 동일: `session` > `all` > `retry_failed` > `since`.
+/// 모든 필드 비활성이면 빈 결과 반환.
+#[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
+pub struct GraphRebuildArgs {
+    pub since: Option<String>,
+    pub session: Option<String>,
+    #[serde(default)]
+    pub all: bool,
+    #[serde(default)]
+    pub retry_failed: bool,
+}
+
+impl From<GraphRebuildArgs> for GraphRebuildFilter {
+    fn from(args: GraphRebuildArgs) -> Self {
+        GraphRebuildFilter {
+            since: args.since,
+            session: args.session,
+            all: args.all,
+            retry_failed: args.retry_failed,
+        }
+    }
+}
+
+/// `graph rebuild` 결과 요약 — REST 응답 / SSE Done payload 용.
+#[derive(Debug, Default, serde::Serialize)]
+pub struct GraphRebuildOutcome {
+    pub processed: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub edges_added: usize,
+}
+
+/// Progress 보고가 가능한 graph rebuild 본체.
+///
+/// CLI 는 `NoopSink`, REST/Job 은 `BroadcastSink` 로 호출.
+/// P36 cancel 패턴: 매 세션 시작 지점에서 `is_cancelled()` 폴링 → 부분 outcome 으로 early return.
+pub async fn run_rebuild(
+    args: GraphRebuildArgs,
+    sink: &dyn ProgressSink,
+) -> Result<GraphRebuildOutcome> {
+    let config = Config::load_or_default();
+    let db = Database::open(&get_default_db_path())?;
+
+    // 1. 처리 대상 ID 목록
+    let filter: GraphRebuildFilter = args.into();
+    let ids = db.list_sessions_for_graph_rebuild(filter)?;
+
+    if ids.is_empty() {
+        sink.message("처리할 세션 없음").await;
+        return Ok(GraphRebuildOutcome::default());
+    }
+
+    // 2. 임베딩 모델 unload — 시맨틱 추출 진입 시점에 한 번만
+    unload_embedding_model_if_needed(&config).await;
+
+    let total = ids.len();
+    let mut outcome = GraphRebuildOutcome::default();
+
+    sink.message(&format!("Graph rebuild: {} session(s) to process", total))
+        .await;
+
+    let now_secs = chrono::Utc::now().timestamp();
+
+    for (i, id) in ids.iter().enumerate() {
+        // 3. 안전 지점 cancel 폴링 (P36 패턴)
+        if sink.is_cancelled() {
+            sink.message(&format!("취소 요청 — {}/{} 처리 후 종료합니다", i, total))
+                .await;
+            return Ok(outcome);
+        }
+        if total > 0 {
+            sink.progress((i as f32) / (total as f32)).await;
+        }
+
+        // 4. 단일 세션 시맨틱 추출 (ingest 와 공유)
+        match extract_one_session_semantic(&db, &config, id).await {
+            ExtractOneResult::Extracted(n) => {
+                outcome.succeeded += 1;
+                outcome.edges_added += n;
+                // 성공 시에만 timestamp 갱신
+                if let Err(e) = db.update_semantic_extracted_at(id, now_secs) {
+                    let short = &id[..8.min(id.len())];
+                    tracing::warn!(
+                        session = short,
+                        error = %e,
+                        "failed to update semantic_extracted_at"
+                    );
+                }
+            }
+            ExtractOneResult::Skipped(_reason) => {
+                outcome.skipped += 1;
+            }
+            ExtractOneResult::Failed(_e) => {
+                outcome.failed += 1;
+            }
+        }
+        outcome.processed += 1;
+    }
+
+    sink.message(&format!(
+        "완료: succeeded={}, failed={}, skipped={}, edges_added={}",
+        outcome.succeeded, outcome.failed, outcome.skipped, outcome.edges_added
+    ))
+    .await;
+
+    Ok(outcome)
+}
+
+/// CLI wrapper — `NoopSink` 사용 (P36 wiki `run_update` 패턴).
+pub async fn run_rebuild_cli(args: GraphRebuildArgs) -> Result<()> {
+    let outcome = run_rebuild(args, &NoopSink).await?;
+    eprintln!(
+        "Graph rebuild complete: processed={}, succeeded={}, failed={}, skipped={}, edges_added={}",
+        outcome.processed, outcome.succeeded, outcome.failed, outcome.skipped, outcome.edges_added,
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// `run_rebuild` 는 `SECALL_DB_PATH` 환경변수를 통해 DB 를 연다.
+    /// 테스트들이 병렬 실행될 때 같은 환경변수를 동시에 set/unset 하면 race 가 발생하므로
+    /// 환경변수 변경을 직렬화한다.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// vault_path 가 설정되지 않은(또는 vault 가 비어있는) 세션은
+    /// `extract_one_session_semantic` 이 Skipped 로 판정한다.
+    /// 본 테스트들은 filter 가 정확한 ID 세트를 선택하는지(processed 값)만 검증.
+    fn insert_minimal_session(db: &Database, id: &str) {
+        use chrono::Utc;
+        use secall_core::ingest::{AgentKind, Session, TokenUsage};
+
+        let session = Session {
+            id: id.to_string(),
+            agent: AgentKind::ClaudeCode,
+            model: None,
+            project: None,
+            cwd: None,
+            git_branch: None,
+            host: None,
+            start_time: Utc::now(),
+            end_time: None,
+            turns: Vec::new(),
+            total_tokens: TokenUsage::default(),
+            session_type: "interactive".to_string(),
+        };
+        use secall_core::store::SessionRepo;
+        db.insert_session(&session).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_run_rebuild_retry_failed_only_processes_null_sessions() {
+        let _env_guard = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("index.sqlite");
+        std::env::set_var("SECALL_DB_PATH", &path);
+
+        let db = Database::open(&get_default_db_path()).unwrap();
+
+        insert_minimal_session(&db, "rf-null-1");
+        insert_minimal_session(&db, "rf-null-2");
+        insert_minimal_session(&db, "rf-done");
+        // rf-done 만 추출 완료 처리 → retry_failed 대상에서 제외
+        db.update_semantic_extracted_at("rf-done", 999).unwrap();
+        drop(db);
+
+        let args = GraphRebuildArgs {
+            retry_failed: true,
+            ..Default::default()
+        };
+        let outcome = run_rebuild(args, &NoopSink).await.unwrap();
+
+        // 두 NULL 세션만 처리됨 (vault 누락이라 모두 skipped 로 카운트되지만
+        // processed 는 NULL 세션 수와 정확히 일치)
+        assert_eq!(outcome.processed, 2);
+        assert_eq!(outcome.skipped, 2);
+        assert_eq!(outcome.succeeded, 0);
+        assert_eq!(outcome.failed, 0);
+
+        std::env::remove_var("SECALL_DB_PATH");
+    }
+
+    #[tokio::test]
+    async fn test_run_rebuild_session_filter_processes_one() {
+        let _env_guard = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("index.sqlite");
+        std::env::set_var("SECALL_DB_PATH", &path);
+
+        let db = Database::open(&get_default_db_path()).unwrap();
+
+        insert_minimal_session(&db, "sf-1");
+        insert_minimal_session(&db, "sf-2");
+        insert_minimal_session(&db, "sf-3");
+        drop(db);
+
+        let args = GraphRebuildArgs {
+            session: Some("sf-2".to_string()),
+            ..Default::default()
+        };
+        let outcome = run_rebuild(args, &NoopSink).await.unwrap();
+
+        assert_eq!(outcome.processed, 1);
+
+        std::env::remove_var("SECALL_DB_PATH");
+    }
 }

--- a/crates/secall/src/commands/graph.rs
+++ b/crates/secall/src/commands/graph.rs
@@ -318,12 +318,14 @@ pub async fn run_rebuild_cli(args: GraphRebuildArgs) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use tokio::sync::Mutex;
 
     /// `run_rebuild` 는 `SECALL_DB_PATH` 환경변수를 통해 DB 를 연다.
     /// 테스트들이 병렬 실행될 때 같은 환경변수를 동시에 set/unset 하면 race 가 발생하므로
     /// 환경변수 변경을 직렬화한다.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // P37 rework — tokio::sync::Mutex 사용 (clippy::await_holding_lock 회피).
+    // std::sync::Mutex 가드를 .await 너머로 들고 가면 CI -D warnings 모드에서 error.
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
     /// vault_path 가 설정되지 않은(또는 vault 가 비어있는) 세션은
     /// `extract_one_session_semantic` 이 Skipped 로 판정한다.
@@ -352,7 +354,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_rebuild_retry_failed_only_processes_null_sessions() {
-        let _env_guard = ENV_LOCK.lock().unwrap();
+        let _env_guard = ENV_LOCK.lock().await;
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("index.sqlite");
         std::env::set_var("SECALL_DB_PATH", &path);
@@ -384,7 +386,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_rebuild_session_filter_processes_one() {
-        let _env_guard = ENV_LOCK.lock().unwrap();
+        let _env_guard = ENV_LOCK.lock().await;
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("index.sqlite");
         std::env::set_var("SECALL_DB_PATH", &path);

--- a/crates/secall/src/commands/ingest.rs
+++ b/crates/secall/src/commands/ingest.rs
@@ -609,32 +609,17 @@ pub async fn ingest_sessions(
         && !no_semantic
         && !new_session_ids.is_empty();
     if semantic_enabled {
-        // 임베딩 모델(bge-m3)이 Ollama에 로드되어 있으면 언로드하여
-        // gemma4와 동시 로드로 인한 메모리 압박 방지 (16GB 시스템 대응)
-        if config.embedding.backend == "ollama" && config.graph.semantic_backend == "ollama" {
-            let embed_model = config.embedding.ollama_model.as_deref().unwrap_or("bge-m3");
-            let ollama_url = config
-                .embedding
-                .ollama_url
-                .as_deref()
-                .unwrap_or("http://localhost:11434");
-            let unload_url = format!("{}/api/generate", ollama_url.trim_end_matches('/'));
-            let body = serde_json::json!({"model": embed_model, "keep_alive": 0});
-            match secall_core::http_post_json(&unload_url, &body).await {
-                Ok(_) => tracing::debug!(
-                    model = embed_model,
-                    "unloaded embedding model before semantic extraction"
-                ),
-                Err(e) => {
-                    tracing::debug!(model = embed_model, "embedding model unload skipped: {}", e)
-                }
-            }
-        }
+        // 임베딩 모델 unload — P37 Task 01: helper 로 분리하여 graph::run_rebuild 와 공유
+        unload_embedding_model_if_needed(config).await;
         eprintln!(
             "Extracting semantic edges for {} session(s)...",
             new_session_ids.len()
         );
         let total_sem = new_session_ids.len();
+        // P37 rework — graph rebuild 와 동일하게 sub-loop 진입 시 timestamp 한 번 계산.
+        // 성공한 세션마다 같은 값으로 `semantic_extracted_at` 갱신 → 새 세션도
+        // `--retry-failed` 후속 실행 시 NULL 로 잡히지 않도록 한다.
+        let semantic_now_secs = chrono::Utc::now().timestamp();
         for (sem_idx, session_id) in new_session_ids.iter().enumerate() {
             // P36 — cancel check at top of semantic loop (before LLM-ish call)
             if let Some(s) = sink {
@@ -656,46 +641,26 @@ pub async fn ingest_sessions(
                 }
             }
             let short = &session_id[..8.min(session_id.len())];
-            // vault에서 세션 마크다운 읽기
-            let vault_path_opt = match db.get_session_vault_path(session_id) {
-                Ok(vp) => vp,
-                Err(e) => {
-                    tracing::warn!(session = short, "DB error reading vault path: {}", e);
-                    continue;
+            // P37 Task 01: 단일 세션 helper 로 추출 (rebuild 경로와 동일 helper).
+            // 동작 변경 없음 — 기존 tracing::warn/debug 메시지 그대로 보존.
+            match extract_one_session_semantic(db, config, session_id).await {
+                ExtractOneResult::Extracted(n) => {
+                    tracing::debug!(session = short, edges = n, "semantic edges extracted");
+                    // P37 rework — 추출 성공 세션은 timestamp 갱신.
+                    // graph rebuild 경로(graph.rs:280) 와 동일 동작 → ingest 후 NULL 로 남지 않음.
+                    // 갱신 실패는 자가 치유 (다음 retry-failed 가 다시 처리) — warn 만 남김.
+                    if let Err(e) = db.update_semantic_extracted_at(session_id, semantic_now_secs) {
+                        tracing::warn!(
+                            session = short,
+                            error = %e,
+                            "failed to update semantic_extracted_at"
+                        );
+                    }
                 }
-            };
-            let md_path = match vault_path_opt {
-                Some(vp) => config.vault.path.join(&vp),
-                None => {
-                    tracing::debug!(
-                        session = short,
-                        "no vault path, skipping semantic extraction"
-                    );
-                    continue;
+                ExtractOneResult::Skipped(reason) => {
+                    tracing::debug!(session = short, "semantic extraction skipped: {}", reason)
                 }
-            };
-            let content = match std::fs::read_to_string(&md_path) {
-                Ok(c) => c,
-                Err(e) => {
-                    tracing::warn!(session = short, "failed to read vault file: {}", e);
-                    continue;
-                }
-            };
-            let fm = match secall_core::ingest::markdown::parse_session_frontmatter(&content) {
-                Ok(f) => f,
-                Err(e) => {
-                    tracing::warn!(session = short, "failed to parse frontmatter: {}", e);
-                    continue;
-                }
-            };
-            let body = secall_core::ingest::markdown::extract_body_text(&content);
-            match secall_core::graph::semantic::extract_and_store(db, &config.graph, &fm, &body)
-                .await
-            {
-                Ok(n) => {
-                    tracing::debug!(session = short, edges = n, "semantic edges extracted")
-                }
-                Err(e) => {
+                ExtractOneResult::Failed(e) => {
                     tracing::warn!(session = short, "semantic extraction skipped: {}", e)
                 }
             }
@@ -711,6 +676,100 @@ pub async fn ingest_sessions(
         new_session_ids,
         error_details,
     })
+}
+
+/// P37 Task 01 — 단일 세션 시맨틱 엣지 추출 결과.
+///
+/// `ingest::ingest_sessions` 의 시맨틱 sub-loop 와
+/// `graph::run_rebuild` 가 동일 helper 를 사용하기 위한 공통 반환 타입.
+pub enum ExtractOneResult {
+    /// 추출 성공. payload 는 새로 저장된 엣지 수.
+    Extracted(usize),
+    /// vault 파일 누락/파싱 실패 등으로 추출 자체를 시도하지 않음.
+    /// reason 은 사용자/로그에 노출 가능한 짧은 설명.
+    Skipped(String),
+    /// 추출 시도했지만 LLM/DB 등 외부 호출 실패.
+    Failed(anyhow::Error),
+}
+
+/// P37 Task 01 — 단일 세션의 시맨틱 엣지를 추출한다.
+///
+/// ingest 와 graph rebuild 가 공유하는 helper. vault 마크다운을 읽어
+/// frontmatter + body 를 파싱하고 `extract_and_store` 호출.
+/// 동작 변경 없음 — 기존 ingest 시맨틱 sub-loop 의 분기 의미를 그대로 옮김.
+pub async fn extract_one_session_semantic(
+    db: &Database,
+    config: &Config,
+    session_id: &str,
+) -> ExtractOneResult {
+    let short = &session_id[..8.min(session_id.len())];
+
+    let vault_path_opt = match db.get_session_vault_path(session_id) {
+        Ok(vp) => vp,
+        Err(e) => {
+            tracing::warn!(session = short, "DB error reading vault path: {}", e);
+            return ExtractOneResult::Skipped(format!("DB error reading vault path: {e}"));
+        }
+    };
+
+    let md_path = match vault_path_opt {
+        Some(vp) => config.vault.path.join(&vp),
+        None => {
+            tracing::debug!(
+                session = short,
+                "no vault path, skipping semantic extraction"
+            );
+            return ExtractOneResult::Skipped("no vault path".to_string());
+        }
+    };
+
+    let content = match std::fs::read_to_string(&md_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(session = short, "failed to read vault file: {}", e);
+            return ExtractOneResult::Skipped(format!("failed to read vault file: {e}"));
+        }
+    };
+
+    let fm = match secall_core::ingest::markdown::parse_session_frontmatter(&content) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!(session = short, "failed to parse frontmatter: {}", e);
+            return ExtractOneResult::Skipped(format!("failed to parse frontmatter: {e}"));
+        }
+    };
+
+    let body = secall_core::ingest::markdown::extract_body_text(&content);
+    match secall_core::graph::semantic::extract_and_store(db, &config.graph, &fm, &body).await {
+        Ok(n) => ExtractOneResult::Extracted(n),
+        Err(e) => ExtractOneResult::Failed(anyhow::anyhow!(e)),
+    }
+}
+
+/// P37 Task 01 — 시맨틱 추출 직전 임베딩 모델 unload.
+///
+/// 16GB 시스템에서 bge-m3(임베딩) 와 gemma4(LLM) 동시 로드 시
+/// OOM 위험을 줄이기 위해 시맨틱 backend 가 ollama 인 경우에만 발사.
+/// ingest 와 graph rebuild 둘 다 진입 시점에 한 번 호출한다.
+pub async fn unload_embedding_model_if_needed(config: &Config) {
+    if config.embedding.backend != "ollama" || config.graph.semantic_backend != "ollama" {
+        return;
+    }
+    let embed_model = config.embedding.ollama_model.as_deref().unwrap_or("bge-m3");
+    let ollama_url = config
+        .embedding
+        .ollama_url
+        .as_deref()
+        .unwrap_or("http://localhost:11434");
+    let unload_url = format!("{}/api/generate", ollama_url.trim_end_matches('/'));
+    let body = serde_json::json!({"model": embed_model, "keep_alive": 0});
+    match secall_core::http_post_json(&unload_url, &body).await {
+        Ok(_) => tracing::debug!(
+            model = embed_model,
+            "unloaded embedding model before semantic extraction"
+        ),
+        Err(e) => tracing::debug!(model = embed_model, "embedding model unload skipped: {}", e),
+    }
 }
 
 /// 분류 규칙 — regex 패턴 또는 project 이름 매칭

--- a/crates/secall/src/commands/serve.rs
+++ b/crates/secall/src/commands/serve.rs
@@ -84,6 +84,25 @@ pub async fn run(port: u16) -> Result<()> {
                 .await?
             })
         }),
+        // P37 Task 02 — graph rebuild 어댑터.
+        // `run_rebuild` 가 내부에서 `Database` (rusqlite, !Sync) 를 await 너머로 들고 있으므로
+        // sync/ingest/wiki 와 동일하게 spawn_blocking + current-thread runtime 으로 격리한다.
+        graph_rebuild_fn: Box::new(|val, sink: BroadcastSink| {
+            Box::pin(async move {
+                tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()?;
+                    rt.block_on(async move {
+                        let args: crate::commands::graph::GraphRebuildArgs =
+                            serde_json::from_value(val)?;
+                        let outcome = crate::commands::graph::run_rebuild(args, &sink).await?;
+                        Ok::<_, anyhow::Error>(serde_json::to_value(outcome)?)
+                    })
+                })
+                .await?
+            })
+        }),
     };
 
     let executor = Arc::new(JobExecutor::with_adapters(db_arc.clone(), cmd_adapters));

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -358,6 +358,24 @@ enum GraphAction {
     Stats,
     /// Export graph to vault/graph/graph.json
     Export,
+    /// Rebuild semantic edges for selected sessions (P37)
+    Rebuild {
+        /// Only process sessions started since this date (YYYY-MM-DD)
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Single session ID (overrides other filters)
+        #[arg(long)]
+        session: Option<String>,
+
+        /// Process all sessions (overrides --retry-failed and --since)
+        #[arg(long)]
+        all: bool,
+
+        /// Only process sessions with NULL semantic_extracted_at
+        #[arg(long)]
+        retry_failed: bool,
+    },
 }
 
 #[tokio::main]
@@ -540,6 +558,20 @@ async fn main() -> anyhow::Result<()> {
             }
             GraphAction::Export => {
                 commands::graph::run_export()?;
+            }
+            GraphAction::Rebuild {
+                since,
+                session,
+                all,
+                retry_failed,
+            } => {
+                commands::graph::run_rebuild_cli(commands::graph::GraphRebuildArgs {
+                    since,
+                    session,
+                    all,
+                    retry_failed,
+                })
+                .await?;
             }
         },
         Commands::Config { action } => match action {

--- a/docs/plans/p37-graph-sync-result.md
+++ b/docs/plans/p37-graph-sync-result.md
@@ -1,0 +1,63 @@
+# Implementation Result: P37 — 시맨틱 Graph Sync 자동화
+
+> Developer: unknown
+> Branch: N/A
+> Date: 2026-05-03 07:25
+> Plan Revision: 1
+
+---
+
+## Summary
+
+## Rework 완료 — 2건 모두 해결
+
+**수정 내역:**
+
+| # | 파일 | 변경 |
+|---|---|---|
+| 1 | `crates/secall/src/commands/ingest.rs:619-665` | sub-loop 진입 전 `let semantic_now_secs = chrono::Utc::now().timestamp();` 한 번 계산. `ExtractOneResult::Extracted(n)` 분기에 `db.update_semantic_extracted_at(session_id, semantic_now_secs)` 호출 추가 (실패는 warn 로그 — 자가 치유). graph rebuild 경로(graph.rs:280)와 동일 동작 → ingest 후 NULL 잔존 + `--retry-failed` 의미 손상 해결. |
+| 2 | `web/src/components/JobOptionsDialog.tsx:354-362` | session 입력란 placeholder `(특정 session_id 한정)` → `full session_id (UUID)`. 안내 문구 `전체 또는 prefix(8+자리) ID` → `전체 session_id 정확히 입력 (backend 는 exact match — prefix 미지원)`. backend `WHERE id = ?1` exact match 와 일관. |
+
+**Recommendation #1 처리:** `docs/plans/p37-graph-sync-task-03.md` 의 Changed files 와 Scope boundary 에 `JobItem.tsx` (exhaustive switch 강제) + `CommandsRoute.tsx` (grid 조정) 명시 — 계약과 구현 일관성 확보.
+
+**Recommendation #2 처리:** axum route-level 통합 테스트는 별도 phase 권장 (현재 jobs_rest 테스트는 executor 직접 호출 수준 — 변경 없음).
+
+**Verification:**
+```
+✅ cargo check --all-targets — exit 0
+✅ cargo clippy --all-targets --all-features — secall (bin test) 의 사전 ENV_LOCK across await 경고 2건 (Task 01 보고에서 알려진 사항, 신규 코드 결함 아님)
+✅ cargo fmt --all -- --check — clean (자동 적용 후)
+✅ cargo test commands::graph::tests — 2 passed
+✅ cargo test --test jobs_rest — 8 passed (graph_rebuild start + cancel 포함)
+✅ pnpm typecheck — exit 0
+```
+
+**Scope 준수:** Task 00 (DB), Task 02 (REST), Task 04 (README) 코드 무수정. Task 01 영역 (ingest.rs 시맨틱 sub-loop) + Task 03 영역 (JobOptionsDialog UI 안내문) 만 수정.
+
+## Subtask Results
+
+### 1. ## Rework 완료 — 2건 모두 해결
+
+**수정 내역:**
+
+| # | 파일 | 변경 |
+|---|---|---|
+| 1 | `crates/secall/src/commands/ingest.rs:619-665` | sub-loop 진입 전 `let semantic_now_secs = chrono::Utc::now().timestamp();` 한 번 계산. `ExtractOneResult::Extracted(n)` 분기에 `db.update_semantic_extracted_at(session_id, semantic_now_secs)` 호출 추가 (실패는 warn 로그 — 자가 치유). graph rebuild 경로(graph.rs:280)와 동일 동작 → ingest 후 NULL 잔존 + `--retry-failed` 의미 손상 해결. |
+| 2 | `web/src/components/JobOptionsDialog.tsx:354-362` | session 입력란 placeholder `(특정 session_id 한정)` → `full session_id (UUID)`. 안내 문구 `전체 또는 prefix(8+자리) ID` → `전체 session_id 정확히 입력 (backend 는 exact match — prefix 미지원)`. backend `WHERE id = ?1` exact match 와 일관. |
+
+**Recommendation #1 처리:** `docs/plans/p37-graph-sync-task-03.md` 의 Changed files 와 Scope boundary 에 `JobItem.tsx` (exhaustive switch 강제) + `CommandsRoute.tsx` (grid 조정) 명시 — 계약과 구현 일관성 확보.
+
+**Recommendation #2 처리:** axum route-level 통합 테스트는 별도 phase 권장 (현재 jobs_rest 테스트는 executor 직접 호출 수준 — 변경 없음).
+
+**Verification:**
+```
+✅ cargo check --all-targets — exit 0
+✅ cargo clippy --all-targets --all-features — secall (bin test) 의 사전 ENV_LOCK across await 경고 2건 (Task 01 보고에서 알려진 사항, 신규 코드 결함 아님)
+✅ cargo fmt --all -- --check — clean (자동 적용 후)
+✅ cargo test commands::graph::tests — 2 passed
+✅ cargo test --test jobs_rest — 8 passed (graph_rebuild start + cancel 포함)
+✅ pnpm typecheck — exit 0
+```
+
+**Scope 준수:** Task 00 (DB), Task 02 (REST), Task 04 (README) 코드 무수정. Task 01 영역 (ingest.rs 시맨틱 sub-loop) + Task 03 영역 (JobOptionsDialog UI 안내문) 만 수정.
+

--- a/docs/plans/p37-graph-sync-review-r1.md
+++ b/docs/plans/p37-graph-sync-review-r1.md
@@ -1,0 +1,33 @@
+# Review Report: P37 — 시맨틱 Graph Sync 자동화 — Round 1
+
+> Verdict: fail
+> Reviewer: 
+> Date: 2026-05-03 07:20
+> Plan Revision: 1
+
+---
+
+## Verdict
+
+**fail**
+
+## Findings
+
+1. crates/secall/src/commands/ingest.rs:642 — ingest 경로에서 `extract_one_session_semantic()` 성공 후 `semantic_extracted_at`를 갱신하지 않습니다. 반면 rebuild 경로는 [crates/secall/src/commands/graph.rs](/Users/d9ng/privateProject/seCall/crates/secall/src/commands/graph.rs:280)에서 성공 시 timestamp를 기록합니다. 이 차이 때문에 새로 ingest 되어 시맨틱 추출에 성공한 세션도 계속 `NULL` 상태로 남고, `--retry-failed`가 정상 성공 세션까지 다시 집어오므로 P37의 상태 추적/재시도 의미가 깨집니다.
+2. web/src/components/JobOptionsDialog.tsx:357 — UI가 session 입력란에 `prefix(8+자리) ID`를 지원한다고 안내하지만, 실제 backend 필터는 [crates/secall-core/src/store/session_repo.rs](/Users/d9ng/privateProject/seCall/crates/secall-core/src/store/session_repo.rs:1007)의 `WHERE id = ?1` exact match만 사용합니다. 사용자는 8자리 prefix를 넣고도 0건 처리되는 오동작을 겪게 됩니다.
+
+## Recommendations
+
+1. `web/src/components/JobItem.tsx`도 함께 수정했으므로, task 문서의 Changed files/Scope boundary에 이 파일을 반영해 계약과 구현을 맞추는 편이 안전합니다.
+2. `crates/secall-core/tests/jobs_rest.rs`의 신규 테스트는 executor 직접 호출 수준이라 실제 Axum 라우트(`/api/commands/graph-rebuild`) 배선까지는 검증하지 않습니다. route-level 테스트를 별도로 두는 것이 좋습니다.
+
+## Subtask Verification
+
+| # | Subtask | Status |
+|---|---------|--------|
+| 1 | DB 스키마 v8 + state tracking (`semantic_extracted_at`) | ✅ done |
+| 2 | CLI `graph rebuild` 명령 + GraphRebuildArgs/Outcome + `run_with_progress` | ✅ done |
+| 3 | REST `/api/commands/graph-rebuild` + Job 어댑터 + P36 cancel 지원 | ✅ done |
+| 4 | web UI: CommandsRoute 카드 + JobOptionsDialog 옵션 + types/api | ✅ done |
+| 5 | README + CI 업데이트 | ✅ done |
+

--- a/docs/plans/p37-graph-sync-review-r2.md
+++ b/docs/plans/p37-graph-sync-review-r2.md
@@ -1,0 +1,27 @@
+# Review Report: P37 — 시맨틱 Graph Sync 자동화 — Round 2
+
+> Verdict: pass
+> Reviewer: 
+> Date: 2026-05-03 07:25
+> Plan Revision: 1
+
+---
+
+## Verdict
+
+**pass**
+
+## Recommendations
+
+1. `crates/secall/src/commands/ingest.rs`와 `crates/secall/src/commands/graph.rs`가 같은 timestamp 갱신 규칙을 공유하므로, 이후에도 한쪽만 바뀌지 않게 작은 helper로 묶는 것을 고려할 수 있습니다.
+
+## Subtask Verification
+
+| # | Subtask | Status |
+|---|---------|--------|
+| 1 | DB 스키마 v8 + state tracking (`semantic_extracted_at`) | ✅ done |
+| 2 | CLI `graph rebuild` 명령 + GraphRebuildArgs/Outcome + `run_with_progress` | ✅ done |
+| 3 | REST `/api/commands/graph-rebuild` + Job 어댑터 + P36 cancel 지원 | ✅ done |
+| 4 | web UI: CommandsRoute 카드 + JobOptionsDialog 옵션 + types/api | ✅ done |
+| 5 | README + CI 업데이트 | ✅ done |
+

--- a/docs/plans/p37-graph-sync-task-00.md
+++ b/docs/plans/p37-graph-sync-task-00.md
@@ -1,0 +1,119 @@
+---
+type: task
+status: draft
+updated_at: 2026-05-02
+plan_slug: p37-graph-sync
+task_id: 00
+parallel_group: A
+depends_on: []
+---
+
+# Task 00 — DB 스키마 v8 + state tracking (`semantic_extracted_at`)
+
+## Changed files
+
+수정:
+- `crates/secall-core/src/store/schema.rs:1` — `CURRENT_SCHEMA_VERSION` 7 → 8.
+- `crates/secall-core/src/store/schema.rs:3` — `CREATE_SESSIONS` 본문에 `semantic_extracted_at INTEGER` 컬럼 추가 (NULL 허용 — 미처리 세션 표현). 신규 DB 는 처음부터 v8 스키마.
+- `crates/secall-core/src/store/db.rs:113` 인접 — v7 마이그레이션 분기 다음에 `if current < 8 && !self.column_exists("sessions", "semantic_extracted_at")?` ALTER TABLE 분기 추가. P34 v7 패턴 그대로.
+- `crates/secall-core/src/store/db.rs` — 기존 마이그레이션 회귀 + 신규 v8 회귀 테스트 추가:
+  - `test_v8_semantic_extracted_at_column_exists` — open 후 컬럼 존재 검증
+  - `test_v8_migrates_v6_db` — v6 schema 로 만든 DB 를 open 시 v8 까지 마이그레이션 적용 + 기존 row 보존
+  - `test_update_semantic_extracted_at_*` — 신규 helper 회귀
+  - `test_list_sessions_for_graph_rebuild_*` — 신규 helper 회귀 (since / session / all / retry-failed 4 케이스)
+- `crates/secall-core/src/store/session_repo.rs` — 신규 helper 메서드 2 개 (기존 `list_sessions_filtered` 패턴 따라):
+  - `update_semantic_extracted_at(&self, session_id: &str, ts: i64) -> Result<()>` — 단일 세션 timestamp set
+  - `list_sessions_for_graph_rebuild(&self, filter: GraphRebuildFilter) -> Result<Vec<String>>` — 처리 대상 세션 id 목록 반환
+- `crates/secall-core/src/store/session_repo.rs` — 신규 구조체:
+  - `pub struct GraphRebuildFilter { pub since: Option<String>, pub session: Option<String>, pub all: bool, pub retry_failed: bool }`
+
+신규: 없음 (기존 파일 확장만)
+
+## Change description
+
+### 1. 스키마 업그레이드 (schema.rs)
+
+`CURRENT_SCHEMA_VERSION` 상수 1 증가. `CREATE_SESSIONS` SQL 본문 끝에 `semantic_extracted_at INTEGER` 한 줄 추가 (NULL 허용 = 미처리). FOREIGN KEY 등 기존 제약 변경 없음.
+
+### 2. 마이그레이션 (db.rs)
+
+P34 의 v7 (notes 컬럼) 마이그레이션 패턴을 그대로 모방:
+- `if current < 8 && !column_exists("sessions", "semantic_extracted_at")?` 분기 안에서 단일 `ALTER TABLE sessions ADD COLUMN semantic_extracted_at INTEGER` 실행.
+- 기존 row 의 `semantic_extracted_at` 은 NULL 로 초기화 → "처리 안 됨" 의미. ingest 시점 추출이 성공한 세션도 NULL — Task 02 가 시작 시 NULL 인 모든 세션을 retry-failed 모드로 처리하면 일괄 backfill 가능.
+- 멱등성 보장: 재실행 시 column_exists 체크.
+- 마이그레이션 끝에서 schema_version row 갱신은 기존 코드(line 117-120) 가 처리.
+
+### 3. session_repo helper 시그니처 계약
+
+```rust
+pub struct GraphRebuildFilter {
+    /// "YYYY-MM-DD" — 이 날짜 이후 시작된 세션만. None 이면 모든 날짜.
+    pub since: Option<String>,
+    /// 단일 세션 ID. 다른 필터 무시.
+    pub session: Option<String>,
+    /// true 면 모든 세션 (since/retry_failed 무시). session 보다 우선순위 낮음.
+    pub all: bool,
+    /// true 면 `semantic_extracted_at IS NULL` 인 세션만.
+    pub retry_failed: bool,
+}
+```
+
+`list_sessions_for_graph_rebuild` SQL 우선순위:
+1. `session.is_some()` → 해당 ID 만 (단일 row)
+2. `all == true` → 모든 sessions (필터 무시)
+3. `retry_failed == true` → `WHERE semantic_extracted_at IS NULL`
+4. `since.is_some()` → `WHERE start_time >= ?` (date 비교, ISO format)
+5. 기본값 (모든 필드 비활성) → 빈 Vec 반환 → CLI/REST 가 "처리할 세션 없음" 안내
+
+`ORDER BY start_time DESC` 일관 정렬.
+
+`update_semantic_extracted_at` 은 `UPDATE sessions SET semantic_extracted_at = ?1 WHERE id = ?2`. 미존재 row 는 0 affected → 호출자가 결과 무시 가능.
+
+### 4. SessionListItem 영향 범위
+
+세션 리스트 응답 (`/api/sessions`) 에 `semantic_extracted_at` 노출이 필요하면 SessionListItem 에 필드 추가 + REST 응답에 포함 — **본 task 범위 외 (별도 phase)**. 본 task 는 graph rebuild 내부 처리에만 사용. 외부 노출은 P38+ 에서 결정.
+
+### 5. 테스트 시나리오 (db.rs tests)
+
+- `test_v8_semantic_extracted_at_column_exists` — 신규 DB open → 컬럼 있음
+- `test_v8_migrates_v6_db` — v6 DB 직접 생성 → open → v8 마이그레이션 후 컬럼 있음 + 기존 sessions row 보존
+- `test_update_semantic_extracted_at_sets_value` — 단일 세션에 1234 set → SELECT 로 1234 확인
+- `test_update_semantic_extracted_at_missing_session_no_op` — 미존재 id 는 에러 안 나고 0 affected
+- `test_list_sessions_for_graph_rebuild_session_only` — session ID 단일 반환
+- `test_list_sessions_for_graph_rebuild_all_overrides_filters` — all=true 면 since/retry_failed 무시하고 모든 row
+- `test_list_sessions_for_graph_rebuild_retry_failed_only_null` — semantic_extracted_at IS NULL 인 세션만
+- `test_list_sessions_for_graph_rebuild_since_filters_by_date` — start_time >= since
+
+## Dependencies
+
+- 외부 crate: 없음
+- 내부 task: 없음
+
+## Verification
+
+```bash
+cargo check --all-targets
+cargo clippy --all-targets --all-features
+cargo fmt --all -- --check
+cargo test -p secall-core --lib store::db::tests::test_v8
+cargo test -p secall-core --lib store::db::tests::test_update_semantic_extracted_at
+cargo test -p secall-core --lib store::db::tests::test_list_sessions_for_graph_rebuild
+```
+
+## Risks
+
+- **기존 row 의 NULL 의미**: ingest 시점에 시맨틱 추출 성공한 세션도 마이그레이션 직후엔 NULL. 사용자가 `--retry-failed` 로 일괄 backfill 가능 — non-issue, 오히려 의도적 reset.
+- **마이그레이션 멱등성**: `column_exists` 체크 + ALTER TABLE 한 번만. P34 v7 패턴 검증됨.
+- **NULL ordering**: `ORDER BY start_time DESC` 사용 → start_time 자체는 NULL 아님 (기존 schema NOT NULL 제약 추정). 확인은 디벨로퍼.
+- **future schema 충돌**: 향후 v9 추가 시 기존 분기 그대로 유지하고 `if current < 9` 추가만 하면 됨. 본 task 의 `if current < 8` 분기는 호환.
+- **tests/rest_listing.rs 회귀**: P32~35 에서 SessionListItem 시그니처 변경마다 영향 받음. 본 task 는 SessionListItem 미변경 → 회귀 없음.
+
+## Scope boundary
+
+수정 금지:
+- `crates/secall-core/src/graph/`, `crates/secall-core/src/mcp/` — Task 01/02 영역과 무관
+- `crates/secall/src/commands/graph.rs` — Task 01 영역
+- `crates/secall/src/main.rs` — Task 01 영역 (graph 서브커맨드)
+- `crates/secall-core/src/jobs/` — Task 02 영역
+- `web/`, `README*`, `.github/` — Task 03/04 영역
+- `crates/secall-core/src/store/jobs_repo.rs`, `tag_normalize.rs` — 무관

--- a/docs/plans/p37-graph-sync-task-01.md
+++ b/docs/plans/p37-graph-sync-task-01.md
@@ -1,0 +1,149 @@
+---
+type: task
+status: draft
+updated_at: 2026-05-02
+plan_slug: p37-graph-sync
+task_id: 01
+parallel_group: B
+depends_on: [00]
+---
+
+# Task 01 — CLI `graph rebuild` 명령 + GraphRebuildArgs/Outcome + `run_with_progress`
+
+## Changed files
+
+수정:
+- `crates/secall/src/main.rs:347-359` 인접 — `GraphCommand` (또는 동등 enum) 에 `Rebuild { ... }` variant 추가. 기존 `Build` / `Stats` / `Export` 와 같은 깊이.
+- `crates/secall/src/commands/graph.rs` — 새 핸들러 추가:
+  - `GraphRebuildArgs` 구조체 (Task 00 의 `GraphRebuildFilter` 와 동등 + serde derive 로 REST DTO 호환)
+  - `GraphRebuildOutcome` 구조체 (`processed`, `succeeded`, `failed`, `skipped`, `edges_added`)
+  - `pub async fn run_rebuild(args, sink: &dyn ProgressSink) -> Result<GraphRebuildOutcome>`
+  - CLI wrapper `pub async fn run_rebuild_cli(args) -> Result<()>` — `NoopSink` wrapper, P36 `run_update` 패턴
+- `crates/secall/src/commands/ingest.rs:606-700` — 시맨틱 추출 핵심 루프 본문을 그대로 두되, `run_rebuild` 가 호출할 수 있도록 단일 세션 처리 함수 (`extract_one_session_semantic` 같은 이름) 로 추출. **시그니처만 분리**, 동작 변경 없음. ingest 측 호출처도 동일 helper 사용 → 중복 로직 제거 + 일관성.
+- `crates/secall-core/src/store/session_repo.rs` (Task 01 에서 추가된 helper 만 사용 — 본 task 는 무수정).
+
+신규: 없음 (기존 graph.rs 에 핸들러 추가)
+
+## Change description
+
+### 1. CLI 서브커맨드 정의 (main.rs)
+
+기존 `secall graph build/stats/export` 옆에 `Rebuild` variant 추가. clap 인자:
+- `--since YYYY-MM-DD` (`Option<String>`)
+- `--session ID` (`Option<String>`)
+- `--all` (bool flag)
+- `--retry-failed` (bool flag)
+
+핸들러는 `commands::graph::run_rebuild_cli(args).await?` 호출.
+
+### 2. `GraphRebuildArgs` / `GraphRebuildOutcome` 구조체 계약
+
+```rust
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
+pub struct GraphRebuildArgs {
+    pub since: Option<String>,
+    pub session: Option<String>,
+    pub all: bool,
+    pub retry_failed: bool,
+}
+
+#[derive(Debug, Default, serde::Serialize)]
+pub struct GraphRebuildOutcome {
+    pub processed: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub edges_added: usize,
+}
+```
+
+`Args` → `GraphRebuildFilter` 변환은 `From` impl 또는 Task 02 함수 내부에서 직접 인스턴스화. REST 측 (Task 02) 도 같은 구조체를 직렬화해서 사용.
+
+### 3. `run_rebuild(args, sink)` 흐름 (P33 + P36 패턴)
+
+1. `db.list_sessions_for_graph_rebuild(filter)` 로 처리 대상 ID 목록 획득
+2. 빈 목록이면 `sink.message("처리할 세션 없음")` + `Ok(default outcome)` 반환
+3. `let total = ids.len()`
+4. for (i, id) in ids.iter().enumerate():
+   - **안전 지점 (P36 패턴)**: `if sink.is_cancelled()` → `sink.message("취소 요청 — N/M 처리 후 종료")` + `Ok(partial outcome)` early return
+   - `sink.progress((i as f32) / (total as f32))`
+   - vault 에서 마크다운 읽기 (ingest.rs:660-690 의 로직 재사용)
+   - `extract_one_session_semantic(db, &config, &fm, &body)` 호출 (ingest.rs 에서 추출한 단일 세션 helper)
+   - 결과:
+     - `Ok(edges)` → `outcome.succeeded += 1; outcome.edges_added += edges; db.update_semantic_extracted_at(id, now)?`
+     - `Err(_)` → `outcome.failed += 1; semantic_extracted_at 갱신 안 함` (다음 retry-failed 대상이 됨)
+     - vault 파일 없음 / 파싱 실패 → `outcome.skipped += 1`
+   - `outcome.processed += 1`
+5. 마지막에 `sink.message("완료: succeeded=N, failed=M, edges=K")` + `Ok(outcome)`
+
+### 4. 단일 세션 추출 helper 분리 (ingest.rs)
+
+현재 `ingest::run_internal` (또는 동등) 안의 시맨틱 처리 루프 본문 (line 658-700 근처) 을 다음 시그니처로 추출:
+
+```rust
+async fn extract_one_session_semantic(
+    db: &Database,
+    config: &Config,
+    session_id: &str,
+) -> ExtractOneResult; // enum: Extracted(usize) | Skipped(reason) | Failed(anyhow::Error)
+```
+
+기존 ingest 측 루프는 이 helper 를 호출하도록 단순화. 동작 변경 없음 (회귀 테스트 그대로 통과).
+
+### 5. CLI wrapper (`run_rebuild_cli`)
+
+`NoopSink` 사용. P36 의 `run_update`(wiki) 패턴 그대로:
+
+```rust
+pub async fn run_rebuild_cli(args: GraphRebuildArgs) -> Result<()> {
+    let outcome = run_rebuild(args, &NoopSink).await?;
+    eprintln!(
+        "Graph rebuild complete: processed={}, succeeded={}, failed={}, skipped={}, edges_added={}",
+        outcome.processed, outcome.succeeded, outcome.failed, outcome.skipped, outcome.edges_added,
+    );
+    Ok(())
+}
+```
+
+### 6. 통합 테스트 (commands/graph.rs 또는 tests/)
+
+- `test_run_rebuild_retry_failed_only_processes_null_sessions` — 가짜 DB 에 3 세션 (2 NULL, 1 timestamp) → `retry_failed=true` 로 `run_rebuild` 호출 → outcome.processed == 2 검증
+- `test_run_rebuild_session_filter_processes_one` — single ID 지정 → outcome.processed == 1
+- 시맨틱 추출 자체는 외부 의존성 (LLM) 큼 → 테스트는 fake/mock 또는 `extract_and_store` 가 NoopBackend 일 때 0 edges 반환하는 분기 활용
+
+## Dependencies
+
+- 외부 crate: 없음
+- 내부 task: **Task 00 완료 필수** — `GraphRebuildFilter`, `update_semantic_extracted_at`, `list_sessions_for_graph_rebuild` API
+
+## Verification
+
+```bash
+cargo check --all-targets
+cargo clippy --all-targets --all-features
+cargo fmt --all -- --check
+cargo test -p secall --lib commands::graph::tests::test_run_rebuild
+cargo test --all  # 기존 ingest 회귀 (단일 세션 helper 추출 영향 검증)
+
+# 라이브 (선택, vault + DB + Ollama/Gemini 필요):
+# secall graph rebuild --retry-failed
+# → 처리 대상 출력 + progress + 완료 통계
+```
+
+## Risks
+
+- **ingest helper 추출 회귀**: 시맨틱 처리 루프를 `extract_one_session_semantic` 으로 추출하면 ingest 의 기존 동작이 바뀌지 않아야 함. 회귀 테스트 (P26 / 기존 ingest 테스트) 통과 확인.
+- **embedding 모델 unload (ingest.rs:614-632)**: 시맨틱 추출 전에 임베딩 모델 unload 하는 로직이 있음. 본 task 의 `run_rebuild` 도 동일 처리 필요 → helper 함수에 포함하거나 `run_rebuild` 진입 시점에 한 번 실행.
+- **partial cancel 시 succeeded/edges 보존**: cancel 분기에서 outcome 그대로 `Ok(...)` 반환 → P36 executor 가 partial_result 보존.
+- **빈 목록 처리**: 필터 결과 0 세션이면 정상 종료. 사용자에게 "처리할 세션 없음" 안내.
+- **DB lock contention**: 단일 세션마다 update_semantic_extracted_at — 짧은 트랜잭션. P33 단일 큐 정책으로 sync/ingest 와 동시 실행 안 됨 → 충돌 없음.
+- **vault 파일 누락 세션**: skipped 카운트로 처리, semantic_extracted_at 갱신 안 함 (다음 retry-failed 대상). 사용자 결정.
+
+## Scope boundary
+
+수정 금지:
+- `crates/secall-core/src/store/` — Task 00 영역 (단, helper 호출은 OK)
+- `crates/secall-core/src/jobs/`, `crates/secall-core/src/mcp/` — Task 02 영역
+- `crates/secall-core/src/graph/semantic/`, `crates/secall-core/src/graph/extract.rs` — 시맨틱 추출 로직 자체 (Non-goals)
+- `crates/secall/src/commands/{sync,wiki,mod}.rs` — 무관
+- `web/`, `README*`, `.github/` — Task 03/04 영역

--- a/docs/plans/p37-graph-sync-task-02.md
+++ b/docs/plans/p37-graph-sync-task-02.md
@@ -1,0 +1,107 @@
+---
+type: task
+status: draft
+updated_at: 2026-05-02
+plan_slug: p37-graph-sync
+task_id: 02
+parallel_group: B
+depends_on: [01]
+---
+
+# Task 02 — REST `/api/commands/graph-rebuild` + Job 어댑터 + P36 cancel 지원
+
+## Changed files
+
+수정:
+- `crates/secall-core/src/jobs/types.rs:9-15` — `JobKind` enum 에 `GraphRebuild` variant 추가, `as_str` / `from_str` 매핑에 `"graph_rebuild"` 추가.
+- `crates/secall-core/src/jobs/adapters/mod.rs:57-66` — `CommandAdapters` 구조체에 `graph_rebuild_fn: GraphRebuildAdapterFn` 필드 추가, 본문에 `pub use graph_rebuild_adapter::GraphRebuildAdapterFn;` + `pub type GraphRebuildArgsValue = serde_json::Value;` 추가.
+- `crates/secall-core/src/jobs/adapters/mod.rs` — module 선언에 `pub mod graph_rebuild_adapter;` 추가.
+- `crates/secall-core/src/mcp/rest.rs:150-152` — 라우터에 `.route("/api/commands/graph-rebuild", post(api_command_graph_rebuild))` 추가.
+- `crates/secall-core/src/mcp/rest.rs:461` 인접 — `JobKind::GraphRebuild => (adapters.graph_rebuild_fn)(args_value, sink)` 분기 추가.
+- `crates/secall-core/src/mcp/rest.rs:495-512` 인접 — `api_command_sync` / `api_command_ingest` 패턴 그대로 따라 `api_command_graph_rebuild` 핸들러 추가. body 는 `GraphRebuildArgs` (Task 01 정의) 직렬화 형태.
+- `crates/secall-core/src/mcp/rest.rs:184` (또는 endpoint list 로그) — `/api/commands/graph-rebuild` 추가 명시.
+- `crates/secall/src/commands/serve.rs` (또는 `main.rs` 의 with_adapters 호출처) — `CommandAdapters` 인스턴스화 시 `graph_rebuild_fn: Box::new(...)` 주입. 호출 본문은 `secall::commands::graph::run_rebuild(args, sink).await` 위임.
+
+신규:
+- `crates/secall-core/src/jobs/adapters/graph_rebuild_adapter.rs` — `IngestAdapterFn` / `WikiUpdateAdapterFn` 패턴 그대로:
+  - `pub type GraphRebuildAdapterFn = AdapterFn;`
+  - 모듈 doc 주석으로 호출 계약 + `crates/secall/src/commands/graph.rs` 가 실제 클로저를 만든다는 indirection 설명.
+
+## Change description
+
+### 1. `JobKind::GraphRebuild` 추가 (types.rs)
+
+기존 enum 에 variant 추가, snake_case 직렬화 → `"graph_rebuild"` (REST status, DB jobs.kind 컬럼 호환). `as_str` / `from_str` 매핑 동기화.
+
+### 2. `CommandAdapters` 확장 (adapters/mod.rs)
+
+```rust
+pub struct CommandAdapters {
+    pub sync_fn: SyncAdapterFn,
+    pub ingest_fn: IngestAdapterFn,
+    pub wiki_update_fn: WikiUpdateAdapterFn,
+    pub graph_rebuild_fn: GraphRebuildAdapterFn, // 신규
+}
+```
+
+신규 `graph_rebuild_adapter.rs` 는 P33 의 다른 어댑터와 같은 형태 (type alias + doc only, 실제 클로저는 secall 측에서 인스턴스화).
+
+### 3. REST 라우터 + 핸들러 (rest.rs)
+
+- 라우터에 `/api/commands/graph-rebuild` 추가
+- spawn 분기에 `JobKind::GraphRebuild` 매핑 추가
+- 핸들러 `api_command_graph_rebuild`: P33 의 `api_command_sync` 그대로 — `Json<GraphRebuildArgs>` 받아 `executor.try_spawn(JobKind::GraphRebuild, Some(args_json), |tx, token| ...)` 호출. 단일 큐 정책상 다른 mutating job 이 실행 중이면 409.
+
+### 4. 어댑터 클로저 주입 (serve.rs / main.rs)
+
+기존 sync/ingest/wiki 어댑터 클로저 옆에 graph_rebuild 클로저 추가. 본문은 args 를 `GraphRebuildArgs` 로 deserialize → `secall::commands::graph::run_rebuild(args, &BroadcastSink::new(tx, cancel_token)).await` → 결과를 `serde_json::to_value(outcome)` 로 직렬화 후 반환. P33 의 sync 어댑터 클로저 패턴 그대로.
+
+### 5. P36 cancel 통합
+
+별도 작업 없음 — Task 01 의 `run_rebuild` 가 sink 를 받아 `is_cancelled()` 폴링하고 partial outcome 반환. P36 `executor::try_spawn` 의 `was_cancelled` 게이팅이 status 강제 + partial_result 보존을 자동 처리.
+
+### 6. 통합 테스트 (tests/jobs_rest.rs 또는 신규 tests/graph_rebuild_rest.rs)
+
+기존 `tests/jobs_rest.rs` 의 sync/ingest 통합 테스트 패턴 따라 1건 추가:
+- `test_graph_rebuild_endpoint_starts_job` — REST POST → 200 + job_id 반환, GET /api/jobs/{id} 로 status 추적 가능 검증
+- (가능하다면) cancel 통합 테스트도 1건 — POST /api/jobs/{id}/cancel → status=interrupted
+
+## Dependencies
+
+- 외부 crate: 없음
+- 내부 task: **Task 01 완료 필수** — `secall::commands::graph::{run_rebuild, GraphRebuildArgs}` 가 어댑터 클로저에서 호출됨
+
+## Verification
+
+```bash
+cargo check --all-targets
+cargo clippy --all-targets --all-features
+cargo fmt --all -- --check
+cargo test -p secall-core --test jobs_rest test_graph_rebuild
+cargo test --all
+
+# 라이브 (서버 + vault 필요):
+# secall serve --bind 127.0.0.1:8080 &
+# curl -X POST http://127.0.0.1:8080/api/commands/graph-rebuild -d '{"retry_failed":true}'
+# → 200 { "job_id": "...", "status": "started" }
+# curl http://127.0.0.1:8080/api/jobs/<id>
+# curl -X POST http://127.0.0.1:8080/api/jobs/<id>/cancel  # P36 통합 검증
+```
+
+## Risks
+
+- **JobKind enum 추가의 호환성**: snake_case `"graph_rebuild"` 를 DB jobs.kind 에 저장. 기존 row 영향 없음 (enum 확장은 후방 호환). `JobKind::from_str` 미매칭 케이스 처리 확인.
+- **단일 큐 정책 (P33)**: graph_rebuild 가 실행 중이면 sync/ingest/wiki 도 차단. 사용자가 의도. 문서 (Task 05 README) 에 명시.
+- **adapter indirection**: secall-core 가 secall 을 reverse 의존하지 않도록 `Box<dyn Fn>` 패턴 유지. 신규 graph_rebuild_adapter.rs 는 type alias + doc only.
+- **REST 응답 시점**: `try_spawn` 즉시 반환 (job 등록만), 실제 실행은 background. 클라이언트는 SSE 또는 polling 으로 추적 — 기존 패턴 그대로.
+- **cancel 시 partial_outcome 직렬화**: `GraphRebuildOutcome` 가 serde::Serialize derive 되어 있어야 P36 executor 의 `result_json.clone()` 보존 경로가 동작.
+
+## Scope boundary
+
+수정 금지:
+- `crates/secall-core/src/store/`, `crates/secall-core/src/graph/` — Task 00 / 무관
+- `crates/secall/src/commands/{graph,ingest,sync,wiki,mod}.rs` 의 본문 — Task 01 영역. 단 `serve.rs` (또는 main.rs) 의 with_adapters 주입 한 줄 추가는 본 task.
+- `web/` — Task 03 영역
+- `README*`, `.github/` — Task 04 영역
+- `crates/secall-core/src/jobs/{registry,executor,mod}.rs` — P33/P36 완료 코드, 본 task 는 추가 없음
+- 기존 `ProgressEvent` variant — 추가/수정 없음

--- a/docs/plans/p37-graph-sync-task-03.md
+++ b/docs/plans/p37-graph-sync-task-03.md
@@ -1,0 +1,134 @@
+---
+type: task
+status: draft
+updated_at: 2026-05-02
+plan_slug: p37-graph-sync
+task_id: 03
+parallel_group: C
+depends_on: [02]
+---
+
+# Task 03 — web UI: CommandsRoute 카드 + JobOptionsDialog 옵션 + types/api
+
+## Changed files
+
+수정:
+- `web/src/lib/types.ts:76` — `JobKind` 유니온에 `"graph_rebuild"` 추가, `GraphRebuildArgs` / `GraphRebuildOutcome` 타입 추가 (Task 01 의 Rust 구조체와 1:1 매핑).
+- `web/src/lib/api.ts:122-138` 인접 — `startGraphRebuild(args)` 메서드 추가 (P33 의 `startSync` / `startIngest` 패턴 그대로). `POST /api/commands/graph-rebuild`.
+- `web/src/hooks/useJob.ts:65-91` 인접 — `useStartJob` 의 switch 분기에 `case "graph_rebuild": return api.startGraphRebuild(args as GraphRebuildArgs);` 추가.
+- `web/src/components/CommandButton.tsx` — sync/ingest/wiki 카드 옆에 "graph rebuild" 카드 추가 (라벨/설명/버튼). 클릭 시 `JobOptionsDialog` 를 `kind="graph_rebuild"` 로 open.
+- `web/src/components/JobItem.tsx` — `JobKind` union 확장으로 인한 exhaustive switch 컴파일 강제 — `renderOutcome` 에 `GraphRebuildOutcome` 분기 추가 (processed/succeeded/failed/skipped/edges_added 표시). 본 task 의 핵심 변경은 아니지만 typecheck 통과 위해 필수.
+- `web/src/routes/CommandsRoute.tsx` — 카드 그리드에 4번째 graph_rebuild 카드 노출 위해 `sm:grid-cols-3` → `sm:grid-cols-2` 변경 (2x2 layout).
+- `web/src/components/JobOptionsDialog.tsx:88-220` 인접 — sync/ingest/wiki 폼 옆에 `GraphRebuildOptionsForm` 추가:
+  - 입력 필드: `since` (date input), `session` (text), `all` (checkbox), `retry_failed` (checkbox)
+  - submit 시 `useStartJob("graph_rebuild")` 의 mutate 호출
+  - cancel 버튼은 기존 onCancel prop 사용
+- `web/src/routes/CommandsRoute.tsx` (필요 시) — 카드 그리드에 graph rebuild 카드가 자동 노출되는지 확인. CommandButton 이 이미 모든 kind 를 매핑하면 변경 없음.
+
+신규: 없음
+
+## Change description
+
+### 1. types.ts 추가 사항
+
+```ts
+// 기존 JobKind:
+export type JobKind = "sync" | "ingest" | "wiki_update" | "graph_rebuild";
+
+// P37 신규
+export interface GraphRebuildArgs {
+  since?: string;
+  session?: string;
+  all?: boolean;
+  retry_failed?: boolean;
+}
+
+export interface GraphRebuildOutcome {
+  processed: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+  edges_added: number;
+}
+```
+
+### 2. api.ts 메서드
+
+P33 의 `startSync` / `startIngest` 그대로 모방:
+- 시그니처: `startGraphRebuild: (args: GraphRebuildArgs) => Promise<JobStartResponse>`
+- 본문: `jfetch<JobStartResponse>("/api/commands/graph-rebuild", { method: "POST", body: JSON.stringify(args) })`
+
+### 3. useJob.ts switch 확장
+
+기존 switch (line 69-76) 에 한 case 추가:
+```ts
+case "graph_rebuild":
+  return api.startGraphRebuild(args as GraphRebuildArgs);
+```
+
+`JobArgs` 타입 union 에 `GraphRebuildArgs` 도 포함되도록 확장 (필요 시 union type 정의 수정).
+
+### 4. CommandButton.tsx 카드 추가
+
+기존 sync/ingest/wiki 카드 정의를 보고 같은 패턴으로 graph_rebuild 카드 추가:
+- 제목: "Graph Rebuild"
+- 설명: "이미 ingest 된 세션의 시맨틱 그래프 재구축. since/session/all/retry-failed 옵션 지원."
+- onClick → setSelectedKind("graph_rebuild")
+
+### 5. JobOptionsDialog.tsx 폼 추가
+
+기존 SyncOptionsForm / IngestOptionsForm / WikiOptionsForm 패턴 따라:
+```tsx
+function GraphRebuildOptionsForm({ onSubmit, onCancel }: { onSubmit: (args: GraphRebuildArgs) => void; onCancel: () => void }) {
+  const [since, setSince] = useState("");
+  const [session, setSession] = useState("");
+  const [all, setAll] = useState(false);
+  const [retryFailed, setRetryFailed] = useState(false);
+  // ...form fields...
+}
+```
+
+dialog 의 kind switch 에 분기 추가:
+```tsx
+case "graph_rebuild":
+  return <GraphRebuildOptionsForm onSubmit={...} onCancel={...} />;
+```
+
+### 6. UX 우선순위 안내
+
+폼 안에 짧은 안내 문구 — "session > all > retry-failed > since 우선순위" — 사용자가 동시에 여러 필드 입력 시 어떤 게 적용되는지 명시 (Task 01 의 SQL 우선순위 그대로).
+
+## Dependencies
+
+- 외부 npm: 없음
+- 내부 task: **Task 02 완료 필수** — `/api/commands/graph-rebuild` 엔드포인트가 있어야 mutation 동작. 미완료 시 404 → onError graceful (사용자에게 표시는 콘솔).
+
+## Verification
+
+```bash
+pnpm --dir /Users/d9ng/privateProject/seCall/web typecheck
+pnpm --dir /Users/d9ng/privateProject/seCall/web build
+
+# 라이브 (서버 + Task 00-02 완료 필요):
+# secall serve & 후 /commands → "Graph Rebuild" 카드 클릭
+# → 옵션 다이얼로그에서 retry_failed 체크 후 시작
+# → JobBanner 진행률 + cancel 버튼 (P36) 동작 확인
+```
+
+## Risks
+
+- **JobKind union 확장의 타입 영향**: 기존 switch / Map 호출에 모두 분기 추가 필요. tsc 가 미분기 케이스 잡아줌 — typecheck 통과 = 모든 분기 처리.
+- **JobArgs union**: useStartJob mutationFn 시그니처가 union 받음 → as 캐스팅 필요. P33 의 기존 패턴 그대로.
+- **카드 그리드 layout**: 4번째 카드 추가 시 grid 가 반응형으로 재배치. CSS 검증 시각적으로 확인.
+- **다이얼로그 폼 검증**: since 가 잘못된 date 형식이면 백엔드가 빈 결과 반환 (Task 01 SQL). 클라이언트 측 validation 은 본 task 외 — placeholder + format hint 정도.
+- **session ID 길이**: text input 에 8자 단축 ID 입력 가능 — Task 01 의 `resolve_session_id` 가 prefix 매칭 처리하면 OK. 그렇지 않으면 full ID 강제 안내.
+
+## Scope boundary
+
+수정 금지:
+- `crates/` 전체 — Task 00-02 영역
+- `web/src/components/{JobBanner,JobToastListener}.tsx` — P33/P36 완료, 본 task 와 무관 (graph_rebuild 도 동일 인터페이스로 자동 노출). `JobItem.tsx` 는 exhaustive switch 강제로 본 task 가 분기 추가 (위 Changed files 참조).
+- `web/src/hooks/{useJobLifecycle,useJobStream,useCancelJob}.ts` — 변경 없음
+- `web/src/routes/{Sessions,Daily,Wiki,SessionDetail}Route.tsx` — 무관
+- `web/src/lib/{store,allTags,tagColor,utils,queryClient,graphStartNode,highlight,graphStyle}.ts` — 무관
+- `README*`, `.github/` — Task 04 영역

--- a/docs/plans/p37-graph-sync-task-04.md
+++ b/docs/plans/p37-graph-sync-task-04.md
@@ -1,0 +1,109 @@
+---
+type: task
+status: draft
+updated_at: 2026-05-02
+plan_slug: p37-graph-sync
+task_id: 04
+parallel_group: D
+depends_on: [00, 01, 02, 03]
+---
+
+# Task 04 — README + CI 업데이트
+
+## Changed files
+
+수정:
+- `README.md` — P36 다음에 P37 항목 추가, `secall graph rebuild` CLI 명령 + `POST /api/commands/graph-rebuild` 엔드포인트 추가, v0.8.0 changelog 행.
+- `README.en.md` — 동일 영문판.
+- `.github/workflows/ci.yml` — 변경 없음 (기존 cargo test job 이 Task 00/01/02 신규 통합 테스트 자동 실행).
+
+신규: 없음
+
+## Change description
+
+### README — P37 섹션 추가
+
+기존 P36 다음에 다음 정보 반영 (한/영 동일):
+- 시맨틱 그래프 sync 자동화 — 이미 ingest 된 세션의 그래프 재구축 가능
+- DB 스키마 v8: `sessions.semantic_extracted_at` 컬럼 — 처리 상태 추적
+- CLI: `secall graph rebuild [--since DATE] [--session ID] [--all] [--retry-failed]`
+- REST: `POST /api/commands/graph-rebuild` (Job 시스템 통합, P36 cancel 지원)
+- web UI: Commands 페이지에 "Graph Rebuild" 카드 + 옵션 다이얼로그
+
+### CLI 사용 예 (README)
+
+```
+# 미처리(NULL) 세션 일괄 backfill
+secall graph rebuild --retry-failed
+
+# 특정 날짜 이후 세션
+secall graph rebuild --since 2026-04-01
+
+# 단일 세션
+secall graph rebuild --session abc12345
+
+# 전체 재구축 (기존 결과도 덮어쓰기)
+secall graph rebuild --all
+```
+
+우선순위: `--session` > `--all` > `--retry-failed` > `--since`. 같이 지정하면 위 순서로 적용.
+
+### 엔드포인트 목록 갱신
+
+```
+- 그래프 재구축 (P37): POST /api/commands/graph-rebuild
+  - body: { since?, session?, all?, retry_failed? }
+  - 응답: { job_id, status: "started" }
+  - 단일 큐 정책: 다른 mutating job 실행 중이면 409
+```
+
+### Changelog 행
+
+상단에 추가:
+```
+| 2026-XX-XX | v0.8.0 | P37 시맨틱 Graph Sync 자동화: DB v8 (semantic_extracted_at), `secall graph rebuild` CLI, `POST /api/commands/graph-rebuild` REST, web UI 카드, P33 Job + P36 cancel 통합 |
+```
+
+날짜는 머지 시점으로 갱신. Cargo.toml 버전 bump 는 별도 release tagging.
+
+### CI 변경 없음
+
+- Task 00: `cargo test --lib store::db::tests::test_v8` 등이 기본 cargo test 로 자동 실행
+- Task 01: `cargo test commands::graph::tests` 도 자동 실행
+- Task 02: `cargo test --test jobs_rest test_graph_rebuild` 도 자동 실행
+- Task 03: `pnpm typecheck` + `pnpm build` 가 web-build job 으로 자동 실행
+
+workflow 파일 변경 없음.
+
+## Dependencies
+
+- 외부: 없음
+- 내부 task: Task 00 (DB), Task 01 (CLI), Task 02 (REST), Task 03 (web UI) 모두 완료 후 정확한 동작 반영 가능
+
+## Verification
+
+```bash
+grep -qE "P37|Graph Sync|graph-rebuild|graph rebuild" /Users/d9ng/privateProject/seCall/README.md && echo "ko P37 OK"
+grep -qE "P37|Graph Sync|graph-rebuild|graph rebuild" /Users/d9ng/privateProject/seCall/README.en.md && echo "en P37 OK"
+grep -q "/api/commands/graph-rebuild" /Users/d9ng/privateProject/seCall/README.md && echo "endpoint listed"
+grep -q "/api/commands/graph-rebuild" /Users/d9ng/privateProject/seCall/README.en.md && echo "endpoint listed (en)"
+grep -qE "semantic_extracted_at|시맨틱.*상태" /Users/d9ng/privateProject/seCall/README.md && echo "state tracking mentioned"
+git diff --stat .github/workflows/ | head -3
+```
+
+`cargo test --all` 회귀는 Task 00/01/02 에서 이미 실행됨 → 본 task 는 docs only 라 skip.
+
+## Risks
+
+- **README 일관성**: 사용자가 보는 동작과 README 설명이 어긋나면 신뢰 저하. Task 00~03 검증 통과 후 본 task 진행.
+- **버전 bump**: Cargo.toml 변경 없음 (release tagging 별도).
+- **changelog 날짜 placeholder**: `2026-XX-XX` → 머지 시점에 정확한 날짜로 갱신.
+- **우선순위 명시**: 사용자가 `--all` 과 `--retry-failed` 를 동시 지정 가능 → 우선순위 안내가 README 에 명시되어야 혼란 방지.
+- **embedding 모델 unload 자동화 안내**: ingest.rs:614-632 의 unload 로직이 `run_rebuild` 에도 반영됐다는 점은 사용자에게 보일 필요 없음 (내부 동작) — README 에 굳이 안내 안 함.
+
+## Scope boundary
+
+수정 금지:
+- `crates/`, `web/src/` 코드 — Task 00~03 완료 후 본 task 는 문서만
+- DB 스키마 — 변경 없음 (Task 00 영역)
+- `.github/workflows/*` — 변경 없음

--- a/docs/plans/p37-graph-sync.md
+++ b/docs/plans/p37-graph-sync.md
@@ -1,0 +1,74 @@
+---
+type: plan
+status: draft
+updated_at: 2026-05-02
+slug: p37-graph-sync
+version: 1
+---
+
+# P37 — 시맨틱 Graph Sync 자동화
+
+## Description
+
+P26 (Gemini API 백엔드) 으로 시맨틱 엣지 추출 자체는 가능해졌지만, 현재 시맨틱 그래프 추출은 **`ingest::run` 안에 인라인** 으로 새 세션에 대해서만 처리됨 (`crates/secall/src/commands/ingest.rs:605-700`). 이미 ingest 된 세션의 시맨틱 그래프를 나중에 재계산할 수단이 없고, 모델/프롬프트 변경 시 전체 재구축 / 부분 재시도 수단도 부재. 처리 상태(완료/실패/미처리) 가시성도 없다.
+
+본 phase 는 시맨틱 그래프 sync 를 **독립 명령** 으로 분리하여 (1) 처리 상태 추적, (2) CLI / REST 양쪽 트리거, (3) Job 시스템 (P33) 통합으로 진행률 + 취소 (P36) 지원, (4) web UI 에서 실행 가능하게 만든다.
+
+## 현재 한계
+
+- `crates/secall/src/commands/ingest.rs:605-700` — 새 세션만, ingest 시점에만 처리.
+- `crates/secall-core/src/store/schema.rs:1` — `CURRENT_SCHEMA_VERSION = 7`, sessions 테이블에 시맨틱 처리 상태 컬럼 없음.
+- `crates/secall/src/main.rs:347-359` — `secall graph` 서브커맨드는 build/stats/export 만, rebuild/sync 없음.
+- `crates/secall-core/src/mcp/rest.rs:150-152` — REST commands 는 sync/ingest/wiki-update 3개만.
+- web UI: `web/src/components/CommandButton.tsx` 카드 3개 (sync/ingest/wiki) — graph 트리거 부재.
+- 실패 세션 자동 재시도 로직 부재 → 모델 일시 장애 시 사람이 직접 reingest.
+
+## Expected Outcome
+
+- DB 스키마 v8: `sessions.semantic_extracted_at: Option<i64>` (NULL = 미처리, Unix epoch = 마지막 성공 시각). 마이그레이션은 NULL 초기화 → 기존 동작 유지.
+- CLI: `secall graph rebuild [--since DATE] [--session ID] [--all] [--retry-failed]`.
+- REST: `POST /api/commands/graph-rebuild` (P33 Job 시스템 패턴 + P36 cancel 지원).
+- web UI: CommandsRoute 에 "graph rebuild" 카드 + JobOptionsDialog 옵션 (since / session / all / retry-failed).
+- 진행률: 세션 단위 progress (`sink.progress(i / total)`). 안전 지점 cancel 폴링.
+- Outcome: `GraphRebuildOutcome { processed, succeeded, failed, skipped, edges_added }` 통계 노출.
+
+## Subtasks
+
+| # | Title | Parallel group | Depends on |
+|---|---|---|---|
+| 00 | DB 스키마 v8 + state tracking (`semantic_extracted_at`) | A | — |
+| 01 | CLI `graph rebuild` 명령 + GraphRebuildArgs/Outcome + `run_with_progress` | B | 00 |
+| 02 | REST `/api/commands/graph-rebuild` + Job 어댑터 + P36 cancel 지원 | B | 01 |
+| 03 | web UI — CommandsRoute 카드 + JobOptionsDialog 옵션 + types/api | C | 02 |
+| 04 | README + CI 업데이트 | D | 00, 01, 02, 03 |
+
+병렬 실행 전략:
+- Phase A — Task 00 (DB 단독)
+- Phase B — Task 01 → Task 02 순차 (02 가 01 의 `run_with_progress` 시그니처 의존)
+- Phase C — Task 03 (web)
+- Phase D — Task 04 (README)
+
+## Constraints
+
+- **수정 금지**: P32~36 완료 코드 동작 변경. 본 phase 는 추가만.
+- **기존 ingest 동작 유지**: ingest 시점 시맨틱 추출은 그대로. `semantic_extracted_at` 도 ingest 성공 시 set.
+- **단일 큐 정책 (P33)**: graph rebuild 도 sync/ingest/wiki 와 동일 큐 — 동시 실행 1개만.
+- **P36 cancel**: graph rebuild 도 안전 지점 (세션 루프 시작 + LLM 호출 직전) 에서 폴링.
+- **DB 트랜잭션 도중 cancel 금지**: 단일 세션 처리 (extract + insert) 는 원자 단위.
+- **partial_outcome 보존**: cancel 시 `Ok(partial_outcome)` 반환.
+
+## Non-goals
+
+- 시맨틱 추출 로직 자체 변경 (`crates/secall-core/src/graph/semantic/`) — 본 phase 는 sync 자동화만.
+- 시맨틱 모델 결과 비교/diff: 별도 phase.
+- 배경 자동 재실행 (cron / interval): 사용자가 명령 트리거. 자동 스케줄러는 별도 phase.
+- 부분 실패 자동 재시도 횟수 제한 / exponential backoff: 본 phase 는 `--retry-failed` 명시 트리거 시 한 번 더 시도.
+- 세션 그룹별 다른 모델 사용: 단일 모델만.
+
+## Success criteria
+
+- `secall graph rebuild --since 2026-04-01` 실행 시 해당 기간 새 세션 + 미처리 세션 처리.
+- `POST /api/commands/graph-rebuild` 트리거 → JobState 진행률 → 완료 시 `GraphRebuildOutcome` 반환.
+- web UI Commands 페이지에서 "graph rebuild" 클릭 → 옵션 입력 → JobBanner 진행률 + 취소 버튼.
+- DB v8 마이그레이션이 v7 DB 에서 멱등하게 적용되고 기존 데이터 손실 없음.
+- 통합 테스트 1건 (Task 02): `--retry-failed` 가 `semantic_extracted_at IS NULL` 인 세션만 재처리하는지 검증.

--- a/web/src/components/CommandButton.tsx
+++ b/web/src/components/CommandButton.tsx
@@ -3,6 +3,7 @@ import { Loader2, Play } from "lucide-react";
 import { useStartJob } from "@/hooks/useJob";
 import { JobOptionsDialog } from "./JobOptionsDialog";
 import type {
+  GraphRebuildArgs,
   IngestArgs,
   JobKind,
   SyncArgs,
@@ -19,7 +20,9 @@ export function CommandButton({ kind, label, description }: Props) {
   const [open, setOpen] = useState(false);
   const mutation = useStartJob(kind);
 
-  const handleSubmit = (args: SyncArgs | IngestArgs | WikiUpdateArgs) => {
+  const handleSubmit = (
+    args: SyncArgs | IngestArgs | WikiUpdateArgs | GraphRebuildArgs,
+  ) => {
     mutation.mutate(args);
     setOpen(false);
   };

--- a/web/src/components/JobItem.tsx
+++ b/web/src/components/JobItem.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { useCancelJob } from "@/hooks/useJob";
 import { useJobStream } from "@/hooks/useJobStream";
 import type {
+  GraphRebuildOutcome,
   IngestOutcome,
   JobState,
   JobStatus,
@@ -264,6 +265,17 @@ function renderOutcome(job: JobState): string | null {
     case "wiki_update": {
       const r = job.result as WikiOutcome;
       return `${r.backend} → ${r.target} · ${r.pages_written} pages`;
+    }
+    case "graph_rebuild": {
+      const r = job.result as GraphRebuildOutcome;
+      const parts = [
+        `processed=${r.processed}`,
+        `succeeded=${r.succeeded}`,
+      ];
+      if (r.failed) parts.push(`failed=${r.failed}`);
+      if (r.skipped) parts.push(`skipped=${r.skipped}`);
+      if (r.edges_added) parts.push(`+${r.edges_added}e`);
+      return parts.join(" · ");
     }
   }
 }

--- a/web/src/components/JobOptionsDialog.tsx
+++ b/web/src/components/JobOptionsDialog.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type {
+  GraphRebuildArgs,
   IngestArgs,
   JobKind,
   SyncArgs,
@@ -64,9 +65,17 @@ const wikiSchema = z.object({
   review_model: z.string().optional(),
 });
 
+const graphRebuildSchema = z.object({
+  since: z.string().optional(),
+  session: z.string().optional(),
+  all: z.boolean().optional(),
+  retry_failed: z.boolean().optional(),
+});
+
 type SyncFormValues = z.input<typeof syncSchema>;
 type IngestFormValues = z.input<typeof ingestSchema>;
 type WikiFormValues = z.input<typeof wikiSchema>;
+type GraphRebuildFormValues = z.input<typeof graphRebuildSchema>;
 
 // 빈 문자열 필드를 제거하여 백엔드 Option<String>이 None이 되도록 한다.
 function stripEmpty<T extends Record<string, unknown>>(obj: T): T {
@@ -82,7 +91,9 @@ interface Props {
   kind: JobKind;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSubmit: (args: SyncArgs | IngestArgs | WikiUpdateArgs) => void;
+  onSubmit: (
+    args: SyncArgs | IngestArgs | WikiUpdateArgs | GraphRebuildArgs,
+  ) => void;
 }
 
 export function JobOptionsDialog({ kind, open, onOpenChange, onSubmit }: Props) {
@@ -111,6 +122,12 @@ export function JobOptionsDialog({ kind, open, onOpenChange, onSubmit }: Props) 
             onSubmit={(v) => onSubmit(stripEmpty(v) as WikiUpdateArgs)}
           />
         )}
+        {kind === "graph_rebuild" && (
+          <GraphRebuildForm
+            onCancel={() => onOpenChange(false)}
+            onSubmit={(v) => onSubmit(stripEmpty(v) as GraphRebuildArgs)}
+          />
+        )}
       </DialogContent>
     </Dialog>
   );
@@ -124,6 +141,8 @@ function labelOf(kind: JobKind): string {
       return "Ingest";
     case "wiki_update":
       return "Wiki Update";
+    case "graph_rebuild":
+      return "Graph Rebuild";
   }
 }
 
@@ -135,6 +154,8 @@ function descOf(kind: JobKind): string {
       return "새 세션 파싱 + 인덱스";
     case "wiki_update":
       return "LLM 백엔드로 위키 페이지 갱신";
+    case "graph_rebuild":
+      return "이미 ingest 된 세션의 시맨틱 그래프 재구축";
   }
 }
 
@@ -287,6 +308,65 @@ function WikiForm({
         <label className="text-sm font-medium">review_model</label>
         <Input placeholder="(빈 값이면 기본값)" {...register("review_model")} />
       </div>
+      <DialogFooter>
+        <Button type="button" variant="ghost" onClick={onCancel}>취소</Button>
+        <Button type="submit">시작</Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+// ----------------------------------------------------------------------------
+// GraphRebuildForm
+// ----------------------------------------------------------------------------
+
+function GraphRebuildForm({
+  onSubmit,
+  onCancel,
+}: {
+  onSubmit: SubmitHandler<GraphRebuildFormValues>;
+  onCancel: () => void;
+}) {
+  const { register, handleSubmit, reset } = useForm<GraphRebuildFormValues>({
+    resolver: zodResolver(graphRebuildSchema),
+    defaultValues: {
+      since: "",
+      session: "",
+      all: false,
+      retry_failed: false,
+    },
+  });
+  useEffect(() => () => reset(), [reset]);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+      <p className="text-xs text-muted-foreground border border-border rounded px-2 py-1.5">
+        우선순위: <span className="font-mono">session</span> &gt;{" "}
+        <span className="font-mono">all</span> &gt;{" "}
+        <span className="font-mono">retry_failed</span> &gt;{" "}
+        <span className="font-mono">since</span> (Task 00 SQL 기준)
+      </p>
+      <div className="space-y-1">
+        <label className="text-sm font-medium">since</label>
+        <Input type="date" {...register("since")} />
+        <p className="text-xs text-muted-foreground">이 날짜 이후 세션만 대상</p>
+      </div>
+      <div className="space-y-1">
+        <label className="text-sm font-medium">session</label>
+        <Input
+          placeholder="full session_id (UUID)"
+          {...register("session")}
+        />
+        <p className="text-xs text-muted-foreground">
+          전체 session_id 정확히 입력 (backend 는 exact match — prefix 미지원)
+        </p>
+      </div>
+      <CheckboxRow label="all" register={register("all")} hint="모든 ingest된 세션 대상" />
+      <CheckboxRow
+        label="retry_failed"
+        register={register("retry_failed")}
+        hint="이전 실패/skip 세션만 재시도"
+      />
       <DialogFooter>
         <Button type="button" variant="ghost" onClick={onCancel}>취소</Button>
         <Button type="submit">시작</Button>

--- a/web/src/hooks/useJob.ts
+++ b/web/src/hooks/useJob.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import type {
+  GraphRebuildArgs,
   IngestArgs,
   JobKind,
   JobState,
@@ -54,7 +55,7 @@ export function useJob(id: string | undefined) {
   });
 }
 
-type JobArgs = SyncArgs | IngestArgs | WikiUpdateArgs;
+type JobArgs = SyncArgs | IngestArgs | WikiUpdateArgs | GraphRebuildArgs;
 
 /**
  * Job 시작 mutation. kind에 따라 적절한 시작 엔드포인트로 분기.
@@ -73,6 +74,8 @@ export function useStartJob(kind: JobKind) {
           return api.startIngest(args as IngestArgs);
         case "wiki_update":
           return api.startWikiUpdate(args as WikiUpdateArgs);
+        case "graph_rebuild":
+          return api.startGraphRebuild(args as GraphRebuildArgs);
       }
     },
     onSuccess: (data) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type {
+  GraphRebuildArgs,
   IngestArgs,
   JobStartResponse,
   JobState,
@@ -133,6 +134,12 @@ export const api = {
 
   startWikiUpdate: (args: WikiUpdateArgs) =>
     jfetch<JobStartResponse>("/api/commands/wiki-update", {
+      method: "POST",
+      body: JSON.stringify(args),
+    }),
+
+  startGraphRebuild: (args: GraphRebuildArgs) =>
+    jfetch<JobStartResponse>("/api/commands/graph-rebuild", {
       method: "POST",
       body: JSON.stringify(args),
     }),

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -117,7 +117,7 @@ export interface RecallResponse {
 // Job system (P33 — Web Phase 1)
 // ============================================================================
 
-export type JobKind = "sync" | "ingest" | "wiki_update";
+export type JobKind = "sync" | "ingest" | "wiki_update" | "graph_rebuild";
 export type JobStatus =
   | "started"
   | "running"
@@ -192,6 +192,17 @@ export interface WikiUpdateArgs {
   review_model?: string;
 }
 
+/**
+ * P37 Task 01 — `secall::commands::graph::GraphRebuildArgs` 와 1:1 매핑.
+ * 우선순위 (Task 00 SQL 기준): session > all > retry_failed > since.
+ */
+export interface GraphRebuildArgs {
+  since?: string;
+  session?: string;
+  all?: boolean;
+  retry_failed?: boolean;
+}
+
 // Outcome 구조 (job 완료 시 result 필드).
 // 백엔드는 단계별 skip 시 null을 반환할 수 있으므로 nullable 허용.
 export interface SyncOutcome {
@@ -220,6 +231,18 @@ export interface WikiOutcome {
   backend: string;
   target: string;
   pages_written: number;
+}
+
+/**
+ * P37 Task 01 — `secall::commands::graph::GraphRebuildOutcome` 와 1:1 매핑.
+ * 모든 카운터는 정수, 단계 skip 없이 항상 채워진다.
+ */
+export interface GraphRebuildOutcome {
+  processed: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+  edges_added: number;
 }
 
 export interface SessionFilterState {

--- a/web/src/routes/CommandsRoute.tsx
+++ b/web/src/routes/CommandsRoute.tsx
@@ -27,7 +27,7 @@ export default function CommandsRoute() {
 
       <Card className="p-4 space-y-3">
         <h2 className="text-lg font-medium">새 작업</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <CommandButton
             kind="sync"
             label="Sync"
@@ -42,6 +42,11 @@ export default function CommandsRoute() {
             kind="wiki_update"
             label="Wiki Update"
             description="LLM으로 위키 갱신"
+          />
+          <CommandButton
+            kind="graph_rebuild"
+            label="Graph Rebuild"
+            description="이미 ingest 된 세션의 시맨틱 그래프 재구축 (since/session/all/retry-failed 옵션)"
           />
         </div>
       </Card>


### PR DESCRIPTION
## Summary

P26 이후 시맨틱 그래프 추출은 ingest 시점 새 세션만 처리됐고, 이미 ingest 된 세션 재계산 / 모델 변경 시 전체 재구축 / 처리 상태 가시성이 부재했음. 본 phase 는 시맨틱 그래프 sync 를 독립 동작으로 분리.

- **DB v8** — `sessions.semantic_extracted_at` 컬럼 + 처리 상태 추적
- **CLI** — \`secall graph rebuild [--since DATE] [--session ID] [--all] [--retry-failed]\`
- **REST** — \`POST /api/commands/graph-rebuild\` (Job 시스템 통합 + P36 cancel)
- **web UI** — Commands 페이지 4번째 카드 + 옵션 다이얼로그 + JobBanner 진행률/취소

## Highlights

### 필터 우선순위 (한 곳에 일관)
\`session > all > retry_failed > since\` — DB SQL / CLI / web UI form / README 모두 동일.

### 안전한 partial outcome 보존
1. CLI \`run_rebuild\` 가 cancel 폴링 시 \`Ok(partial outcome)\` 반환
2. P36 executor 가 \`was_cancelled\` 게이팅으로 status=Interrupted 강제
3. SSE 구독자는 \`Failed { error: \"cancelled by user\", partial_result }\` 수신
4. 사용자는 \`processed/succeeded/failed/skipped/edges_added\` 카운트 확인 가능

### 상태 추적의 자가 치유성
- 추출 성공 → \`semantic_extracted_at\` 갱신 (ingest + rebuild 양쪽 동일)
- 추출 실패 → 갱신 안 함 → 다음 \`--retry-failed\` 가 다시 처리
- 갱신 자체 실패도 자가 치유 (warn 로그 + 다음 retry 가 잡음)

### 코드 공유 — ingest helper 추출
\`extract_one_session_semantic\` + \`unload_embedding_model_if_needed\` 를 ingest.rs 에서 helper 로 분리 → ingest sub-loop + graph rebuild 양쪽 공유. 동작 변경 없음 (374 tests passed).

## Reviewer 사이클

- **review-r1**: PASS — code 결함 없음, 6 recommendations
- **review-r2**: rework 2건 처리
  - ingest 경로에서 \`semantic_extracted_at\` 미갱신 → graph rebuild 와 일관하게 갱신 추가
  - UI session 입력 안내 prefix 표기 → backend exact match 와 일관 (full UUID)

## Test plan

- [x] \`cargo test --all\` — 374 passed (신규: db 8 + graph filter 2 + jobs_rest 2)
- [x] \`cargo clippy --all-targets --all-features\` — 0 신규 warnings
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`pnpm typecheck\` / \`pnpm build\` — exit 0
- [ ] **수동 확인**: \`secall graph rebuild --retry-failed\` → 새 ingest 세션도 NULL 잔존 안 함 확인
- [ ] **수동 확인**: \`secall serve\` → \`/commands\` "Graph Rebuild" 카드 → 옵션 다이얼로그 → JobBanner 진행률 + 취소 버튼

## Known follow-ups (별도 phase)

- axum route-level 통합 테스트 (현재 jobs_rest 는 executor 직접 호출 수준)
- ENV_LOCK MutexGuard across await clippy 경고 정리 (\`tokio::sync::Mutex\`)
- session ID prefix 매칭 backend 지원 (현재 exact match 만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)