### PR TITLE
fix(vault): push() git add -A + 회귀 테스트 (P39 review follow-up)

### DIFF
--- a/crates/secall-core/src/vault/git.rs
+++ b/crates/secall-core/src/vault/git.rs
@@ -163,9 +163,9 @@ impl<'a> VaultGit<'a> {
 
         let committed = changes.lines().count();
 
-        // raw/, wiki/ 외에 vault 루트 메타데이터(index.md, log.md)도 함께 stage.
-        // vault.write_session()은 index.md와 log.md를 갱신하므로 누락 시 원격 상태 불일치.
-        self.run_git(&["add", "raw/", "wiki/", "index.md", "log.md"])?;
+        // vault 디렉터리 안의 모든 변경을 stage (auto_commit 과 동일 패턴).
+        // 신규 dir (graph/, log/) 및 파일 (SCHEMA.md) 도 누락 없이 포착. .gitignore 안전망.
+        self.run_git(&["add", "-A"])?;
         self.run_git(&["commit", "-m", message])?;
         self.run_git(&["push", "origin", &self.branch])?;
 

--- a/crates/secall-core/tests/vault_auto_commit.rs
+++ b/crates/secall-core/tests/vault_auto_commit.rs
@@ -1,9 +1,12 @@
-//! Regression tests for `VaultGit::auto_commit`.
+//! Regression tests for `VaultGit::auto_commit` + `VaultGit::push`.
 //!
 //! 배경: 기존 `auto_commit` 가 `git add raw/ wiki/ index.md log.md .gitignore`
 //! 명시 패턴을 사용했는데, vault 의 신규 디렉터리(`graph/`, `log/`)나
 //! 신규 top-level 파일(`SCHEMA.md`)을 stage 하지 못해 pull rebase 가 실패했다.
 //! P39 Task 00 에서 `git add -A` 로 단순화. 본 파일은 그 회귀 테스트.
+//!
+//! P39 리뷰 권고 (rework): `push()` 도 동일 명시 패턴이라 같은 회귀를 유발했음.
+//! 같은 fix 가 push() 에도 적용됐는지 별도 검증 (bare remote 사용).
 
 use std::path::Path;
 use std::process::Command;
@@ -170,6 +173,115 @@ fn test_auto_commit_non_git_dir_returns_false() {
     let git = VaultGit::new(dir.path(), "main");
     let committed = git.auto_commit().expect("auto_commit");
     assert!(!committed);
+}
+
+// ─── push() 회귀 — bare remote 로 commit + push 함께 검증 ───────────────────
+
+/// `init_repo_with_initial_commit` + `git init --bare` remote + `push -u origin main`.
+/// 반환된 두 TempDir 는 호출부에서 alive 유지 (drop 시 cleanup).
+fn init_repo_with_bare_remote() -> (TempDir, TempDir) {
+    let remote = TempDir::new().expect("remote tempdir");
+    run(remote.path(), &["init", "--bare"]);
+
+    let work = init_repo_with_initial_commit();
+    let url = remote.path().to_str().expect("remote utf8");
+    run(work.path(), &["remote", "add", "origin", url]);
+    run(work.path(), &["push", "-u", "origin", "main"]);
+
+    (work, remote)
+}
+
+/// bare remote 의 main 브랜치 트리에 있는 파일 경로 목록 (개행 분리).
+/// `git init --bare` 의 default HEAD 가 main 을 안 가리킬 수 있어 ref 직접 지정.
+fn remote_head_files(remote: &Path) -> String {
+    let out = Command::new("git")
+        .args(["ls-tree", "-r", "--name-only", "refs/heads/main"])
+        .current_dir(remote)
+        .output()
+        .expect("git ls-tree");
+    assert!(
+        out.status.success(),
+        "ls-tree failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).expect("utf8")
+}
+
+#[test]
+fn test_push_stages_new_dirs_and_top_level_files() {
+    // 핵심 회귀: 명시 패턴 (raw/ wiki/ index.md log.md) 외 경로도 push() 가 모두 포함.
+    let (work, remote) = init_repo_with_bare_remote();
+    let wp = work.path();
+
+    write(wp, "graph/edges.json", "{}\n");
+    write(wp, "SCHEMA.md", "# v1\n");
+    write(wp, "log/2026-05-06.md", "log entry\n");
+
+    let git = VaultGit::new(wp, "main");
+    let result = git
+        .push("regression: ensure new dirs+files captured")
+        .expect("push");
+    assert!(
+        result.committed > 0,
+        "expected committed > 0, got {}",
+        result.committed
+    );
+    assert!(
+        porcelain(wp).trim().is_empty(),
+        "local should be clean after push; status: {:?}",
+        porcelain(wp)
+    );
+
+    let remote_files = remote_head_files(remote.path());
+    assert!(
+        remote_files.contains("graph/edges.json"),
+        "graph/edges.json not pushed: {remote_files}"
+    );
+    assert!(
+        remote_files.contains("SCHEMA.md"),
+        "SCHEMA.md not pushed: {remote_files}"
+    );
+    assert!(
+        remote_files.contains("log/2026-05-06.md"),
+        "log/2026-05-06.md not pushed: {remote_files}"
+    );
+}
+
+#[test]
+fn test_push_stages_deletions() {
+    // 삭제도 git add -A 로 잡혀야 remote 에 반영됨 (예전 명시 패턴은 신규 dir 만 누락이 아니라
+    // top-level 삭제도 누락 가능했음).
+    let (work, remote) = init_repo_with_bare_remote();
+    let wp = work.path();
+
+    write(wp, "wiki/topic.md", "topic\n");
+    run(wp, &["add", "wiki/topic.md"]);
+    run(wp, &["commit", "-m", "add topic"]);
+    run(wp, &["push", "origin", "main"]);
+
+    std::fs::remove_file(wp.join("wiki/topic.md")).expect("rm topic");
+
+    let git = VaultGit::new(wp, "main");
+    let result = git.push("regression: deletion captured").expect("push");
+    assert!(
+        result.committed > 0,
+        "deletion should produce committed > 0"
+    );
+    assert!(porcelain(wp).trim().is_empty(), "local should be clean");
+
+    let remote_files = remote_head_files(remote.path());
+    assert!(
+        !remote_files.contains("wiki/topic.md"),
+        "deletion should be reflected on remote: {remote_files}"
+    );
+}
+
+#[test]
+fn test_push_no_changes_returns_committed_zero() {
+    let (work, _remote) = init_repo_with_bare_remote();
+    let git = VaultGit::new(work.path(), "main");
+    let result = git.push("noop").expect("push");
+    assert_eq!(result.committed, 0, "clean repo should report 0 committed");
 }
 
 #[test]

--- a/crates/secall-core/tests/vault_auto_commit.rs
+++ b/crates/secall-core/tests/vault_auto_commit.rs
@@ -177,47 +177,56 @@ fn test_auto_commit_non_git_dir_returns_false() {
 
 // ─── push() 회귀 — bare remote 로 commit + push 함께 검증 ───────────────────
 
-/// `init_repo_with_initial_commit` + `git init --bare` remote + `push -u origin main`.
+/// `init_repo_with_initial_commit` + `git init --bare` remote + `push -u origin <branch>`.
 /// 반환된 두 TempDir 는 호출부에서 alive 유지 (drop 시 cleanup).
-fn init_repo_with_bare_remote() -> (TempDir, TempDir) {
+/// `branch` 는 `VaultGit::new` 인자와 일치해야 함.
+fn init_repo_with_bare_remote(branch: &str) -> (TempDir, TempDir) {
     let remote = TempDir::new().expect("remote tempdir");
     run(remote.path(), &["init", "--bare"]);
 
     let work = init_repo_with_initial_commit();
     let url = remote.path().to_str().expect("remote utf8");
     run(work.path(), &["remote", "add", "origin", url]);
-    run(work.path(), &["push", "-u", "origin", "main"]);
+    run(work.path(), &["push", "-u", "origin", branch]);
 
     (work, remote)
 }
 
-/// bare remote 의 main 브랜치 트리에 있는 파일 경로 목록 (개행 분리).
+/// bare remote 의 지정 브랜치 트리에 있는 파일 경로 목록 (개행 분리).
 /// `git init --bare` 의 default HEAD 가 main 을 안 가리킬 수 있어 ref 직접 지정.
-fn remote_head_files(remote: &Path) -> String {
+fn remote_head_files(remote: &Path, branch: &str) -> String {
+    let ref_name = format!("refs/heads/{branch}");
     let out = Command::new("git")
-        .args(["ls-tree", "-r", "--name-only", "refs/heads/main"])
+        .args(["ls-tree", "-r", "--name-only", &ref_name])
         .current_dir(remote)
         .output()
         .expect("git ls-tree");
     assert!(
         out.status.success(),
-        "ls-tree failed: {}",
+        "ls-tree {ref_name} failed: {}",
         String::from_utf8_lossy(&out.stderr)
     );
     String::from_utf8(out.stdout).expect("utf8")
 }
 
+/// substring match 가 아닌 정확한 경로 라인 매칭 — `foo.json` 이 `foo.json.bak` 에
+/// false-positive 매칭되는 것 회피.
+fn contains_exact_path(file_list: &str, target: &str) -> bool {
+    file_list.lines().any(|l| l == target)
+}
+
 #[test]
 fn test_push_stages_new_dirs_and_top_level_files() {
     // 핵심 회귀: 명시 패턴 (raw/ wiki/ index.md log.md) 외 경로도 push() 가 모두 포함.
-    let (work, remote) = init_repo_with_bare_remote();
+    let branch = "main";
+    let (work, remote) = init_repo_with_bare_remote(branch);
     let wp = work.path();
 
     write(wp, "graph/edges.json", "{}\n");
     write(wp, "SCHEMA.md", "# v1\n");
     write(wp, "log/2026-05-06.md", "log entry\n");
 
-    let git = VaultGit::new(wp, "main");
+    let git = VaultGit::new(wp, branch);
     let result = git
         .push("regression: ensure new dirs+files captured")
         .expect("push");
@@ -232,17 +241,17 @@ fn test_push_stages_new_dirs_and_top_level_files() {
         porcelain(wp)
     );
 
-    let remote_files = remote_head_files(remote.path());
+    let remote_files = remote_head_files(remote.path(), branch);
     assert!(
-        remote_files.contains("graph/edges.json"),
+        contains_exact_path(&remote_files, "graph/edges.json"),
         "graph/edges.json not pushed: {remote_files}"
     );
     assert!(
-        remote_files.contains("SCHEMA.md"),
+        contains_exact_path(&remote_files, "SCHEMA.md"),
         "SCHEMA.md not pushed: {remote_files}"
     );
     assert!(
-        remote_files.contains("log/2026-05-06.md"),
+        contains_exact_path(&remote_files, "log/2026-05-06.md"),
         "log/2026-05-06.md not pushed: {remote_files}"
     );
 }
@@ -251,17 +260,18 @@ fn test_push_stages_new_dirs_and_top_level_files() {
 fn test_push_stages_deletions() {
     // 삭제도 git add -A 로 잡혀야 remote 에 반영됨 (예전 명시 패턴은 신규 dir 만 누락이 아니라
     // top-level 삭제도 누락 가능했음).
-    let (work, remote) = init_repo_with_bare_remote();
+    let branch = "main";
+    let (work, remote) = init_repo_with_bare_remote(branch);
     let wp = work.path();
 
     write(wp, "wiki/topic.md", "topic\n");
     run(wp, &["add", "wiki/topic.md"]);
     run(wp, &["commit", "-m", "add topic"]);
-    run(wp, &["push", "origin", "main"]);
+    run(wp, &["push", "origin", branch]);
 
     std::fs::remove_file(wp.join("wiki/topic.md")).expect("rm topic");
 
-    let git = VaultGit::new(wp, "main");
+    let git = VaultGit::new(wp, branch);
     let result = git.push("regression: deletion captured").expect("push");
     assert!(
         result.committed > 0,
@@ -269,17 +279,18 @@ fn test_push_stages_deletions() {
     );
     assert!(porcelain(wp).trim().is_empty(), "local should be clean");
 
-    let remote_files = remote_head_files(remote.path());
+    let remote_files = remote_head_files(remote.path(), branch);
     assert!(
-        !remote_files.contains("wiki/topic.md"),
+        !contains_exact_path(&remote_files, "wiki/topic.md"),
         "deletion should be reflected on remote: {remote_files}"
     );
 }
 
 #[test]
 fn test_push_no_changes_returns_committed_zero() {
-    let (work, _remote) = init_repo_with_bare_remote();
-    let git = VaultGit::new(work.path(), "main");
+    let branch = "main";
+    let (work, _remote) = init_repo_with_bare_remote(branch);
+    let git = VaultGit::new(work.path(), branch);
     let result = git.push("noop").expect("push");
     assert_eq!(result.committed, 0, "clean repo should report 0 committed");
 }

--- a/docs/baseline/p39-p40-decision.md
+++ b/docs/baseline/p39-p40-decision.md
@@ -110,10 +110,12 @@ task_id: 03
 
 ## 6. 후속 액션
 
-- (보류 결정) 외부 컨트리뷰터에게 본 측정 데이터 + 보류 근거 회신 (Task 04 답변 초안)
-- wiki_search 호출 카운터 (DB column 추가 또는 access log) — P40 재평가 위한 데이터 수집 인프라. 별도 phase 후보 (~1일 작업)
-- 6 개월 cron 재측정 또는 페이지 수 50 도달 시 본 보고서 갱신 (`docs/baseline/p39-p40-decision.md` 새 버전)
-- (즉시 진행 시 — 해당 없음) P40 plan-proposal 초안: chunker 재사용, embedding backend Ollama bge-m3, DB v9 `wiki_vectors`, hybrid mode
+> 결정: **P40 즉시 진행**. 이전 "보류" 분기 액션은 제거됨.
+
+- 외부 컨트리뷰터에게 본 측정 데이터 + 즉시 진행 결정 회신 (Task 04 답변 초안 `docs/community/p39-wiki-vector-response.md`)
+- P40 plan-proposal 초안: chunker 재사용, embedding backend Ollama bge-m3, DB v9 `wiki_vectors`, hybrid mode (`?mode={keyword|semantic|hybrid}`)
+- (선택) wiki_search 호출 카운터 (DB column 추가 또는 access log) — P40 효과 측정 / 향후 chunker 분리 결정 인프라. 별도 phase 후보 (~1일 작업)
+- 6 개월 후 또는 페이지 수 50 도달 시 본 보고서 갱신 (`docs/baseline/p39-p40-decision.md` 새 버전) — chunker 분리 phase 진입 시점 판단 위함
 
 ---
 


### PR DESCRIPTION
## Summary

P39 PR #43 머지 후 Reviewer (Codex) 추가 권고 처리:

- **Finding (FAIL)**: `vault/git.rs:168` 의 `push()` 가 여전히 명시 패턴 (`raw/ wiki/ index.md log.md`) → P39 Task 00 fix 가 `auto_commit()` 에만 적용되어 sync 마지막 push 단계에서 `graph/`, `log/`, `SCHEMA.md` 같은 신규 경로가 여전히 누락 가능
- **Recommendation**: `vault_auto_commit.rs` 가 `auto_commit()` 만 직접 검증 → `push()` 회귀 별도 테스트 부재

## Changes

| File | Change |
|---|---|
| `crates/secall-core/src/vault/git.rs` | `push()` 도 `git add -A` 로 통일 (auto_commit 과 동일 패턴) |
| `crates/secall-core/tests/vault_auto_commit.rs` | bare remote 헬퍼 + push() 회귀 테스트 3건 추가 |
| `docs/baseline/p39-p40-decision.md` | '보류 결정' 분기 액션 제거 (recommendation) |

## Test plan

- [x] `cargo test -p secall-core --test vault_auto_commit` — 11 passed (8 기존 auto_commit + 3 신규 push)
  - `test_push_stages_new_dirs_and_top_level_files` — graph/edges.json, SCHEMA.md, log/2026-05-06.md 모두 remote 반영 확인
  - `test_push_stages_deletions` — 삭제 파일 remote 반영 확인
  - `test_push_no_changes_returns_committed_zero` — clean repo no-op 확인
- [x] `cargo check -p secall-core` — 0 errors
- [ ] CI: ubuntu + windows + web build

🤖 Generated with [Claude Code](https://claude.com/claude-code)