### PR TITLE
chore: bump v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,7 +3226,7 @@ checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "secall"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "secall-core"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ codegen-units = 1
 strip = true
 
 [workspace.package]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.75"
 license = "AGPL-3.0"


### PR DESCRIPTION
P28~P40 누적 변경 묶음 release. 머지 후 v0.4.0 tag push 예정.