### PR TITLE
fix(web+core): graph 시작 노드 ID prefix + wiki list 를 실존 페이지 기준으로

### DIFF
--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -135,7 +135,7 @@ pub fn rest_router(server: SeCallMcpServer, executor: Arc<JobExecutor>) -> Route
         .route("/api/recall", post(api_recall))
         .route("/api/get", post(api_get))
         .route("/api/status", get(api_status))
-        .route("/api/wiki", post(api_wiki))
+        .route("/api/wiki", post(api_wiki).get(api_wiki_list))
         .route("/api/wiki/{project}", get(api_wiki_get))
         .route("/api/graph", post(api_graph))
         .route("/api/daily", post(api_daily))
@@ -227,6 +227,13 @@ async fn api_wiki(
     Json(p): Json<WikiSearchParams>,
 ) -> impl IntoResponse {
     match s.do_wiki_search(p) {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => error_response(e),
+    }
+}
+
+async fn api_wiki_list(State(s): State<Arc<SeCallMcpServer>>) -> impl IntoResponse {
+    match s.do_wiki_list() {
         Ok(json) => (StatusCode::OK, Json(json)).into_response(),
         Err(e) => error_response(e),
     }

--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -233,9 +233,12 @@ async fn api_wiki(
 }
 
 async fn api_wiki_list(State(s): State<Arc<SeCallMcpServer>>) -> impl IntoResponse {
-    match s.do_wiki_list() {
-        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
-        Err(e) => error_response(e),
+    // do_wiki_list 는 std::fs::read_dir/metadata 동기 호출을 사용하므로 spawn_blocking 으로 감싸
+    // Tokio 워커 스레드를 차단하지 않게 함.
+    match tokio::task::spawn_blocking(move || s.do_wiki_list()).await {
+        Ok(Ok(json)) => (StatusCode::OK, Json(json)).into_response(),
+        Ok(Err(e)) => error_response(e),
+        Err(e) => error_response(anyhow::anyhow!("wiki_list task join: {e}")),
     }
 }
 

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -324,6 +324,53 @@ impl SeCallMcpServer {
         }))
     }
 
