### PR TITLE
docs(insight+plans): 누적 finding 동기화 + 누락된 plan 산출물

### DIFF
--- a/docs/insight/findings/DEB-known-issues가-claude-md에-인라인으로-관리됨.md
+++ b/docs/insight/findings/DEB-known-issues가-claude-md에-인라인으로-관리됨.md
@@ -1,0 +1,22 @@
+# Known Issues가 CLAUDE.md에 인라인으로 관리됨
+
+- **Category**: debt
+- **Severity**: minor
+- **Fix Difficulty**: guided
+- **Status**: open
+- **File**: CLAUDE.md:97
+
+## Description
+
+CLAUDE.md의 Known Issues 섹션에 FTS 중복 잔존 등 미해결 기술 부채가 텍스트로 기록되어 있습니다. 이슈 트래커(GitHub Issues)와 이중 관리되면 동기화 누락 위험이 있고, 실제 수정 여부를 코드 리뷰 없이 확인하기 어렵습니다.
+
+**Evidence**: `- 기존 DB에 FTS 중복 잔존 (--force reingest로 세션별 정리 가능)
+- Issue #26 — Codex wiki 백엔드 추가 (외부 기여 PR 요청 중)`
+
+## Snippet
+
+```
+### Known Issues
+- 기존 DB에 FTS 중복 잔존 (--force reingest로 세션별 정리 가능)
+- Issue #26 — Codex wiki 백엔드 추가 (외부 기여 PR 요청 중)
+```

--- a/docs/insight/findings/DEB-rework-절차에-반복-실패-방지-장치가-주석-수준으로만-존재.md
+++ b/docs/insight/findings/DEB-rework-절차에-반복-실패-방지-장치가-주석-수준으로만-존재.md
@@ -1,0 +1,22 @@
+# Rework 절차에 반복 실패 방지 장치가 주석 수준으로만 존재
+
+- **Category**: debt
+- **Severity**: info
+- **Fix Difficulty**: guided
+- **Status**: open
+- **File**: docs/agents/developer.md:63
+
+## Description
+
+developer.md의 Rework 섹션에서 '이전 시도 이력'을 확인하라는 지침이 있지만, 이 이력이 어디에 어떤 형식으로 저장되는지 명시되지 않습니다. 이력 미참조로 동일한 실수가 반복될 수 있습니다.
+
+**Evidence**: `3. Check "이전 시도 이력" to avoid repeating past mistakes`
+
+## Snippet
+
+```
+When you receive a rework request with review findings:
+1. Read each finding carefully — **only fix the specified subtasks**
+2. If "대상 서브태스크" is specified, do NOT modify other tasks' code
+3. Check "이전 시도 이력" to avoid repeating past mistakes
+```

--- a/docs/insight/findings/DEB-프로젝트-상태-추적-섹션-미관리.md
+++ b/docs/insight/findings/DEB-프로젝트-상태-추적-섹션-미관리.md
@@ -3,7 +3,7 @@
 - **Category**: debt
 - **Severity**: info
 - **Fix Difficulty**: guided
-- **Status**: open
+- **Status**: in_progress
 - **File**: CLAUDE.md:94
 
 ## Description

--- a/docs/insight/findings/STA-graph-build-시-파일-읽기-파싱-실패를-continue로-조용히-건너뜀.md
+++ b/docs/insight/findings/STA-graph-build-시-파일-읽기-파싱-실패를-continue로-조용히-건너뜀.md
@@ -3,7 +3,7 @@
 - **Category**: stability
 - **Severity**: major
 - **Fix Difficulty**: guided
-- **Status**: open
+- **Status**: in_progress
 - **File**: crates/secall-core/src/graph/build.rs:76
 
 ## Description

--- a/docs/insight/findings/STA-is_date_dir가-유효하지-않은-날짜를-통과시킴.md
+++ b/docs/insight/findings/STA-is_date_dir가-유효하지-않은-날짜를-통과시킴.md
@@ -3,7 +3,7 @@
 - **Category**: stability
 - **Severity**: minor
 - **Fix Difficulty**: guided
-- **Status**: open
+- **Status**: in_progress
 - **File**: crates/secall-core/src/graph/build.rs:21
 
 ## Description

--- a/docs/insight/findings/STA-post-ingest-hook-실패-시-에러가-로그만-남기고-무시됨.md
+++ b/docs/insight/findings/STA-post-ingest-hook-실패-시-에러가-로그만-남기고-무시됨.md
@@ -3,7 +3,7 @@
 - **Category**: stability
 - **Severity**: major
 - **Fix Difficulty**: guided
-- **Status**: open
+- **Status**: in_progress
 - **File**: crates/secall/src/commands/ingest.rs:603
 
 ## Description

--- a/docs/insight/findings/STA-review-실패-시-자동-재시도-로직-없음.md
+++ b/docs/insight/findings/STA-review-실패-시-자동-재시도-로직-없음.md
@@ -1,0 +1,19 @@
+# review 실패 시 자동 재시도 로직 없음
+
+- **Category**: stability
+- **Severity**: major
+- **Fix Difficulty**: guided
+- **Status**: open
+- **File**: crates/secall/src/commands/wiki.rs:595
+
+## Description
+
+`wiki.rs:595` — `approved == false` 또는 `severity=error` 이슈가 존재해도 결과를 출력만 하고 프로세스가 종료됩니다. Task 03 계약에서 요구한 '자동 수정 1회 + 재검수' 루프가 구현되지 않아 검수 단계가 단순 리포트로만 동작합니다.
+
+**Evidence**: `[wiki.rs:595] `--review` 경로가 `approved == false`이거나 `severity=error` 이슈가 있어도 결과를 출력만 하고 종료합니다. Task 03 계약은 error급 이슈에 대해 자동 수정 1회와 재검수를 요구하는데, 그 재시도 로직이 없어 검수 단계가 단순 리포트로만 동작합니다.`
+
+## Snippet
+
+```
+// severity=error → 출력 후 종료, 재시도 없음
+```

--- a/docs/insight/findings/STA-검수-review-가-post-lint-최종본이-아닌-pre-lint-초안을-받음.md
+++ b/docs/insight/findings/STA-검수-review-가-post-lint-최종본이-아닌-pre-lint-초안을-받음.md
@@ -1,0 +1,19 @@
+# 검수(review)가 post-lint 최종본이 아닌 pre-lint 초안을 받음
+
+- **Category**: stability
+- **Severity**: major
+- **Fix Difficulty**: guided
+- **Status**: open
+- **File**: crates/secall/src/commands/wiki.rs:148
+
+## Description
+
+`wiki.rs:148` — `run_markdownlint()`가 파일을 수정할 수 있음에도, `run_review()`에 수정 전 문자열 `linked`를 그대로 전달합니다. 결과적으로 `--review` 단계는 실제 저장본이 아닌 lint 전 초안을 검수하게 되어 검수 결과의 신뢰성이 근본적으로 깨집니다.
+
+**Evidence**: `[wiki.rs:148] `run_markdownlint()`가 파일을 수정할 수 있는데도 검수는 수정 전 문자열 `linked`를 그대로 `run_review()`에 넘깁니다. 결과적으로 `--review`는 최종 저장본이 아닌 pre-lint 초안을 검수하게 됩니다.`
+
+## Snippet
+
+```
+// run_review(linked) — lint 적용 전 문자열 전달
+```

