### PR TITLE
feat(sync,ingest): `--no-embed` flag

### DIFF
--- a/crates/secall/src/commands/ingest.rs
+++ b/crates/secall/src/commands/ingest.rs
@@ -33,6 +33,9 @@ pub struct IngestArgs {
     pub force: bool,
     #[serde(default)]
     pub no_semantic: bool,
+    /// vector embedding sub-loop 스킵 (BM25/구조 인덱싱만 수행)
+    #[serde(default)]
+    pub no_embed: bool,
     /// ingest 후 신규 세션을 graph에 자동 증분 추가 (기본: false)
     #[serde(default)]
     pub auto_graph: bool,
@@ -89,6 +92,7 @@ pub async fn run(
     min_turns: usize,
     force: bool,
     no_semantic: bool,
+    no_embed: bool,
     auto_graph: bool,
     format: &OutputFormat,
 ) -> Result<()> {
@@ -121,6 +125,7 @@ pub async fn run(
         min_turns,
         force,
         no_semantic,
+        no_embed,
         format,
         None,
     )
@@ -213,6 +218,7 @@ pub async fn run_with_progress(args: IngestArgs, sink: &dyn ProgressSink) -> Res
         min_turns,
         force,
         no_semantic,
+        no_embed,
         auto_graph,
     } = args;
 
@@ -256,6 +262,7 @@ pub async fn run_with_progress(args: IngestArgs, sink: &dyn ProgressSink) -> Res
         min_turns,
         force,
         no_semantic,
+        no_embed,
         &OutputFormat::Text,
         Some(sink),
     )