+    /// `vault/wiki/projects/*.md` 디렉토리를 스캔해 실제 존재하는 wiki 페이지 목록 반환.
+    /// 응답 형태: `{ "projects": [{"project": "<safe_name>", "updated": "<rfc3339>"}, ...], "count": N }`
+    /// — secall-web 의 좌측 wiki 리스트가 sessions DB 의 distinct project 가 아닌
+    ///   실제 wiki 페이지 기준으로 표시되도록 분리된 endpoint.
+    pub fn do_wiki_list(&self) -> anyhow::Result<serde_json::Value> {
+        let projects_dir = self.vault_path.join("wiki").join("projects");
+        if !projects_dir.exists() {
+            return Ok(serde_json::json!({"projects": [], "count": 0}));
+        }
+
+        let mut projects: Vec<serde_json::Value> = Vec::new();
+        for entry in std::fs::read_dir(&projects_dir)? {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let path = entry.path();
+            if !path.extension().map(|e| e == "md").unwrap_or(false) {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let updated = std::fs::metadata(&path)
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339());
+            projects.push(serde_json::json!({
+                "project": stem,
+                "updated": updated,
+            }));
+        }
+
+        projects.sort_by(|a, b| {
+            a["project"]
+                .as_str()
+                .unwrap_or("")
+                .cmp(b["project"].as_str().unwrap_or(""))
+        });
+
+        let count = projects.len();
+        Ok(serde_json::json!({
+            "projects": projects,
+            "count": count,
+        }))
+    }
+
     pub fn do_wiki_search(&self, params: WikiSearchParams) -> anyhow::Result<serde_json::Value> {
         let mode = params.mode.unwrap_or_default();
         let matches = match mode {

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -341,7 +341,8 @@ impl SeCallMcpServer {
                 Err(_) => continue,
             };
             let path = entry.path();
-            if !path.extension().map(|e| e == "md").unwrap_or(false) {
+            // `.md` 확장자를 가진 디렉토리가 들어올 가능성 차단 (실제 파일만 통과).
+            if !path.is_file() || !path.extension().map(|e| e == "md").unwrap_or(false) {
                 continue;
             }
             let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {

--- a/web/src/hooks/useWiki.ts
+++ b/web/src/hooks/useWiki.ts
@@ -45,3 +45,27 @@ export function useWikiPage(project: string | undefined) {
     retry: false, // 404는 재시도 의미 없음 — 사용자가 다른 프로젝트 누르면 새 쿼리
   });
 }
+
+/**
+ * `vault/wiki/projects/*.md` 실존 페이지 목록 — `GET /api/wiki`.
+ *
+ * 좌측 리스트는 sessions DB 의 distinct project (`/api/projects`) 가 아닌
+ * 실제 wiki 페이지 기준으로 표시해야 클릭 시 404 가 안 남.
+ */
+export interface WikiListItem {
+  project: string;
+  updated: string | null;
+}
+
+export interface WikiListResponse {
+  projects: WikiListItem[];
+  count: number;
+}
+
+export function useWikiList() {
+  return useQuery<WikiListResponse>({
+    queryKey: ["wiki", "list"],
+    queryFn: () => api.wikiList() as Promise<WikiListResponse>,
+    staleTime: 30_000,
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -112,6 +112,9 @@ export const api = {
   wikiSearch: (q: { query: string; limit?: number }) =>
     jfetch<unknown>("/api/wiki", { method: "POST", body: JSON.stringify(q) }),
 
+  /** vault/wiki/projects/*.md 실존 페이지 목록. (sessions DB 의 distinct project 와 별개) */
+  wikiList: () => jfetch<unknown>("/api/wiki", { method: "GET" }),
+
   /** 단일 위키 페이지 본문. 파일 없으면 HTTP 404 → throw. */
   getWikiPage: (project: string) =>
     jfetch<WikiPage>(`/api/wiki/${encodeURIComponent(project)}`),

--- a/web/src/lib/graphStartNode.ts
+++ b/web/src/lib/graphStartNode.ts
@@ -25,9 +25,10 @@ export function useStartNode(): string | null {
     staleTime: 60_000,
   });
 
-  return (
-    explicitFromUrl ??
-    selectedFromStore ??
-    (fallback.data?.items[0]?.id ?? null)
-  );
+  // Backend 의 graph_nodes/edges 는 type prefix 를 포함한 ID(`session:UUID`) 를 사용.
+  // 시작 노드는 항상 session 이므로 raw UUID 에 `session:` 접두를 붙여 backend 와 일치시킨다.
+  // (이후 expand 시엔 backend 응답의 r.node_id 가 이미 prefixed 라 별도 처리 불필요.)
+  const raw =
+    explicitFromUrl ?? selectedFromStore ?? fallback.data?.items[0]?.id ?? null;
+  return raw ? `session:${raw}` : null;
 }

--- a/web/src/lib/graphStartNode.ts
+++ b/web/src/lib/graphStartNode.ts
@@ -30,5 +30,7 @@ export function useStartNode(): string | null {
   // (이후 expand 시엔 backend 응답의 r.node_id 가 이미 prefixed 라 별도 처리 불필요.)
   const raw =
     explicitFromUrl ?? selectedFromStore ?? fallback.data?.items[0]?.id ?? null;
-  return raw ? `session:${raw}` : null;
+  if (!raw) return null;
+  // raw 가 이미 `session:` 접두를 포함한 경우(직접 호출처 등) 중복 접두 방지.
+  return raw.startsWith("session:") ? raw : `session:${raw}`;
 }

--- a/web/src/routes/WikiRoute.tsx
+++ b/web/src/routes/WikiRoute.tsx
@@ -1,7 +1,6 @@
 import { useNavigate, useParams } from "react-router";
 import { Loader2 } from "lucide-react";
-import { useProjects } from "@/hooks/useSessions";
-import { useWikiPage } from "@/hooks/useWiki";
+import { useWikiList, useWikiPage } from "@/hooks/useWiki";
 import { MarkdownView } from "@/components/MarkdownView";
 
 /**
@@ -17,7 +16,7 @@ export default function WikiRoute() {
   const { project } = useParams<{ project?: string }>();
   const navigate = useNavigate();
 
-  const projectsQuery = useProjects();
+  const projectsQuery = useWikiList();
   const wikiQuery = useWikiPage(project);
 
   return (
@@ -39,22 +38,27 @@ export default function WikiRoute() {
           </div>
         )}
         <div className="divide-y divide-border">
-          {projectsQuery.data?.projects.map((p) => (
+          {projectsQuery.data?.projects.map((item) => (
             <button
-              key={p}
+              key={item.project}
               type="button"
-              onClick={() => navigate(`/wiki/${encodeURIComponent(p)}`)}
+              onClick={() => navigate(`/wiki/${encodeURIComponent(item.project)}`)}
               className={`block w-full text-left px-3 py-2 text-sm hover:bg-accent transition-colors ${
-                p === project ? "bg-accent font-medium" : ""
+                item.project === project ? "bg-accent font-medium" : ""
               }`}
             >
-              {p}
+              <div>{item.project}</div>
+              {item.updated && (
+                <div className="text-[10px] text-muted-foreground mt-0.5">
+                  {item.updated.slice(0, 10)}
+                </div>
+              )}
             </button>
           ))}
         </div>
         {projectsQuery.data && projectsQuery.data.projects.length === 0 && (
           <div className="p-3 text-xs text-muted-foreground italic">
-            프로젝트가 없습니다
+            위키 페이지가 없습니다 (vault/wiki/projects/*.md)
           </div>
         )}
       </aside>


### PR DESCRIPTION
## Summary

secall-web 에서 발견된 두 bug 한 묶음 fix.

### 1. 그래프 빈 결과
`graph_nodes/edges` 의 source/target 은 `session:UUID` 형식인데 frontend 가 raw UUID 만 보내 backend 매칭 실패 → 시작 노드 1개만 표시.

- `web/src/lib/graphStartNode.ts`: 시작 노드에 `session:` 접두를 붙여 backend 와 일치.

### 2. Wiki 좌측 리스트의 stale 항목
`WikiRoute` 좌측이 sessions DB 의 distinct project (`/api/projects`) 였어서 옛 "Temp" 같은 프로젝트가 표시되지만 `vault/wiki/projects/Temp.md` 가 없어 클릭 시 404. 실제 wiki 페이지 기준으로 분리.

- backend: `do_wiki_list()` + `GET /api/wiki` 신규 (POST 검색과 method 분리)
- frontend: `useWikiList` hook + `WikiRoute` 좌측 교체, 항목에 last-modified 표시

## Test plan

- [x] `cargo check -p secall-core` — exit 0
- [x] `pnpm typecheck` (web/) — 에러 없음
- [ ] (수동) secall serve 띄우고 그래프 페이지 → 시작 세션 이외 노드 표시 확인
- [ ] (수동) Wiki 페이지 → 좌측에 vault/wiki/projects/*.md 만 표시 + 'Temp' 같은 stale 항목 사라짐 확인

> 머지 후 사용자 환경 반영: `just build` 또는 release v0.4.x 다운로드

🤖 Generated with [Claude Code](https://claude.com/claude-code)