--- a/docs/insight/findings/STA-배치-모드--파일-생성-병합-파이프라인-전체-누락.md
+++ b/docs/insight/findings/STA-배치-모드--파일-생성-병합-파이프라인-전체-누락.md
@@ -1,0 +1,21 @@
+# 배치 모드: 파일 생성·병합 파이프라인 전체 누락
+
+- **Category**: stability
+- **Severity**: critical
+- **Fix Difficulty**: guided
+- **Status**: open
+- **File**: crates/secall/src/commands/wiki.rs:95
+
+## Description
+
+`wiki.rs:95` — `--session` 없이 배치 실행 시 생성 결과를 `println!`으로만 출력하고 종료합니다. `validate_frontmatter()`, `merge_with_existing()`, `insert_obsidian_links()`, 파일 쓰기, `run_markdownlint()` 호출이 전혀 없어 `wiki/` 파일이 실제로 생성되지 않습니다. 또한 `wiki.rs:117/415` — 배치 출력 전체를 단일 `index.md`로만 기록해 Task 01/02 계약의 '프로젝트별 별도 페이지 생성·병합' 요구를 충족하지 못합니다. 프로덕션에서 배치 실행 결과가 디스크에 저장되지 않는 데이터 유실 수준의 버그입니다.
+
+**Evidence**: `[wiki.rs:95] 생성 결과를 `println!`으로만 출력하고 종료합니다. Task 02 계약상 필수인 `validate_frontmatter()`, `merge_with_existing()`, `insert_obsidian_links()`, 파일 쓰기, `run_markdownlint()` 호출이 전혀 없어 `wiki/` 파일 생성·병합이 수행되지 않습니다.
+[wiki.rs:117, wiki.rs:415] 배치 모드에서 생성 결과 전체에 대해 단일 `page_path`만 계산하고, `session == None`이면 항상 `index.md`로 기록합니다.`
+
+## Snippet
+
+```
+// wiki.rs:95 — println! 출력 후 파이프라인 종료
+// wiki.rs:117/415 — session == None → page_path = index.md (단일 파일)
+```

--- a/docs/insight/findings/STA-사실-정확성-검수-시-원본-세션-내용-미전달.md
+++ b/docs/insight/findings/STA-사실-정확성-검수-시-원본-세션-내용-미전달.md
@@ -1,0 +1,19 @@
+# 사실 정확성 검수 시 원본 세션 내용 미전달
+
+- **Category**: stability
+- **Severity**: major
+- **Fix Difficulty**: guided
+- **Status**: open
+- **File**: crates/secall/src/commands/wiki.rs:463
+
+## Description
+
+`wiki.rs:463` — 검수 단계가 모델에 `session: <id>` 또는 `batch update` 문자열만 전달합니다. 원본 세션 요약·내용을 대조 근거로 제공하지 않아 모델이 생성된 위키 내용의 사실 정확성을 실질적으로 검증할 수 없습니다.
+
+**Evidence**: `[wiki.rs:463] 검수 단계가 모델에 전달하는 원본 근거가 `session: <id>` 또는 `batch update` 문자열뿐입니다. Task 03은 원본 세션 요약/내용을 대조용으로 전달해야 하는데, 현재 구현으로는 사실 정확성 검수가 실질적으로 동작할 수 없습니다.`
+
+## Snippet
+
+```
+// run_review(content, "session: <id>") — 원본 세션 데이터 없음
+```

--- a/docs/insight/findings/STA-세션-id-중복-등장-시-첫-번째-이후-링크-치환-누락.md
+++ b/docs/insight/findings/STA-세션-id-중복-등장-시-첫-번째-이후-링크-치환-누락.md
@@ -1,0 +1,19 @@
+# 세션 ID 중복 등장 시 첫 번째 이후 링크 치환 누락
+
+- **Category**: stability
+- **Severity**: minor
+- **Fix Difficulty**: guided
+- **Status**: open
+- **File**: crates/secall-core/src/wiki/lint.rs:121
+
+## Description
+
+`lint.rs:121` — 같은 세션 ID가 이미 한 번 링크된 경우 나머지 평문 참조를 건너뜁니다. 같은 세션이 문서 내 여러 위치에 언급되면 일부가 링크되지 않은 채로 저장됩니다.
+
+**Evidence**: `[lint.rs:121] 같은 세션 ID가 이미 한 번 링크돼 있으면 그 세션의 나머지 평문 참조까지 전부 건너뛰고, 그렇지 않은 경우에도 첫 번째 매치만 치환합니다. 한 문서에 같은 세션 ID가 여러 번 나오면 일부 참조가 평문으로 남습니다.`
+
+## Snippet
+
+```
+// 첫 번째 매치만 치환, 이후 동일 ID 평문 잔존
+```

--- a/docs/insight/findings/STA-세션-링크가-obsidian에서-깨진-링크로-생성됨.md
+++ b/docs/insight/findings/STA-세션-링크가-obsidian에서-깨진-링크로-생성됨.md
@@ -1,0 +1,19 @@
+# 세션 링크가 Obsidian에서 깨진 링크로 생성됨
+
+- **Category**: stability
+- **Severity**: major
+- **Fix Difficulty**: guided
+- **Status**: open
+- **File**: crates/secall-core/src/wiki/lint.rs:116
+
+## Description
+
+`lint.rs:116` — `insert_obsidian_links()`가 세션 참조를 `[[<full-session-id>|<short-id>]]` 형식으로 생성하지만 실제 vault 경로는 `sessions/{short_id}.md` 또는 `raw/sessions/YYYY-MM-DD_session-id` 계열입니다. vault 경로를 계산하지 않아 생성된 모든 세션 링크가 Obsidian에서 dead link가 됩니다.
+
+**Evidence**: `[lint.rs:116] 세션 링크를 `[[{full_uuid}|{short_id}]]`로 생성하지만, 실제 생성 경로는 `sessions/{short_id}.md` 또는 `projects/...`라서 링크 대상 노트가 존재하지 않습니다. 프로젝트의 링크 규약은 `[[raw/sessions/YYYY-MM-DD_session-id]]` 계열입니다.`
+
+## Snippet
+
+```
+// [[{full_uuid}|{short_id}]] — vault 경로 불일치로 dead link
+```

--- a/docs/insight/findings/STA-이전-리뷰-지적사항-다수-해결됨---regex-사전-컴파일--skip_embed_types--vector-필터.md
+++ b/docs/insight/findings/STA-이전-리뷰-지적사항-다수-해결됨---regex-사전-컴파일--skip_embed_types--vector-필터.md
@@ -3,7 +3,7 @@
 - **Category**: stability
 - **Severity**: info
 - **Fix Difficulty**: guided
-- **Status**: open
+- **Status**: in_progress
 - **File**: crates/secall/src/commands/classify.rs:30
 
 ## Description

--- a/docs/insight/findings/STA-증분-프롬프트에-기존-위키-페이지-목록-미주입.md
+++ b/docs/insight/findings/STA-증분-프롬프트에-기존-위키-페이지-목록-미주입.md
@@ -1,0 +1,19 @@
+# 증분 프롬프트에 기존 위키 페이지 목록 미주입
+
+- **Category**: stability
+- **Severity**: major
+- **Fix Difficulty**: guided
+- **Status**: open
+- **File**: crates/secall/src/commands/wiki.rs:283
+
+## Description
+
+`wiki.rs:283` — `build_haiku_incremental_prompt()`가 세션 메타와 턴만 직렬화하고, 기존 위키 페이지 목록을 컨텍스트로 주입하지 않습니다. `--session` 모드에서 모델이 기존 페이지와의 병합 힌트를 받지 못해 중복 페이지 생성 또는 기존 내용 누락이 발생할 수 있습니다.
+
+**Evidence**: `[wiki.rs:283] `build_haiku_incremental_prompt()`는 세션 메타와 턴만 직렬화하고 끝나며, Task 01 계약에 있던 '기존 위키 페이지 목록도 함께 주입' 단계가 없습니다. 그 결과 `--session` 모드에서 기존 페이지 병합 힌트를 모델에 전달하지 못합니다.`
+
+## Snippet
+
+```
+// build_haiku_incremental_prompt(): 세션 메타+턴만 직렬화, 기존 페이지 목록 없음
+```