@@ -351,6 +358,7 @@ pub async fn ingest_sessions(
     min_turns: usize,
     force: bool,
     no_semantic: bool,
+    no_embed: bool,
     format: &OutputFormat,
     sink: Option<&dyn ProgressSink>,
 ) -> Result<IngestStats> {
@@ -559,7 +567,13 @@ pub async fn ingest_sessions(
     }
 
     // 벡터 인덱싱 일괄 처리 (BM25/vault와 분리하여 체감 속도 개선)
-    if !vector_tasks.is_empty() {
+    if no_embed && !vector_tasks.is_empty() {
+        eprintln!(
+            "Skipping vector embedding for {} session(s) (--no-embed)",
+            vector_tasks.len()
+        );
+    }
+    if !no_embed && !vector_tasks.is_empty() {
         let total = vector_tasks.len();
         eprintln!("Embedding {total} session(s)...");
         let tz = config.timezone();

--- a/crates/secall/src/commands/ingest.rs
+++ b/crates/secall/src/commands/ingest.rs
@@ -105,7 +105,11 @@ pub async fn run(
     // Build search engine (BM25 + optional vector)
     let tok = create_tokenizer(&config.search.tokenizer)
         .map_err(|e| anyhow!("tokenizer init failed: {e}"))?;
-    let vector_indexer = secall_core::search::vector::create_vector_indexer(&config).await;
+    let vector_indexer = if no_embed {
+        None
+    } else {
+        secall_core::search::vector::create_vector_indexer(&config).await
+    };
     let engine = SearchEngine::new(Bm25Indexer::new(tok), vector_indexer);
 
     // Collect paths to ingest
@@ -230,7 +234,11 @@ pub async fn run_with_progress(args: IngestArgs, sink: &dyn ProgressSink) -> Res
 
     let tok = create_tokenizer(&config.search.tokenizer)
         .map_err(|e| anyhow!("tokenizer init failed: {e}"))?;
-    let vector_indexer = secall_core::search::vector::create_vector_indexer(&config).await;
+    let vector_indexer = if no_embed {
+        None
+    } else {
+        secall_core::search::vector::create_vector_indexer(&config).await
+    };
     let engine = SearchEngine::new(Bm25Indexer::new(tok), vector_indexer);
 
     // ── detect phase ──
@@ -572,6 +580,8 @@ pub async fn ingest_sessions(
             "Skipping vector embedding for {} session(s) (--no-embed)",
             vector_tasks.len()
         );
+        // 후속 semantic / wiki 단계가 길어질 수 있어 사용 끝난 핸들 즉시 해제.
+        vector_tasks.clear();
     }
     if !no_embed && !vector_tasks.is_empty() {
         let total = vector_tasks.len();

--- a/crates/secall/src/commands/sync.rs
+++ b/crates/secall/src/commands/sync.rs
@@ -22,6 +22,9 @@ pub struct SyncArgs {
     /// graph 증분 갱신 비활성화 (기본: false → 활성화)
     #[serde(default)]
     pub no_graph: bool,
+    /// vector embedding sub-loop 스킵 (BM25/구조 인덱싱만 수행)
+    #[serde(default)]
+    pub no_embed: bool,
 }
 
 /// `sync` 결과 요약 — REST 응답 / SSE Done payload용.
@@ -49,6 +52,7 @@ pub async fn run(
     no_wiki: bool,
     no_semantic: bool,
     no_graph: bool,
+    no_embed: bool,
 ) -> Result<()> {
     let args = SyncArgs {
         local_only,
@@ -56,6 +60,7 @@ pub async fn run(
         no_wiki,
         no_semantic,
         no_graph,
+        no_embed,
     };
     let _outcome = run_with_progress(args, &super::NoopSink).await?;
     Ok(())
@@ -71,6 +76,7 @@ pub async fn run_with_progress(args: SyncArgs, sink: &dyn ProgressSink) -> Resul
         no_wiki,
         no_semantic,
         no_graph,
+        no_embed,
     } = args;
 
     let config = Config::load_or_default();
@@ -250,7 +256,7 @@ pub async fn run_with_progress(args: SyncArgs, sink: &dyn ProgressSink) -> Resul
     sink.phase_start("ingest").await;
     eprintln!("Ingesting local sessions...");
     sink.message("Ingesting local sessions...").await;
-    let ingest_result = run_auto_ingest(&config, &db, no_semantic, sink).await?;
+    let ingest_result = run_auto_ingest(&config, &db, no_semantic, no_embed, sink).await?;
     eprintln!(
         "  -> {} ingested, {} skipped, {} errors.",
         ingest_result.ingested, ingest_result.skipped, ingest_result.errors
@@ -519,6 +525,7 @@ async fn run_auto_ingest(
     config: &Config,
     db: &Database,
     no_semantic: bool,
+    no_embed: bool,
     sink: &dyn ProgressSink,
 ) -> Result<IngestStats> {
     use secall_core::ingest::detect::{
@@ -558,6 +565,7 @@ async fn run_auto_ingest(
         0,
         false,
         no_semantic,
+        no_embed,
         &OutputFormat::Text,
         Some(sink),
     )

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -209,7 +209,7 @@ enum Commands {
         #[arg(long)]
         no_graph: bool,
 
-        /// Skip vector embedding during ingest phase (BM25/structure indexing only).
+        /// Skip vector embedding during ingest phase (BM25/structure indexing only). Run `secall embed` separately to fill in vectors later.
         #[arg(long)]
         no_embed: bool,
     },

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -54,6 +54,10 @@ enum Commands {
         #[arg(long)]
         no_semantic: bool,
 
+        /// Skip vector embedding (BM25/structure indexing only). Run `secall embed` separately to fill in vectors later.
+        #[arg(long)]
+        no_embed: bool,
+
         /// Automatically run graph incremental extraction for new sessions after ingest
         #[arg(long)]
         auto_graph: bool,
@@ -204,6 +208,10 @@ enum Commands {
         /// Skip graph incremental extraction (default: enabled)
         #[arg(long)]
         no_graph: bool,
+
+        /// Skip vector embedding during ingest phase (BM25/structure indexing only).
+        #[arg(long)]
+        no_embed: bool,
     },
 
     /// Rebuild DB index from vault markdown files
@@ -423,6 +431,7 @@ async fn main() -> anyhow::Result<()> {
             min_turns,
             force,
             no_semantic,
+            no_embed,
             auto_graph,
         } => {
             commands::ingest::run(
@@ -432,6 +441,7 @@ async fn main() -> anyhow::Result<()> {
                 min_turns,
                 force,
                 no_semantic,
+                no_embed,
                 auto_graph,
                 &cli.format,
             )
@@ -519,8 +529,17 @@ async fn main() -> anyhow::Result<()> {
             no_wiki,
             no_semantic,
             no_graph,
+            no_embed,
         } => {
-            commands::sync::run(local_only, dry_run, no_wiki, no_semantic, no_graph).await?;
+            commands::sync::run(
+                local_only,
+                dry_run,
+                no_wiki,
+                no_semantic,
+                no_graph,
+                no_embed,
+            )
+            .await?;
         }
         Commands::Reindex { from_vault } => {
             commands::reindex::run(from_vault)?;


### PR DESCRIPTION
## 요약

`secall sync` / `secall ingest` 에 `--no-embed` 플래그를 추가합니다. 켜면 ingest 흐름에서 vector embedding sub-loop 만 건너뛰고 BM25 / turns / FTS5 인덱싱은 평소대로 진행됩니다. 임베딩은 별도 cycle (`secall embed` 또는 외부 catchup) 에서 채울 수 있습니다.

기존 `--no-semantic` (#34) 과 같은 동기입니다 — embed 백엔드(ollama/ORT) 큐 점유가 sync/ingest critical path 를 막는 상황을 풀기 위함입니다. `--no-semantic` 은 graph semantic edge 추출만 끄고 chunk-level embed 는 그대로 도므로 본 변경과 직교합니다. embed 를 영구 끄는 `embedding.backend = "none"` 옵션은 `secall embed` 자체도 차단하므로 "sync 는 embed 없이, `secall embed` 는 평소대로" 같은 invocation 별 분리에는 부적절합니다.

## 변경

- `crates/secall/src/commands/ingest.rs`: `IngestArgs.no_embed` (`#[serde(default)]`) 를 `run` / `run_with_progress` / `ingest_sessions` 까지 전달합니다. flag 가 켜져 있으면 vector embedding sub-loop 진입 직전에 skip notice 만 stderr 로 띄우고 빠집니다.
- `crates/secall/src/commands/sync.rs`: 같은 형태로 `SyncArgs.no_embed` 를 추가하고 `run_auto_ingest` 까지 전파해 `ingest_sessions` 호출 시 전달합니다.
- `crates/secall/src/main.rs`: `Sync` / `Ingest` 서브커맨드에 `--no-embed` 플래그를 노출합니다.

3 files / +44 / −3.

## 호환성

`#[serde(default)]` 덕분에 새 필드를 모르는 기존 JSON 요청(REST adapter) 도 그대로 deserialize 됩니다.

## 검증

- `secall sync --no-embed`: phase 3 ingest 정상, vector embedding sub-loop 미진입. stderr 에 `Skipping vector embedding for N session(s) (--no-embed)`.
- `secall ingest <jsonl> --no-embed`: 동일.
- 플래그 없을 때 기존 동작 유지.
- `cargo test --all` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` 모두 클린.