--- a/docs/insight/findings/STA-페이지-간-내부-링크-생성-로직-미구현.md
+++ b/docs/insight/findings/STA-페이지-간-내부-링크-생성-로직-미구현.md
@@ -1,0 +1,19 @@
+# 페이지 간 내부 링크 생성 로직 미구현
+
+- **Category**: stability
+- **Severity**: minor
+- **Fix Difficulty**: guided
+- **Status**: open
+- **File**: crates/secall-core/src/wiki/lint.rs:113
+
+## Description
+
+`lint.rs:113` — `insert_obsidian_links()`가 `session_ids`/`vault_paths`만 처리합니다. Task 02 계약에서 요구한 '알려진 위키 페이지 제목이 본문에 나오면 `[[페이지명]]`으로 변환' 로직이 없어 페이지 간 내부 링크가 생성되지 않습니다.
+
+**Evidence**: `[lint.rs:113] `insert_obsidian_links()`는 `session_ids`/`vault_paths`만 받아 세션 참조만 링크화합니다. Task 02 계약에 있던 '알려진 위키 페이지 제목이 본문에 나오면 `[[페이지명]]`으로 변환' 로직이 없어서 페이지 간 내부 링크 생성이 누락됩니다.`
+
+## Snippet
+
+```
+// insert_obsidian_links(session_ids, vault_paths) — 페이지 간 링크 변환 없음
+```

--- a/docs/insight/findings/TES-classify-rs-커맨드에-테스트-모듈-없음.md
+++ b/docs/insight/findings/TES-classify-rs-커맨드에-테스트-모듈-없음.md
@@ -4,20 +4,22 @@
 - **Severity**: minor
 - **Fix Difficulty**: guided
 - **Status**: open
-- **File**: crates/secall/src/commands/classify.rs:25
+- **File**: crates/secall/src/commands/classify.rs:55
 
 ## Description
 
-classify.rs의 `run_backfill` 함수는 `ingest.rs`의 `CompiledRule`과 `apply_classification`을 재사용하므로 핵심 로직은 `ingest.rs` 테스트에서 커버됩니다. 그러나 backfill 특유의 흐름(전체 세션 순회, dry_run 분기)은 테스트되지 않습니다. ingest.rs에 이미 10개의 분류 테스트가 있어 severity는 minor로 판단합니다.
+run_backfill의 핵심 분류 로직(apply_classification)은 ingest.rs 테스트 9개로 잘 커버되어 있습니다. 그러나 classify.rs 자체의 dry_run 분기(eprintln만 하고 DB 미갱신), regex 컴파일 실패 시 조기 반환, updated 카운트 집계 로직은 별도 테스트가 없습니다. dry_run=true일 때 DB가 실제로 변경되지 않는다는 보장을 코드로 검증할 수 없습니다.
 
-**Evidence**: `let compiled_rules: Vec<super::ingest::CompiledRule> = classification
-    .rules
-    .iter()
-    .map(|rule| { ... })
-    .collect::<anyhow::Result<_>>()?;`
+**Evidence**: `if dry_run {
+    eprintln!("  [dry-run] {} → {}", short_id, new_type);
+} else {
+    db.update_session_type(session_id, &new_type)?;
+    tracing::debug!(session = short_id, session_type = new_type, "classified");
+}
+updated += 1;`
 
 ## Snippet
 
 ```
-pub async fn run_backfill(dry_run: bool) -> Result<()> { ... }
+// #[cfg(test)] 모듈 없음 (72줄 전체)
 ```

--- a/docs/insight/findings/TES-db-메서드-get_sessions_for_date--get_topics_for_sessions-테스트-부재.md
+++ b/docs/insight/findings/TES-db-메서드-get_sessions_for_date--get_topics_for_sessions-테스트-부재.md
@@ -3,7 +3,7 @@
 - **Category**: test
 - **Severity**: minor
 - **Fix Difficulty**: guided
-- **Status**: open
+- **Status**: in_progress
 - **File**: crates/secall-core/src/store/db.rs:658
 
 ## Description

--- a/docs/insight/findings/TES-graph-build-시-파일-읽기-파싱-실패를-continue로-조용히-건너뜀.md
+++ b/docs/insight/findings/TES-graph-build-시-파일-읽기-파싱-실패를-continue로-조용히-건너뜀.md
@@ -1,0 +1,36 @@
+# graph build 시 파일 읽기/파싱 실패를 continue로 조용히 건너뜀
+
+- **Category**: test
+- **Severity**: major
+- **Fix Difficulty**: auto
+- **Status**: open
+- **File**: crates/secall/src/commands/graph.rs:92
+
+## Description
+
+run_semantic에서 vault 파일 읽기 실패나 frontmatter 파싱 실패 시 tracing::warn만 기록하고 skipped += 1로 넘어갑니다. 테스트가 없어 이 분기(skipped 카운팅, 에러 메시지 포맷, 루프 진행)의 정확성을 검증할 수 없습니다. 다수의 세션이 silently 누락된 채 그래프가 부분 빌드될 수 있으며, 사용자는 최종 'X skipped' 수치만 보고 원인을 알 수 없습니다.
+
+**Evidence**: `let content = match std::fs::read_to_string(&md_path) {
+    Ok(c) => c,
+    Err(e) => {
+        tracing::warn!(session = short, "cannot read vault file: {}", e);
+        skipped += 1;
+        continue;
+    }
+};
+
+let fm = match parse_session_frontmatter(&content) {
+    Ok(f) => f,
+    Err(e) => {
+        tracing::warn!(session = short, "cannot parse frontmatter: {}", e);
+        skipped += 1;
+        continue;
+    }
+};`
+
+## Snippet
+
+```
+skipped += 1;
+continue;
+```

--- a/docs/insight/findings/TES-graph-rs-커맨드에-테스트-모듈-없음--156-loc.md
+++ b/docs/insight/findings/TES-graph-rs-커맨드에-테스트-모듈-없음--156-loc.md
@@ -3,7 +3,7 @@
 - **Category**: test
 - **Severity**: minor
 - **Fix Difficulty**: guided
-- **Status**: open
+- **Status**: in_progress
 - **File**: crates/secall/src/commands/graph.rs:28
 
 ## Description

--- a/docs/insight/findings/TES-graph-rs-커맨드에-테스트-모듈-없음--188-loc.md
+++ b/docs/insight/findings/TES-graph-rs-커맨드에-테스트-모듈-없음--188-loc.md
@@ -1,0 +1,30 @@
+# graph.rs 커맨드에 테스트 모듈 없음 (188 LOC)
+
+- **Category**: test
+- **Severity**: major
+- **Fix Difficulty**: auto
+- **Status**: open
+- **File**: crates/secall/src/commands/graph.rs:10
+
+## Description
+
+4개의 공개 함수(run_semantic, run_build, run_stats, run_export)를 포함한 188줄 파일에 #[cfg(test)] 모듈이 전혀 없습니다. run_semantic은 백엔드 오버라이드 로직(CLI 플래그 > 환경변수 > config 우선순위)이 복잡하게 얽혀 있고, run_build/run_stats/run_export는 DB와 파일시스템 양쪽에 영향을 줍니다. 회귀 감지 수단이 없어 config 오버라이드 우선순위 버그가 프로덕션에서 silently 잘못된 백엔드로 연결될 수 있습니다.
+
+**Evidence**: `pub async fn run_semantic(
+    delay_secs: f64,
+    limit: Option<usize>,
+    backend: Option<String>,
+    api_url: Option<String>,
+    model: Option<String>,
+    api_key: Option<String>,
+) -> Result<()> {
+    ...
+    if let Some(b) = backend {
+        config.graph.semantic_backend = b;
+    }`
+
+## Snippet
+
+```
+// 파일 전체에 #[cfg(test)] mod tests { ... } 없음
+```

--- a/docs/insight/findings/TES-신규-log-rs-커맨드에-테스트-모듈-없음--200-loc.md
+++ b/docs/insight/findings/TES-신규-log-rs-커맨드에-테스트-모듈-없음--200-loc.md
@@ -3,7 +3,7 @@
 - **Category**: test
 - **Severity**: major
 - **Fix Difficulty**: guided
-- **Status**: open
+- **Status**: in_progress
 - **File**: crates/secall/src/commands/log.rs:29
 
 ## Description

--- a/docs/insight/latest-report.md
+++ b/docs/insight/latest-report.md
@@ -1,23 +1,28 @@
-# Insight Report — 2026-04-13 12:09
+# Insight Report — 2026-04-18 04:34
 
-총 10건 발견 — 안정성 (Stability): 4건, 기술 부채 (Technical Debt): 1건, 테스트 (Testing): 5건 ($1.362, 0in/0out)
+총 15건 발견 — 안정성 (Stability): 8건, 기술 부채 (Technical Debt): 2건, 테스트 (Testing): 5건 ($0.896, 0in/0out)
 
 ## debt
 
-- ⬜ **프로젝트 상태 추적 섹션 미관리** [info] — CLAUDE.md
+- ⬜ **Known Issues가 CLAUDE.md에 인라인으로 관리됨** [minor] — CLAUDE.md
+- ⬜ **Rework 절차에 반복 실패 방지 장치가 주석 수준으로만 존재** [info] — docs/agents/developer.md
 
 ## stability
 
-- ⬜ **post-ingest hook 실패 시 에러가 로그만 남기고 무시됨** [major] — crates/secall/src/commands/ingest.rs
-- ⬜ **graph build 시 파일 읽기/파싱 실패를 continue로 조용히 건너뜀** [major] — crates/secall-core/src/graph/build.rs
-- ⬜ **is_date_dir가 유효하지 않은 날짜를 통과시킴** [minor] — crates/secall-core/src/graph/build.rs
-- ⬜ **이전 리뷰 지적사항 다수 해결됨 — regex 사전 컴파일, skip_embed_types, vector 필터** [info] — crates/secall/src/commands/classify.rs
+- ⬜ **배치 모드: 파일 생성·병합 파이프라인 전체 누락** [critical] — crates/secall/src/commands/wiki.rs
+- ⬜ **세션 링크가 Obsidian에서 깨진 링크로 생성됨** [major] — crates/secall-core/src/wiki/lint.rs
+- ⬜ **검수(review)가 post-lint 최종본이 아닌 pre-lint 초안을 받음** [major] — crates/secall/src/commands/wiki.rs
+- ⬜ **review 실패 시 자동 재시도 로직 없음** [major] — crates/secall/src/commands/wiki.rs
+- ⬜ **증분 프롬프트에 기존 위키 페이지 목록 미주입** [major] — crates/secall/src/commands/wiki.rs
+- ⬜ **사실 정확성 검수 시 원본 세션 내용 미전달** [major] — crates/secall/src/commands/wiki.rs
+- ⬜ **세션 ID 중복 등장 시 첫 번째 이후 링크 치환 누락** [minor] — crates/secall-core/src/wiki/lint.rs
+- ⬜ **페이지 간 내부 링크 생성 로직 미구현** [minor] — crates/secall-core/src/wiki/lint.rs
 
 ## test
 
-- ⬜ **신규 log.rs 커맨드에 테스트 모듈 없음 (200 LOC)** [major] — crates/secall/src/commands/log.rs
+- ⬜ **graph.rs 커맨드에 테스트 모듈 없음 (188 LOC)** [major] — crates/secall/src/commands/graph.rs
+- ⬜ **graph build 시 파일 읽기/파싱 실패를 continue로 조용히 건너뜀** [major] — crates/secall/src/commands/graph.rs
+- ⬜ **session_repo.rs — 722줄 핵심 파일에 테스트 모듈 없음** [major] — crates/secall-core/src/store/session_repo.rs
 - ⬜ **classify.rs 커맨드에 테스트 모듈 없음** [minor] — crates/secall/src/commands/classify.rs
-- ⬜ **graph.rs 커맨드에 테스트 모듈 없음 (156 LOC)** [minor] — crates/secall/src/commands/graph.rs
-- ⬜ **DB 메서드 get_sessions_for_date, get_topics_for_sessions 테스트 부재** [minor] — crates/secall-core/src/store/db.rs
-- ⬜ **session_repo.rs trait에 신규 메서드 미반영** [info] — crates/secall-core/src/store/session_repo.rs
+- ⬜ **SessionRepo trait에 신규 메서드 미반영** [minor] — crates/secall-core/src/store/session_repo.rs
 

--- a/docs/plans/p30-openai-sync-no-semantic-34-35-result.md
+++ b/docs/plans/p30-openai-sync-no-semantic-34-35-result.md
@@ -1,0 +1,43 @@
+# Implementation Result: P30 — OpenAI 호환 백엔드 + sync --no-semantic (#34, #35)
+
+> Developer: unknown
+> Branch: N/A
+> Date: 2026-04-17 08:45
+> Plan Revision: 0
+
+---
+
+## Summary
+
+모든 Verification 통과했습니다.
+
+---
+
+Verification results for Task 01:
+✅ `cargo check -p secall-core -p secall` — exit 0
+✅ `cargo test -p secall-core` — 260 passed, 0 failed
+✅ `cargo run -- graph semantic --help 2>&1 | grep -i lmstudio` — `"lmstudio"` 출력 확인
+
+Verification results for Task 02:
+✅ `cargo check -p secall` — exit 0
+✅ `cargo run -- sync --help 2>&1 | grep -i "no-semantic"` — `--no-semantic` 출력 확인
+✅ `cargo test -p secall` — 16 + 4 passed, 0 failed
+
+## Subtask Results
+
+### 1. 모든 Verification 통과했습니다.
+
+---
+
+Verification results for Task 01:
+✅ `cargo check -p secall-core -p secall` — exit 0
+✅ `cargo test -p secall-core` — 260 passed, 0 failed
+✅ `cargo run -- graph semantic --help 2>&1 | grep -i lmstudio` — `"lmstudio"` 출력 확인
+
+Verification results for Task 02:
+✅ `cargo check -p secall` — exit 0
+✅ `cargo run -- sync --help 2>&1 | grep -i "no-semantic"` — `--no-semantic` 출력 확인
+✅ `cargo test -p secall` — 16 + 4 passed, 0 failed
+
+<!-- tunafl
+

--- a/docs/plans/p30-openai-sync-no-semantic-34-35-review-r1.md
+++ b/docs/plans/p30-openai-sync-no-semantic-34-35-review-r1.md
@@ -1,0 +1,29 @@
+# Review Report: P30 — OpenAI 호환 백엔드 + sync --no-semantic (#34, #35) — Round 1
+
+> Verdict: pass
+> Reviewer: 
+> Date: 2026-04-17 08:46
+> Plan Revision: 0
+
+---
+
+## Verdict
+
+**pass**
+
+## Findings
+
+1. 없음
+
+## Recommendations
+
+1. `crates/secall-core/src/graph/semantic.rs`의 `extract_with_openai_compat` 및 `"lmstudio"` 디스패치에 대한 단위 테스트를 추가하면 회귀 방지에 도움이 됩니다.
+2. `crates/secall/src/main.rs:328` 부근의 `api_url` 도움말은 현재 Ollama 전용으로 읽히므로, 추후 LM Studio/OpenAI-compat도 포함하도록 설명을 넓히면 사용성 개선 여지가 있습니다.
+
+## Subtask Verification
+
+| # | Subtask | Status |
+|---|---------|--------|
+| 1 | OpenAI 호환 백엔드 함수 추가 | ✅ done |
+| 2 | sync --no-semantic 플래그 추가 | ✅ done |
+

--- a/docs/plans/p30-openai-sync-no-semantic-34-35-task-01.md
+++ b/docs/plans/p30-openai-sync-no-semantic-34-35-task-01.md
@@ -1,0 +1,130 @@
+---
+type: task
+status: pending
+updated_at: 2026-04-17
+plan: p30-openai-sync-no-semantic-34-35
+task_number: 1
+parallel_group: A
+depends_on: []
+github_issue: "#35"
+---
+
+# Task 01 — OpenAI 호환 백엔드 함수 추가
+
+## Changed files
+
+- `crates/secall-core/src/graph/semantic.rs` — OpenAI 호환 함수 + 응답 구조체 + 디스패치 분기
+- `crates/secall-core/src/vault/config.rs:156` — `semantic_backend` 주석에 `"lmstudio"` 추가
+- `crates/secall/src/main.rs:322` — `--backend` 도움말에 `"lmstudio"` 추가
+
+## Change description
+
+### Step 1: OpenAI 응답 구조체 추가 (`semantic.rs`)
+
+`OllamaResponse` / `OllamaMessage` (L39-44) 근처에 OpenAI ChatCompletion 응답 구조체를 추가한다:
+
+```
+#[derive(Debug, Deserialize)]
+struct OpenAIResponse {
+    choices: Vec<OpenAIChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIChoice {
+    message: OpenAIMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIMessage {
+    content: String,
+}
+```
+
+### Step 2: `extract_with_openai_compat` 함수 추가 (`semantic.rs`)
+
+`extract_with_ollama` (L166-204) 직후에 새 함수를 추가한다:
+
+```
+async fn extract_with_openai_compat(
+    fm: &SessionFrontmatter,
+    body: &str,
+    base_url: &str,
+    model: &str,
+) -> Result<Vec<GraphEdge>>
+```
+
+핵심 차이점 (vs `extract_with_ollama`):
+- **URL**: `{base_url}/v1/chat/completions` (Ollama는 `/api/chat`)
+- **요청 포맷**: OpenAI ChatCompletion (`model`, `temperature`, `messages` — `stream`과 `options` 대신 top-level `temperature`)
+- **응답 파싱**: `OpenAIResponse` → `choices[0].message.content` (Ollama는 `message.content` 직접)
+- 나머지(프롬프트, 파싱)는 동일하게 `build_user_content` + `parse_llm_edges` 사용
+
+요청 바디 형태:
+```json
+{
+  "model": "<model>",
+  "temperature": 0.1,
+  "messages": [
+    {"role": "system", "content": SYSTEM_PROMPT},
+    {"role": "user", "content": user_content}
+  ]
+}
+```
+
+에러 처리는 `extract_with_ollama`와 동일 패턴:
+- `!resp.status().is_success()` → `anyhow::bail!("OpenAI-compat API error {}: {}", status, text)`
+- `choices`가 비어있으면 `anyhow::bail!("OpenAI-compat API returned empty choices")`
+
+### Step 3: `extract_with_llm` 디스패치에 `"lmstudio"` 분기 추가 (`semantic.rs:352`)
+
+현재 match 분기:
+```
+"ollama" => ...
+"anthropic" => ...
+"gemini" => ...
+_ => anyhow::bail!(...)
+```
+
+`"gemini"` 뒤, `_` 앞에 추가:
+```
+"lmstudio" => {
+    let base_url = config.ollama_url.as_deref().unwrap_or("http://localhost:1234");
+    let model = config.ollama_model.as_deref().unwrap_or("gemma-4-e4b-it");
+    extract_with_openai_compat(fm, body, base_url, model).await
+}
+```
+
+> 기본 URL이 Ollama(`11434`)가 아닌 LM Studio(`1234`)임에 주의.
+
+### Step 4: 주석/도움말 업데이트
+
+- `config.rs:156` — `semantic_backend` 주석: `"ollama" | "anthropic" | "gemini" | "lmstudio" | "disabled"`
+- `main.rs:322` — `--backend` arg 도움말: `"ollama" | "gemini" | "anthropic" | "lmstudio" | "disabled"`
+
+## Dependencies
+
+없음 (독립 태스크)
+
+## Verification
+
+```bash
+# 1. 타입 체크
+cargo check -p secall-core -p secall
+
+# 2. 기존 테스트 통과 확인
+cargo test -p secall-core
+
+# 3. CLI 도움말에 lmstudio 표시 확인
+cargo run -- graph semantic --help 2>&1 | grep -i lmstudio
+```
+
+## Risks
+
+- **낮음**: 새 함수 + 새 match 분기 추가만이므로 기존 ollama/anthropic/gemini 코드에 영향 없음
+- `OpenAIResponse` 구조체가 LM Studio 실제 응답과 불일치할 가능성 — LM Studio는 OpenAI 호환이므로 `choices[0].message.content` 경로는 안전. 단, `usage` 등 추가 필드는 `#[derive(Deserialize)]`에서 자동 무시됨 (serde 기본 동작)
+
+## Scope boundary (수정 금지)
+
+- `commands/sync.rs` — Task 02 영역
+- `commands/ingest.rs` — 기존 코드
+- `extract_with_ollama`, `extract_with_gemini`, `extract_with_anthropic` 함수 본문 — 기존 백엔드 건드리지 않음

--- a/docs/plans/p30-openai-sync-no-semantic-34-35-task-02.md
+++ b/docs/plans/p30-openai-sync-no-semantic-34-35-task-02.md
@@ -1,0 +1,108 @@
+---
+type: task
+status: pending
+updated_at: 2026-04-17
+plan: p30-openai-sync-no-semantic-34-35
+task_number: 2
+parallel_group: A
+depends_on: []
+github_issue: "#34"
+---
+
+# Task 02 — sync --no-semantic 플래그 추가
+
+## Changed files
+
+- `crates/secall/src/main.rs:183-195` — `Sync` 커맨드 구조체에 `no_semantic` 필드 추가
+- `crates/secall/src/main.rs:456-461` — 디스패치에서 `no_semantic` 인자 전달
+- `crates/secall/src/commands/sync.rs:14` — `run` 함수 시그니처에 `no_semantic: bool` 추가
+- `crates/secall/src/commands/sync.rs:293` — 하드코딩 `false` → `no_semantic` 변수로 교체
+
+## Change description
+
+### Step 1: CLI 인자 추가 (`main.rs:183-195`)
+
+`Sync` 구조체의 `no_wiki` 필드(L193-194) 뒤에 추가:
+
+```rust
+/// Skip semantic edge extraction during ingest
+#[arg(long)]
+no_semantic: bool,
+```
+
+### Step 2: 디스패치 업데이트 (`main.rs:456-461`)
+
+현재:
+```rust
+Commands::Sync {
+    local_only,
+    dry_run,
+    no_wiki,
+} => {
+    commands::sync::run(local_only, dry_run, no_wiki).await?;
+}
+```
+
+변경:
+```rust
+Commands::Sync {
+    local_only,
+    dry_run,
+    no_wiki,
+    no_semantic,
+} => {
+    commands::sync::run(local_only, dry_run, no_wiki, no_semantic).await?;
+}
+```
+
+### Step 3: `run` 함수 시그니처 변경 (`sync.rs:14`)
+
+현재:
+```rust
+pub async fn run(local_only: bool, dry_run: bool, no_wiki: bool) -> Result<()> {
+```
+
+변경:
+```rust
+pub async fn run(local_only: bool, dry_run: bool, no_wiki: bool, no_semantic: bool) -> Result<()> {
+```
+
+### Step 4: 하드코딩 제거 (`sync.rs:293`)
+
+현재:
+```rust
+false, // no_semantic: sync에서는 시맨틱 추출 활성화
+```
+
+변경:
+```rust
+no_semantic,
+```
+
+## Dependencies
+
+없음 (독립 태스크)
+
+## Verification
+
+```bash
+# 1. 타입 체크
+cargo check -p secall
+
+# 2. CLI 도움말에 --no-semantic 표시 확인
+cargo run -- sync --help 2>&1 | grep -i "no-semantic"
+
+# 3. 기존 테스트 통과 (sync 관련)
+cargo test -p secall
+```
+
+## Risks
+
+- **매우 낮음**: 함수 시그니처에 `bool` 하나 추가 + 하드코딩 제거. `run` 호출부는 `main.rs` 한 곳뿐 (grep으로 확인됨)
+- `ingest_sessions`의 `no_semantic` 파라미터 위치가 8번째 인자(0-based: 7)인데, 기존 `false` 자리를 변수로 교체하므로 위치 오류 가능성 없음
+
+## Scope boundary (수정 금지)
+
+- `crates/secall-core/src/graph/semantic.rs` — Task 01 영역
+- `crates/secall-core/src/vault/config.rs` — Task 01 영역
+- `crates/secall/src/commands/ingest.rs` — 기존 `--no-semantic` 구현 건드리지 않음

--- a/docs/plans/p30-openai-sync-no-semantic-34-35.md
+++ b/docs/plans/p30-openai-sync-no-semantic-34-35.md
@@ -1,0 +1,42 @@
+---
+type: plan
+status: in_progress
+updated_at: 2026-04-17
+version: 1
+github_issues: ["#34", "#35"]
+---
+
+# P30 — OpenAI 호환 백엔드 + sync --no-semantic (#34, #35)
+
+## Description
+
+두 가지 외부 이슈(batmania52)를 묶어 처리한다.
+
+- **#35**: `graph semantic`에 LM Studio(OpenAI 호환) 백엔드 추가. 현재 `extract_with_ollama`는 `/api/chat`(Ollama 전용)을 사용하여 LM Studio `/v1/chat/completions`와 호환 불가.
+- **#34**: `secall sync`에 `--no-semantic` 플래그 추가. sync.rs:293에서 `no_semantic`이 `false`로 하드코딩되어 크론 실행 시 GPU 메모리 경합 회피 불가.
+
+## Expected Outcome
+
+- `secall graph semantic --backend lmstudio --api-url http://localhost:1234 --model gemma-4-e4b-it` 동작
+- `secall sync --no-semantic` 플래그로 시맨틱 추출 비활성화 가능
+- 기존 ollama/gemini/anthropic/disabled 백엔드 영향 없음
+
+## Subtasks
+
+| # | Title | File | depends_on |
+|---|-------|------|------------|
+| 01 | OpenAI 호환 백엔드 함수 추가 | `p30-openai-sync-no-semantic-34-35-task-01.md` | — |
+| 02 | sync --no-semantic 플래그 추가 | `p30-openai-sync-no-semantic-34-35-task-02.md` | — |
+
+> Task 01, 02는 독립적이며 병렬 실행 가능 (parallel_group: A)
+
+## Constraints
+
+- `extract_with_openai_compat`는 `ollama_url` + `ollama_model` 설정을 재사용 (이슈 #35 제안)
+- OpenAI 응답 파싱은 `choices[0].message.content` 경로
+
+## Non-goals
+
+- vLLM 등을 위한 범용 `openai_compatible` 백엔드명 (lmstudio만)
+- wiki 백엔드에 lmstudio 추가 (#26과 별도)
+- `--no-graph` 플래그 추가 (이슈 #34에서 "이상적"으로 언급했으나 별도 이슈로)

--- a/docs/plans/p31-opencode-json-ingest-36-result.md
+++ b/docs/plans/p31-opencode-json-ingest-36-result.md
@@ -1,0 +1,55 @@
+# Implementation Result: P31 — opencode JSON 세션 ingest 지원 (#36)
+
+> Developer: unknown
+> Branch: N/A
+> Date: 2026-04-26 08:32
+> Plan Revision: 0
+
+---
+
+## Summary
+
+모든 verification 통과.
+
+```
+Verification results for Task 02:
+✅ `cargo test -p secall-core -- ingest::detect::tests::test_detect_opencode_json --exact` — 1 passed
+✅ `cargo test -p secall-core -- ingest::opencode::tests` — 6 passed
+✅ `cargo test --all` — 287 passed (267 lib + 16 bin + 4 integration, 10 ignored)
+✅ `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --all-features` — exit 0
+```
+
+---
+
+## 구현 요약
+
+**Task 01 — AgentKind 확장 + opencode 파서 구현**
+- `types.rs`: `AgentKind::OpenCode` variant + `as_str() → "opencode"` 추가
+- `opencode.rs`: 신규 파서 (serde 모델 8개, `parse_opencode_json()`, 6개 단위 테스트)
+- `mod.rs`: `pub mod opencode;` 등록
+
+**Task 02 — 감지 로직 통합 + 테스트**
+- `detect.rs`: import에 `OpenCodeParser` 추가, content sniffing에서 Gemini보다 앞에 `v["info"]["id"].is_string() && v["messages"].is_array()` 감지 삽입
+- `detect.rs`: `test_detect_opencode_json` 테스트 추가
+
+총 287개 테스트 통과, clippy 경고 0건.
+
+## Subtask Results
+
+### 1. 모든 verification 통과.
+
+```
+Verification results for Task 02:
+✅ `cargo test -p secall-core -- ingest::detect::tests::test_detect_opencode_json --exact` — 1 passed
+✅ `cargo test -p secall-core -- ingest::opencode::tests` — 6 passed
+✅ `cargo test --all` — 287 passed (267 lib + 16 bin + 4 integration, 10 ignored)
+✅ `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --all-features` — exit 0
+```
+
+---
+
+## 구현 요약
+
+**Task 01 — AgentKind 확장 + opencode 파서 구현**
+- `types.rs`: `
+

--- a/docs/plans/p31-opencode-json-ingest-36-review-r1.md
+++ b/docs/plans/p31-opencode-json-ingest-36-review-r1.md
@@ -1,0 +1,28 @@
+# Review Report: P31 — opencode JSON 세션 ingest 지원 (#36) — Round 1
+
+> Verdict: pass
+> Reviewer: 
+> Date: 2026-04-26 08:34
+> Plan Revision: 0
+
+---
+
+## Verdict
+
+**pass**
+
+## Findings
+
+1. 없음
+
+## Recommendations
+
+1. 없음
+
+## Subtask Verification
+
+| # | Subtask | Status |
+|---|---------|--------|
+| 1 | AgentKind 확장 + opencode 파서 구현 | ✅ done |
+| 2 | 감지 로직 통합 + 테스트 | ✅ done |
+

--- a/docs/plans/p35-secall-web-phase-3-result.md
+++ b/docs/plans/p35-secall-web-phase-3-result.md
@@ -1,0 +1,65 @@
+# Implementation Result: P35 — secall-web Phase 3 (성능 + 정확도)
+
+> Developer: unknown
+> Branch: N/A
+> Date: 2026-05-02 22:06
+> Plan Revision: 0
+
+---
+
+## Summary
+
+## P35 Phase 3 완료 (5/5)
+
+**최종 verification 통과:**
+- ✅ `cargo check --all-targets`
+- ✅ `cargo clippy --all-targets --all-features` — 0 warnings
+- ✅ `cargo fmt --check`
+- ✅ `pnpm typecheck`
+- ✅ `cargo test --test rest_listing` — **12 passed** (Task 00의 신규 2개 포함)
+
+**완료된 task:**
+| # | 제목 | 핵심 변경 |
+|---|---|---|
+| 00 | 백엔드 `/api/tags` | session_repo.rs / server.rs / rest.rs + 2 통합 테스트 |
+| 01 | `useAllTags` → `/api/tags` | types.ts / api.ts / allTags.ts (시그니처 호환) |
+| 02 | SessionList 무한 스크롤 | useInfiniteQuery + IntersectionObserver, page_size=100 |
+| 03 | Code-split | 16 chunks, 최대 265 kB (978 kB → 단일에서 ~73% 감소) |
+| 04 | README + CI | Phase 3 섹션, /api/tags 엔드포인트, v0.6.0 changelog |
+
+**번들 분리 결과 (max chunk):**
+- index 265 kB · vendor-radix 216 kB · MarkdownView 157 kB · CommandsRoute 94 kB · vendor-react 89 kB · vendor-viz 51 kB · vendor-query 51 kB · 9개 추가 chunks
+- 초기 진입 (/sessions) ≈ 206 kB gzip — chunk warning 사라짐
+
+**병렬 실행 활용:** Phase A (Task 00 + 02 + 03) 동시 dispatch → Phase B (Task 01) → Phase C (Task 04). 메인 컨텍스트는 머지/검증에만 사용.
+
+다음 단계로 P35용 PR 생성 권장 (현재 PR #38는 P32~34만 포함). 진행하시겠습니까?
+
+## Subtask Results
+
+### 1. ## P35 Phase 3 완료 (5/5)
+
+**최종 verification 통과:**
+- ✅ `cargo check --all-targets`
+- ✅ `cargo clippy --all-targets --all-features` — 0 warnings
+- ✅ `cargo fmt --check`
+- ✅ `pnpm typecheck`
+- ✅ `cargo test --test rest_listing` — **12 passed** (Task 00의 신규 2개 포함)
+
+**완료된 task:**
+| # | 제목 | 핵심 변경 |
+|---|---|---|
+| 00 | 백엔드 `/api/tags` | session_repo.rs / server.rs / rest.rs + 2 통합 테스트 |
+| 01 | `useAllTags` → `/api/tags` | types.ts / api.ts / allTags.ts (시그니처 호환) |
+| 02 | SessionList 무한 스크롤 | useInfiniteQuery + IntersectionObserver, page_size=100 |
+| 03 | Code-split | 16 chunks, 최대 265 kB (978 kB → 단일에서 ~73% 감소) |
+| 04 | README + CI | Phase 3 섹션, /api/tags 엔드포인트, v0.6.0 changelog |
+
+**번들 분리 결과 (max chunk):**
+- index 265 kB · vendor-radix 216 kB · MarkdownView 157 kB · CommandsRoute 94 kB · vendor-react 89 kB · vendor-viz 51 kB · vendor-query 51 kB · 9개 추가 chunks
+- 초기 진입 (/sessions) ≈ 206 kB gzip — chunk warning 사라짐
+
+**병렬 실행 활용:** Phase A (Task 00 + 02 + 03) 동시 dispatch → Phase B (Task 01) → Phase C (Task 04). 메인 컨텍스트는 머지/검증에만 사용.
+
+다음 단계로 P35용 PR 생성 권장 (현재 PR #38는 P32~34만 포함). 진행하시겠습니까?
+

--- a/docs/plans/p35-secall-web-phase-3-review-r1.md
+++ b/docs/plans/p35-secall-web-phase-3-review-r1.md
@@ -1,0 +1,31 @@
+# Review Report: P35 — secall-web Phase 3 (성능 + 정확도) — Round 1
+
+> Verdict: pass
+> Reviewer: 
+> Date: 2026-05-02 22:08
+> Plan Revision: 0
+
+---
+
+## Verdict
+
+**pass**
+
+## Findings
+
+1. 없음
+
+## Recommendations
+
+1. Task 03 문서의 Changed files 목록에 실제 분리된 `web/src/components/SessionEmptyState.tsx`와 `web/src/routes/SessionsRoute.tsx` 보조 수정을 다음 라운드부터 명시하면 구현 계약 추적이 더 명확해집니다.
+
+## Subtask Verification
+
+| # | Subtask | Status |
+|---|---------|--------|
+| 1 | 백엔드 `/api/tags` 엔드포인트 | ✅ done |
+| 2 | web `useAllTags`를 `/api/tags`로 전환 | ✅ done |
+| 3 | SessionList 무한 스크롤 | ✅ done |
+| 4 | Code-split (라우트 + vendor) | ✅ done |
+| 5 | README + CI 업데이트 | ✅ done |
+

--- a/docs/plans/p39-wiki-sync-auto-commit-fix-result.md
+++ b/docs/plans/p39-wiki-sync-auto-commit-fix-result.md
@@ -1,0 +1,39 @@
+# Implementation Result: P39 — Wiki 파이프라인 대규모 실행 검증 + sync auto-commit fix
+
+> Developer: claude
+> Branch: N/A
+> Date: 2026-05-06 10:40
+> Plan Revision: 0
+
+---
+
+## Summary
+
+**Rework 처리 완료**
+
+| 항목 | 변경 |
+|---|---|
+| **Finding** `vault/git.rs:168` (push 경로 stage 누락) | `git add raw/ wiki/ index.md log.md` → `git add -A` (auto_commit 과 동일 패턴) + 코멘트 갱신 |
+| **Recommendation** `p39-p40-decision.md:113-116` (보류 분기 잔존) | 보류 분기 액션 제거, P40 즉시 진행 액션으로 단일화. 결정 명시 헤더 추가 |
+
+Verification:
+- ✅ `cargo test -p secall-core --test vault_auto_commit` — 8 passed
+- ✅ `cargo check -p secall-core` — Finished (0 errors, 0 warnings)
+
+`auto_commit()` 과 `push()` 모두 `git add -A` 동일 패턴 → vault 의 모든 변경 (graph/, log/, SCHEMA.md 포함) 누락 없이 stage. 회귀는 기존 8개 vault_auto_commit 테스트가 underlying primitive 검증.
+
+## Subtask Results
+
+### 1. **Rework 처리 완료**
+
+| 항목 | 변경 |
+|---|---|
+| **Finding** `vault/git.rs:168` (push 경로 stage 누락) | `git add raw/ wiki/ index.md log.md` → `git add -A` (auto_commit 과 동일 패턴) + 코멘트 갱신 |
+| **Recommendation** `p39-p40-decision.md:113-116` (보류 분기 잔존) | 보류 분기 액션 제거, P40 즉시 진행 액션으로 단일화. 결정 명시 헤더 추가 |
+
+Verification:
+- ✅ `cargo test -p secall-core --test vault_auto_commit` — 8 passed
+- ✅ `cargo check -p secall-core` — Finished (0 errors, 0 warnings)
+
+`auto_commit()` 과 `push()` 모두 `git add -A` 동일 패턴 → vault 의 모든 변경 (graph/, log/, SCHEMA.md 포함) 누락 없이 stage. 회귀는 기존 8개 vault_auto_commit 테스트가 underlying primitive 검증.
+

--- a/docs/plans/p39-wiki-sync-auto-commit-fix-review-r1.md
+++ b/docs/plans/p39-wiki-sync-auto-commit-fix-review-r1.md
@@ -1,0 +1,31 @@
+# Review Report: P39 — Wiki 파이프라인 대규모 실행 검증 + sync auto-commit fix — Round 1
+
+> Verdict: fail
+> Reviewer: 
+> Date: 2026-05-06 10:26
+> Plan Revision: 0
+
+---
+
+## Verdict
+
+**fail**
+
+## Findings
+
+1. crates/secall-core/src/vault/git.rs:168 — Task 00은 `auto_commit()`만 `git add -A`로 고쳤지만, sync 마지막 `push()` 경로는 여전히 `raw/`, `wiki/`, `index.md`, `log.md`만 stage합니다. 그래서 sync 도중 생성·수정된 `graph/`, `log/`, `SCHEMA.md` 같은 경로는 이번 실행의 push에 포함되지 않고 다음 sync 시작 시점까지 dirty 상태로 남을 수 있어, Task 00이 문서에서 약속한 "누락 경로를 모두 포착" 목표를 완전히 충족하지 못합니다.
+
+## Recommendations
+
+1. docs/baseline/p39-p40-decision.md:113 — 결정이 `P40 즉시 진행`인데 후속 액션에는 아직 `보류 결정` 분기가 남아 있습니다. 문서 소비자가 헷갈리지 않도록 선택되지 않은 분기는 제거하거나 "비적용"으로 명확히 표시하는 편이 좋습니다.
+
+## Subtask Verification
+
+| # | Subtask | Status |
+|---|---------|--------|
+| 1 | sync auto-commit 로직 fix (hot-fix) | ✅ done |
+| 2 | wiki 파이프라인 baseline 측정 보고서 | ✅ done |
+| 3 | wiki 페이지 품질 spot check | ✅ done |
+| 4 | wiki 콘텐츠 양 측정 + P40 (wiki 벡터화) 우선순위 데이터 | ✅ done |
+| 5 | README + Insight findings + 컨트리뷰터 답변 초안 | ✅ done |
+

--- a/docs/plans/p39-wiki-sync-auto-commit-fix-review-r2.md
+++ b/docs/plans/p39-wiki-sync-auto-commit-fix-review-r2.md
@@ -1,0 +1,27 @@
+# Review Report: P39 — Wiki 파이프라인 대규모 실행 검증 + sync auto-commit fix — Round 2
+
+> Verdict: pass
+> Reviewer: 
+> Date: 2026-05-06 10:40
+> Plan Revision: 0
+
+---
+
+## Verdict
+
+**pass**
+
+## Recommendations
+
+1. `crates/secall-core/tests/vault_auto_commit.rs` 는 `auto_commit()`만 직접 검증합니다. 같은 회귀를 더 단단히 막으려면 `push()` 경로도 `graph/`/`SCHEMA.md`/삭제 파일을 포함해 stage하는지 별도 테스트를 추가하는 편이 좋습니다.
+
+## Subtask Verification
+
+| # | Subtask | Status |
+|---|---------|--------|
+| 1 | sync auto-commit 로직 fix (hot-fix) | ✅ done |
+| 2 | wiki 파이프라인 baseline 측정 보고서 | ✅ done |
+| 3 | wiki 페이지 품질 spot check | ✅ done |
+| 4 | wiki 콘텐츠 양 측정 + P40 (wiki 벡터화) 우선순위 데이터 | ✅ done |
+| 5 | README + Insight findings + 컨트리뷰터 답변 초안 | ✅ done |
+

--- a/docs/plans/secall-refactor-p4-review-r5.md
+++ b/docs/plans/secall-refactor-p4-review-r5.md
@@ -1,0 +1,68 @@
+# Review Report: seCall Refactor P4 — 아키텍처 개선 — Round 5
+
+> Verdict: pass
+> Reviewer: claude (re-review)
+> Date: 2026-04-22
+> Plan Revision: 0
+> Scope: Task 01, Task 03 (이전 리뷰 findings 3건 재검증)
+
+---
+
+## Verdict
+
+**pass**
+
+이전 Round에서 지적된 3개 Finding이 모두 해결되었습니다. Task 01과 Task 03의 Changed files·Change description·Verification 조건을 모두 확인했습니다.
+
+---
+
+## Finding 재검증 결과
+
+### Finding 1 — `SessionParser::parse` 반환 타입 (Task 01)
+
+**이전 지적**: `crates/secall-core/src/ingest/mod.rs:20`의 `SessionParser::parse`가 `anyhow::Result<Session>`을 반환해 Task 01의 typed error 계약이 완결되지 않음.
+
+**확인 결과** — **resolved**:
+- `ingest/mod.rs:21` — `fn parse(&self, path: &Path) -> crate::error::Result<Session>`
+- `ingest/mod.rs:28` — `parse_all` 기본 구현도 `crate::error::Result<Vec<Session>>`
+- 모든 6개 parser 구현(claude, claude_ai, chatgpt, codex, gemini, gemini_web)이 `crate::error::Result<Session>` 시그니처로 전환되었으며, 내부 `parse_*_jsonl/json` 결과를 `SecallError::Parse { path, source }` variant로 래핑해 오류가 typed 계층으로 전파됨. 예: `ingest/claude.rs:24-29`, `ingest/codex.rs:21-26`, `ingest/gemini.rs:19-24`.
+
+### Finding 2 — semantic recall 경로의 오류 삼킴 (Task 01)
+
+**이전 지적**: `crates/secall-core/src/mcp/server.rs:103`에서 `search_with_embedding(...).unwrap_or_default()`로 벡터 오류를 삼키고, 같은 함수의 embed 실패도 로그만 남기고 성공 응답으로 진행해 클라이언트가 장애를 빈 결과로 오인.
+
+**확인 결과** — **resolved**:
+- `mcp/server.rs:83-88` — `search_with_embedding`은 `?` 연산자로 오류 전파. `unwrap_or_default()` 제거됨.
+- `mcp/server.rs:95-97` — embed 실패는 `return Err(anyhow::anyhow!("embedding failed: {e}"))`로 명시적 에러 반환. 더 이상 성공 응답으로 위장되지 않음.
+- `Ok(None)` (Ollama 미설치 등 정상 disable) 경로는 의도적으로 유지되어 정상 상태와 장애 상태가 구분됨.
+
+### Finding 3 — ANN 인덱스 고정 경로·차원 호환성 미검증 (Task 03)
+
+**이전 지적**: `crates/secall-core/src/search/vector.rs:292`에서 ANN 인덱스 파일 경로가 `ann_index.usearch`로 고정되어 embedder 모델/차원 교체 시 stale 인덱스를 로드해 `--vec` 검색이 실패하거나 결과가 누락될 수 있음.
+
+**확인 결과** — **resolved**:
+- `search/vector.rs:480-485` — 파일명이 모델명과 차원을 포함한 `ann_{model}_{dimensions}.usearch` 형식으로 변경됨. 슬래시·콜론은 `_`로 치환되어 파일명 안전성도 확보.
+- `search/vector.rs:474-478` — 차원이 0이면(알 수 없으면) ANN 생성 자체를 건너뜀.
+- 서로 다른 모델/차원은 물리적으로 별도 파일로 분리되므로, 1024↔1536 전환 시 서로의 stale 인덱스를 로드할 수 없음 → 근본 해결.
+- 로드 실패 시 `attach_ann_index`(496-499)에서 graceful fallback 유지.
+
+---
+
+## Subtask Verification
+
+| # | Subtask | 이전 리뷰 | 본 리뷰 |
+|---|---------|----------|---------|
+| 1 | typed error 도입 (SecallError enum) | fail (Finding 1·2) | ✅ pass |
+| 3 | ANN 인덱스 도입 (--vec 전용) | fail (Finding 3) | ✅ pass |
+
+Developer가 보고한 Verification 결과:
+- `cargo check --all` — exit 0
+- `cargo test --all` — 126 passed, 0 failed (포함: mcp, vector, ann 하위 테스트)
+- `cargo clippy --all-targets -- -D warnings` — exit 0
+
+Task 문서에 개별 명령으로 나열된 `cargo test -p secall-core mcp`, `cargo test -p secall-core vector`, `cargo test -p secall-core ann`, `cargo doc -p secall-core --no-deps ... grep SecallError`는 `cargo test --all`·`cargo check --all`이 상위 집합으로 포괄하며, 세 Finding에 대응하는 코드 계약이 모두 코드상 확인되므로 이를 fail 사유로 삼지 않음.
+
+## Recommendations
+
+1. (비차단) 차후 task에서 ANN 인덱스 파일명을 더 엄격하게 스킴화(예: 버전 prefix 포함)하면 사용자 정의 모델 이름 충돌 가능성을 추가로 줄일 수 있음.
+2. (비차단) `do_recall`의 `anyhow::Result` 반환은 후속 task에서 `SecallError` 계층과 통합하면 클라이언트 에러 구분 품질이 더 향상됨.


### PR DESCRIPTION
## Summary

P30~P40 진행 과정에서 자동 생성된 \`docs/insight/findings/\` 와 \`docs/plans/*-result.md / *-review-r*.md\` 파일들이 working tree 에 미커밋 상태로 누적돼 있어 일괄 보존.

- \`docs/insight/findings/*\` — 11건 modified (status/note 업데이트) + 11건 신규 등록
- \`docs/insight/latest-report.md\` — 최신 Insight 보고서 갱신
- \`docs/plans/p30-openai-sync-no-semantic-34-35-{result,review-r1}.md\` 외 task 파일들
- \`docs/plans/p31-opencode-json-ingest-36-{result,review-r1}.md\`
- \`docs/plans/p35-secall-web-phase-3-{result,review-r1}.md\`
- \`docs/plans/p39-wiki-sync-auto-commit-fix-{result,review-r1,review-r2}.md\`
- \`docs/plans/secall-refactor-p4-review-r5.md\`

## Test plan

- [x] CI 빌드 통과 — docs only 변경
- 코드 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)