### PR TITLE
feat(embed): turn-level partial healing

### DIFF
--- a/crates/secall-core/src/search/vector.rs
+++ b/crates/secall-core/src/search/vector.rs
@@ -69,21 +69,65 @@ impl VectorIndexer {
         Ok(())
     }
 
+    /// Index a session's vectors, turn-incrementally.
+    ///
+    /// Skips chunks whose `(turn_index, chunk_seq)` already exists in
+    /// `turn_vectors` for this session, and INSERTs only the missing ones.
+    /// No DELETE step — already-embedded turns are preserved across calls,
+    /// so partial commits from prior failures get healed without re-embedding
+    /// the entire session. Re-running with no input changes is a no-op.
+    ///
+    /// Callers that need a wholesale rebuild (e.g. model change) should call
+    /// `db.delete_session_vectors(session_id)` first.
+    /// Cheap dry-run check: does this session have any chunk that would need
+    /// to be embedded? Used by `secall embed` to pre-filter no-op sessions
+    /// (already fully embedded, or every turn is chunker-skip) so the actual
+    /// embed pass shows accurate `[i/total]` progress instead of iterating
+    /// over thousands of fast no-ops.
+    ///
+    /// No DB write, no network — just chunker + a single indexed SELECT.
+    pub fn has_pending_chunks(
+        &self,
+        db: &Database,
+        session: &Session,
+        tz: chrono_tz::Tz,
+    ) -> Result<bool> {
+        let all_chunks = chunk_session(session, tz);
+        if all_chunks.is_empty() {
+            return Ok(false);
+        }
+        let existing_keys = db.get_session_chunk_keys(&session.id)?;
+        Ok(all_chunks
+            .iter()
+            .any(|c| !existing_keys.contains(&(c.turn_index, c.seq))))
+    }
+
     pub async fn index_session(
         &self,
         db: &Database,
         session: &Session,
         tz: chrono_tz::Tz,
     ) -> Result<IndexStats> {
-        let chunks = chunk_session(session, tz);
+        let all_chunks = chunk_session(session, tz);
 
         // Ensure vector table exists
         db.init_vector_table()?;
 
+        // Filter out chunks already embedded for this session.
+        let existing_keys = db.get_session_chunk_keys(&session.id)?;
+        let pending_chunks: Vec<&super::chunker::Chunk> = all_chunks
+            .iter()
+            .filter(|c| !existing_keys.contains(&(c.turn_index, c.seq)))
+            .collect();
+
+        if pending_chunks.is_empty() {
+            return Ok(IndexStats::default());
+        }
+
         // Phase 1: 임베딩 계산 — 트랜잭션 밖에서 수행 (CPU 시간 동안 DB lock 없음)
-        let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
+        let texts: Vec<&str> = pending_chunks.iter().map(|c| c.text.as_str()).collect();
         let batch_size = self.batch_size;
-        let mut embeddings: Vec<Option<Vec<f32>>> = vec![None; chunks.len()];
+        let mut embeddings: Vec<Option<Vec<f32>>> = vec![None; pending_chunks.len()];
         let mut embed_errors = 0usize;
 
         for (batch_idx, text_batch) in texts.chunks(batch_size).enumerate() {
@@ -139,13 +183,14 @@ impl VectorIndexer {
             }
         }
 
-        // 유효한 임베딩이 하나도 없으면 실패, 부분 성공은 허용
+        // 유효한 임베딩이 하나도 없으면 실패, 부분 성공은 허용 — 나머지는 다음
+        // cycle에서 turn-incremental하게 채워진다.
         let valid_count = embeddings.iter().filter(|e| e.is_some()).count();
-        if valid_count == 0 && !chunks.is_empty() {
+        if valid_count == 0 && !pending_chunks.is_empty() {
             return Err(anyhow::anyhow!(
                 "session {} embedding completely failed: 0/{} chunks embedded",
                 &session.id,
-                chunks.len()
+                pending_chunks.len()
             ));
         }
 
@@ -154,23 +199,18 @@ impl VectorIndexer {
                 session_id = %session.id,
                 embedded = valid_count,
                 skipped = embed_errors,
-                total = chunks.len(),
-                "partial embedding — some chunks skipped"
+                pending = pending_chunks.len(),
+                total = all_chunks.len(),
+                "partial embedding — some chunks skipped (will retry next cycle)"
             );
         }
 
-        // Phase 2: DELETE + INSERT — 세션 단위 트랜잭션으로 원자성 보장
-        // INSERT 실패 시 클로저에서 Err 반환 → with_transaction이 ROLLBACK
-        // 중단 시 트랜잭션 미커밋 → DELETE도 롤백 → 기존 상태 유지
+        // Phase 2: INSERT only — DELETE 단계 없음. 이미 임베딩된 chunk는 보존되므로
+        // partial commit이 발생해도 다음 호출이 잔여분만 채운다 (turn-incremental).
         let mut chunks_embedded = 0usize;
 
         db.with_transaction(|| {
-            let deleted = db.delete_session_vectors(&session.id)?;
-            if deleted > 0 {
-                tracing::info!(session_id = %session.id, deleted, "cleaned up partial vectors");
-            }
-
-            for (chunk, emb_opt) in chunks.iter().zip(embeddings.iter()) {
+            for (chunk, emb_opt) in pending_chunks.iter().zip(embeddings.iter()) {
                 if let Some(embedding) = emb_opt {
                     let _rowid = db.insert_vector(
                         embedding,

--- a/crates/secall-core/src/store/vector_repo.rs
+++ b/crates/secall-core/src/store/vector_repo.rs
@@ -237,7 +237,14 @@ impl Database {
         Ok(count as usize)
     }
 
-    /// Sessions that have no rows in turn_vectors
+    /// Sessions with at least one turn missing a vector row.
+    ///
+    /// Anti-joins `turns` against `turn_vectors` on `(session_id, turn_index)`,
+    /// so this catches both fully-unembedded sessions (zero-vec) and partially
+    /// embedded sessions (some turns committed, others missing — e.g. after
+    /// transient embedder failures).
+    ///
+    /// Sessions with zero rows in `turns` are not returned (nothing to embed).
     pub fn find_sessions_without_vectors(&self) -> Result<Vec<String>> {
         let table_exists: i64 = self.conn().query_row(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='turn_vectors'",
@@ -246,13 +253,41 @@ impl Database {
         )?;
 
         let query = if table_exists == 0 {
-            "SELECT id FROM sessions"
+            "SELECT DISTINCT session_id FROM turns"
         } else {
-            "SELECT id FROM sessions WHERE id NOT IN (SELECT DISTINCT session_id FROM turn_vectors)"
+            "SELECT DISTINCT session_id FROM turns AS t \
+             WHERE NOT EXISTS ( \
+                 SELECT 1 FROM turn_vectors AS v \
+                 WHERE v.session_id = t.session_id AND v.turn_index = t.turn_index \
+             )"
         };
 
         let mut stmt = self.conn().prepare(query)?;
         let rows = stmt.query_map([], |row| row.get(0))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Existing `(turn_index, chunk_seq)` pairs already in `turn_vectors` for
+    /// the given session. Used by `index_session` to skip already-embedded
+    /// chunks (turn-incremental healing).
+    pub fn get_session_chunk_keys(
+        &self,
+        session_id: &str,
+    ) -> Result<std::collections::HashSet<(u32, u32)>> {
+        let table_exists: i64 = self.conn().query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='turn_vectors'",
+            [],
+            |r| r.get(0),
+        )?;
+        if table_exists == 0 {
+            return Ok(std::collections::HashSet::new());
+        }
+        let mut stmt = self
+            .conn()
+            .prepare("SELECT turn_index, chunk_seq FROM turn_vectors WHERE session_id = ?1")?;
+        let rows = stmt.query_map([session_id], |row| {
+            Ok((row.get::<_, i64>(0)? as u32, row.get::<_, i64>(1)? as u32))
+        })?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
@@ -273,5 +308,133 @@ impl Database {
         )?;
         let rows = stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ingest::{AgentKind, Role, Session, TokenUsage, Turn};
+    use crate::store::db::Database;
+    use crate::store::{SessionRepo, VectorRepo};
+    use chrono::TimeZone;
+
+    fn make_session(id: &str) -> Session {
+        Session {
+            id: id.to_string(),
+            agent: AgentKind::ClaudeCode,
+            model: None,
+            project: None,
+            cwd: None,
+            git_branch: None,
+            host: None,
+            start_time: chrono::Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap(),
+            end_time: None,
+            turns: vec![],
+            total_tokens: TokenUsage::default(),
+            session_type: "interactive".to_string(),
+        }
+    }
+
+    fn make_turn(idx: u32) -> Turn {
+        Turn {
+            index: idx,
+            role: Role::User,
+            timestamp: None,
+            content: format!("turn {idx} content"),
+            actions: vec![],
+            tokens: None,
+            thinking: None,
+            is_sidechain: false,
+        }
+    }
+
+    /// 한 세션이 일부 turn에만 vector를 가진 경우, anti-join 기반 detection이
+    /// 그 세션을 healing 대상으로 잡아야 한다 (partial commit 잔여분 healing).
+    #[test]
+    fn test_find_sessions_without_vectors_detects_partial() {
+        let db = Database::open_memory().unwrap();
+        db.init_vector_table().unwrap();
+        db.insert_session(&make_session("partial")).unwrap();
+        db.insert_turn("partial", &make_turn(0)).unwrap();
+        db.insert_turn("partial", &make_turn(1)).unwrap();
+        db.insert_turn("partial", &make_turn(2)).unwrap();
+
+        // turn 0, 1만 임베딩됨 — turn 2 누락
+        db.insert_vector(&[1.0_f32, 0.0, 0.0], "partial", 0, 0, "test")
+            .unwrap();
+        db.insert_vector(&[0.0_f32, 1.0, 0.0], "partial", 1, 0, "test")
+            .unwrap();
+
+        let sessions = db.find_sessions_without_vectors().unwrap();
+        assert!(
+            sessions.contains(&"partial".to_string()),
+            "partial session must be returned, got {:?}",
+            sessions
+        );
+    }
+
+    /// 모든 turn에 vector가 있는 세션은 healing 대상에서 제외.
+    #[test]
+    fn test_find_sessions_without_vectors_excludes_complete() {
+        let db = Database::open_memory().unwrap();
+        db.init_vector_table().unwrap();
+        db.insert_session(&make_session("complete")).unwrap();
+        db.insert_turn("complete", &make_turn(0)).unwrap();
+        db.insert_turn("complete", &make_turn(1)).unwrap();
+
+        db.insert_vector(&[1.0_f32, 0.0, 0.0], "complete", 0, 0, "test")
+            .unwrap();
+        db.insert_vector(&[0.0_f32, 1.0, 0.0], "complete", 1, 0, "test")
+            .unwrap();
+
+        let sessions = db.find_sessions_without_vectors().unwrap();
+        assert!(
+            !sessions.contains(&"complete".to_string()),
+            "complete session must be excluded, got {:?}",
+            sessions
+        );
+    }
+
+    /// Vector가 전혀 없는 세션도 잡힌다 (zero-vec — 기존 동작 유지).
+    #[test]
+    fn test_find_sessions_without_vectors_detects_zero() {
+        let db = Database::open_memory().unwrap();
+        db.init_vector_table().unwrap();
+        db.insert_session(&make_session("zero")).unwrap();
+        db.insert_turn("zero", &make_turn(0)).unwrap();
+
+        let sessions = db.find_sessions_without_vectors().unwrap();
+        assert!(sessions.contains(&"zero".to_string()));
+    }
+
+    /// `get_session_chunk_keys`는 해당 세션의 `(turn_index, chunk_seq)` 집합을
+    /// 정확히 반환해 turn-incremental 호출자가 누락 chunk만 골라내도록 한다.
+    #[test]
+    fn test_get_session_chunk_keys_returns_existing_pairs() {
+        let db = Database::open_memory().unwrap();
+        db.init_vector_table().unwrap();
+        db.insert_vector(&[1.0_f32, 0.0, 0.0], "A", 0, 0, "test")
+            .unwrap();
+        db.insert_vector(&[0.0_f32, 1.0, 0.0], "A", 0, 1, "test")
+            .unwrap();
+        db.insert_vector(&[0.0_f32, 0.0, 1.0], "A", 1, 0, "test")
+            .unwrap();
+        // Different session — must not leak in
+        db.insert_vector(&[1.0_f32, 1.0, 0.0], "B", 0, 0, "test")
+            .unwrap();
+
+        let keys = db.get_session_chunk_keys("A").unwrap();
+        assert_eq!(keys.len(), 3);
+        assert!(keys.contains(&(0, 0)));
+        assert!(keys.contains(&(0, 1)));
+        assert!(keys.contains(&(1, 0)));
+        assert!(!keys.contains(&(1, 1)));
+
+        let other = db.get_session_chunk_keys("B").unwrap();
+        assert_eq!(other.len(), 1);
+        assert!(other.contains(&(0, 0)));
+
+        let empty = db.get_session_chunk_keys("missing").unwrap();
+        assert!(empty.is_empty());
     }
 }

--- a/crates/secall-core/src/store/vector_repo.rs
+++ b/crates/secall-core/src/store/vector_repo.rs
@@ -37,6 +37,7 @@ impl VectorRepo for Database {
                 embedding   BLOB NOT NULL
             );
             CREATE INDEX IF NOT EXISTS idx_vectors_session ON turn_vectors(session_id);
+            CREATE INDEX IF NOT EXISTS idx_vectors_session_turn ON turn_vectors(session_id, turn_index);
         ",
         )?;
         Ok(())

--- a/crates/secall/src/commands/embed.rs
+++ b/crates/secall/src/commands/embed.rs
@@ -26,10 +26,48 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
     let batch_size = batch_size.unwrap_or(32);
     let indexer = Arc::new(indexer.with_batch_size(batch_size));
 
+    let tz = config.timezone();
+    let candidate_ids: Vec<String> = db.list_all_session_ids()?;
+
+    // Pre-filter pass — drop sessions whose chunks are all already embedded
+    // (or whose every turn is chunker-skip, e.g. empty content + no thinking
+    // + no ToolUse). Without this filter, --all-sessions iteration would show
+    // misleading [i/N] progress where N is dominated by fast no-ops. The
+    // filter itself is cheap: chunker is in-memory and `get_session_chunk_keys`
+    // hits the indexed `(session_id)` lookup.
+    //
+    // `--all` mode skips the filter — wholesale rebuild applies to every
+    // session unconditionally (model change, corruption recovery).
     let session_ids: Vec<String> = if all {
-        db.list_all_session_ids()?
+        candidate_ids
     } else {
-        db.find_sessions_without_vectors()?
+        let scan_start = Instant::now();
+        let total_candidates = candidate_ids.len();
+        eprintln!("Scanning {total_candidates} session(s) for pending chunks...");
+        let mut filtered: Vec<String> = Vec::new();
+        for sid in &candidate_ids {
+            let session = match db.get_session_for_embedding(sid) {
+                Ok(s) => s,
+                Err(_) => {
+                    // include in real_work so the per-session error path runs
+                    // and the failure surfaces in the embed pass logs
+                    filtered.push(sid.clone());
+                    continue;
+                }
+            };
+            match indexer.has_pending_chunks(&db, &session, tz) {
+                Ok(true) => filtered.push(sid.clone()),
+                Ok(false) => {} // truly no-op, skip silently
+                Err(_) => filtered.push(sid.clone()),
+            }
+        }
+        eprintln!(
+            "  Scan: {} session(s) need embedding, {} skipped no-op (in {:.2}s)",
+            filtered.len(),
+            total_candidates - filtered.len(),
+            scan_start.elapsed().as_secs_f64(),
+        );
+        filtered
     };
 
     if session_ids.is_empty() {
@@ -42,8 +80,6 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
         "Embedding {} session(s) [batch_size={}, concurrency={}]...",
         total, batch_size, concurrency
     );
-
-    let tz = config.timezone();
     let db_path: Arc<PathBuf> = Arc::new(db_path);
     let counter = Arc::new(AtomicUsize::new(0));
     let total_chunks = Arc::new(AtomicUsize::new(0));
@@ -78,6 +114,20 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
                         return;
                     }
                 };
+                // --all: wholesale rebuild — drop existing vectors so that
+                // index_session re-embeds every chunk (e.g. after model change).
+                // Default mode skips this and lets index_session fill only
+                // missing chunks (turn-incremental healing).
+                if all {
+                    if let Err(e) = db.delete_session_vectors(&sid) {
+                        let i = counter.fetch_add(1, Ordering::Relaxed) + 1;
+                        eprintln!(
+                            "  [{i}/{total}] {} — delete-before-rebuild failed: {e}",
+                            &sid[..sid.len().min(8)]
+                        );
+                        return;
+                    }
+                }
                 match indexer.index_session(&db, &session, tz).await {
                     Ok(stats) => {
                         let done = counter.fetch_add(1, Ordering::Relaxed) + 1;

--- a/crates/secall/src/commands/embed.rs
+++ b/crates/secall/src/commands/embed.rs
@@ -13,7 +13,9 @@ use secall_core::{
 
 enum WorkItem {
     /// Default mode — pre-filter loaded the Session, embed pending chunks.
-    Cached(Session),
+    /// Boxed so the enum size doesn't balloon to the Session size for the
+    /// `Rebuild` variant too (clippy `large_enum_variant`).
+    Cached(Box<Session>),
     /// `--all` mode — only sid; the worker reloads the Session after deleting
     /// existing vectors for wholesale rebuild.
     Rebuild(String),
@@ -71,7 +73,7 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
                 }
             };
             match indexer.has_pending_chunks(&db, &session, tz) {
-                Ok(true) => filtered.push(WorkItem::Cached(session)),
+                Ok(true) => filtered.push(WorkItem::Cached(Box::new(session))),
                 Ok(false) => {} // silent skip
                 Err(_) => filtered.push(WorkItem::Rebuild(sid.clone())),
             }
@@ -117,8 +119,8 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
                         return;
                     }
                 };
-                let session = match item {
-                    WorkItem::Cached(s) => s,
+                let session: Session = match item {
+                    WorkItem::Cached(s) => *s,
                     WorkItem::Rebuild(sid) => {
                         // --all (또는 pre-filter 로드 실패) — 기존 vector drop 후 reload
                         if all {

--- a/crates/secall/src/commands/embed.rs
+++ b/crates/secall/src/commands/embed.rs
@@ -6,9 +6,27 @@ use std::time::Instant;
 use anyhow::Result;
 use futures::stream::{self, StreamExt};
 use secall_core::{
+    ingest::Session,
     store::{get_default_db_path, Database},
     vault::Config,
 };
+
+enum WorkItem {
+    /// Default mode — pre-filter loaded the Session, embed pending chunks.
+    Cached(Session),
+    /// `--all` mode — only sid; the worker reloads the Session after deleting
+    /// existing vectors for wholesale rebuild.
+    Rebuild(String),
+}
+
+impl WorkItem {
+    fn id(&self) -> &str {
+        match self {
+            Self::Cached(s) => &s.id,
+            Self::Rebuild(sid) => sid,
+        }
+    }
+}
 
 pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Result<()> {
     let config = Config::load_or_default();
@@ -29,36 +47,33 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
     let tz = config.timezone();
     let candidate_ids: Vec<String> = db.list_all_session_ids()?;
 
-    // Pre-filter pass — drop sessions whose chunks are all already embedded
-    // (or whose every turn is chunker-skip, e.g. empty content + no thinking
-    // + no ToolUse). Without this filter, --all-sessions iteration would show
-    // misleading [i/N] progress where N is dominated by fast no-ops. The
-    // filter itself is cheap: chunker is in-memory and `get_session_chunk_keys`
-    // hits the indexed `(session_id)` lookup.
+    // Pre-filter pass — sessions whose chunks are all already embedded (or
+    // whose every turn is chunker-skip) are dropped, so [i/N] progress reflects
+    // actual work. Loaded Session values are reused by the embed pass to avoid
+    // a second `get_session_for_embedding` round-trip.
     //
-    // `--all` mode skips the filter — wholesale rebuild applies to every
-    // session unconditionally (model change, corruption recovery).
-    let session_ids: Vec<String> = if all {
-        candidate_ids
+    // `--all` skips the pre-filter and only carries sids — wholesale rebuild
+    // deletes vectors and reloads inside the worker.
+    let work_items: Vec<WorkItem> = if all {
+        candidate_ids.into_iter().map(WorkItem::Rebuild).collect()
     } else {
         let scan_start = Instant::now();
         let total_candidates = candidate_ids.len();
         eprintln!("Scanning {total_candidates} session(s) for pending chunks...");
-        let mut filtered: Vec<String> = Vec::new();
+        let mut filtered: Vec<WorkItem> = Vec::new();
         for sid in &candidate_ids {
             let session = match db.get_session_for_embedding(sid) {
                 Ok(s) => s,
                 Err(_) => {
-                    // include in real_work so the per-session error path runs
-                    // and the failure surfaces in the embed pass logs
-                    filtered.push(sid.clone());
+                    // surface failure in the embed pass (worker reload path)
+                    filtered.push(WorkItem::Rebuild(sid.clone()));
                     continue;
                 }
             };
             match indexer.has_pending_chunks(&db, &session, tz) {
-                Ok(true) => filtered.push(sid.clone()),
-                Ok(false) => {} // truly no-op, skip silently
-                Err(_) => filtered.push(sid.clone()),
+                Ok(true) => filtered.push(WorkItem::Cached(session)),
+                Ok(false) => {} // silent skip
+                Err(_) => filtered.push(WorkItem::Rebuild(sid.clone())),
             }
         }
         eprintln!(
@@ -70,12 +85,12 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
         filtered
     };
 
-    if session_ids.is_empty() {
+    if work_items.is_empty() {
         println!("All sessions already embedded.");
         return Ok(());
     }
 
-    let total = session_ids.len();
+    let total = work_items.len();
     eprintln!(
         "Embedding {} session(s) [batch_size={}, concurrency={}]...",
         total, batch_size, concurrency
@@ -85,49 +100,46 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
     let total_chunks = Arc::new(AtomicUsize::new(0));
     let start = Instant::now();
 
-    stream::iter(session_ids)
-        .map(|sid| {
+    stream::iter(work_items)
+        .map(|item| {
             let indexer = Arc::clone(&indexer);
             let db_path = Arc::clone(&db_path);
             let counter = Arc::clone(&counter);
             let total_chunks = Arc::clone(&total_chunks);
             async move {
+                let sid = item.id().to_string();
+                let short = &sid[..sid.len().min(8)];
                 let db = match Database::open(db_path.as_path()) {
                     Ok(d) => d,
                     Err(e) => {
                         let i = counter.fetch_add(1, Ordering::Relaxed) + 1;
-                        eprintln!(
-                            "  [{i}/{total}] {} — db open failed: {e}",
-                            &sid[..sid.len().min(8)]
-                        );
+                        eprintln!("  [{i}/{total}] {short} — db open failed: {e}");
                         return;
                     }
                 };
-                let session = match db.get_session_for_embedding(&sid) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        let i = counter.fetch_add(1, Ordering::Relaxed) + 1;
-                        eprintln!(
-                            "  [{i}/{total}] {} — load failed: {e}",
-                            &sid[..sid.len().min(8)]
-                        );
-                        return;
+                let session = match item {
+                    WorkItem::Cached(s) => s,
+                    WorkItem::Rebuild(sid) => {
+                        // --all (또는 pre-filter 로드 실패) — 기존 vector drop 후 reload
+                        if all {
+                            if let Err(e) = db.delete_session_vectors(&sid) {
+                                let i = counter.fetch_add(1, Ordering::Relaxed) + 1;
+                                eprintln!(
+                                    "  [{i}/{total}] {short} — delete-before-rebuild failed: {e}"
+                                );
+                                return;
+                            }
+                        }
+                        match db.get_session_for_embedding(&sid) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                let i = counter.fetch_add(1, Ordering::Relaxed) + 1;
+                                eprintln!("  [{i}/{total}] {short} — load failed: {e}");
+                                return;
+                            }
+                        }
                     }
                 };
-                // --all: wholesale rebuild — drop existing vectors so that
-                // index_session re-embeds every chunk (e.g. after model change).
-                // Default mode skips this and lets index_session fill only
-                // missing chunks (turn-incremental healing).
-                if all {
-                    if let Err(e) = db.delete_session_vectors(&sid) {
-                        let i = counter.fetch_add(1, Ordering::Relaxed) + 1;
-                        eprintln!(
-                            "  [{i}/{total}] {} — delete-before-rebuild failed: {e}",
-                            &sid[..sid.len().min(8)]
-                        );
-                        return;
-                    }
-                }
                 match indexer.index_session(&db, &session, tz).await {
                     Ok(stats) => {
                         let done = counter.fetch_add(1, Ordering::Relaxed) + 1;
@@ -148,18 +160,14 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
                         };
                         let eta_min = (eta_secs / 60.0).ceil() as u64;
                         eprintln!(
-                            "  [{done}/{total}] {} — {} chunks ({:.1} chunks/s, ETA ~{eta_min}m)",
-                            &sid[..sid.len().min(8)],
+                            "  [{done}/{total}] {short} — {} chunks ({:.1} chunks/s, ETA ~{eta_min}m)",
                             stats.chunks_embedded,
                             rate,
                         );
                     }
                     Err(e) => {
                         let i = counter.fetch_add(1, Ordering::Relaxed) + 1;
-                        eprintln!(
-                            "  [{i}/{total}] {} — embedding failed: {e}",
-                            &sid[..sid.len().min(8)]
-                        );
+                        eprintln!("  [{i}/{total}] {short} — embedding failed: {e}");
                     }
                 }
             }


### PR DESCRIPTION
## 요약

`secall embed` 를 turn / chunk-incremental 동작으로 전환해, P11 review-r1 finding #1 (`docs/plans/secall-p11-review-r1.md`) 의 partial-commit detection gap 을 닫습니다. 이미 임베딩된 chunk 는 `(session_id, turn_index, chunk_seq)` 키로 보존하고 누락된 chunk 만 INSERT 하므로, 이전 cycle 의 partial commit 이 다음 cycle 에서 자연스럽게 healing 됩니다.

## 배경

P11 은 *세션 단위 트랜잭션* (DELETE → INSERT all → COMMIT) 으로 atomic 보장을 의도했고, `find_sessions_without_vectors()` 는 그 가정 위에서 `id NOT IN (...)` 단순 query 를 유지했습니다. 그러나 `index_session()` 은 일부 chunk 임베딩 실패를 `tracing::warn!` 만 남기고 partial commit 을 진행하기 때문에 (`crates/secall-core/src/search/vector.rs:144-160`), partial 세션이 누적되며 detection 에는 done 으로 잡힙니다. P11 R1 finding #1 이 이 gap 을 지적했지만 R3 통과 시점까지 closure 되지 않았습니다.

본 PR 은 partial commit 을 받아들이고 healing 단위를 chunk-level 로 좁힙니다 — 실제 embedder 실패가 chunk-granular 이므로 session 단위 retry 는 blast radius 가 부적절합니다.

## 변경

- `crates/secall-core/src/store/vector_repo.rs`: 새 헬퍼 `get_session_chunk_keys(session_id) -> HashSet<(u32, u32)>`. `find_sessions_without_vectors()` 는 `(session_id, turn_index)` anti-join 으로 바꿔 turn-level partial 까지 검출. 단위 테스트 4개 추가.
- `crates/secall-core/src/search/vector.rs`: `index_session()` 진입 시 `get_session_chunk_keys()` 로 누락 chunk 만 골라 embed + INSERT. `delete_session_vectors` 호출 제거 — pending 이 비면 fast no-op. 새 헬퍼 `has_pending_chunks` 는 dry-run 체크. `embed_errors > 0` 은 그대로 허용하고 잔여분은 다음 cycle 이 자가 회수.
- `crates/secall/src/commands/embed.rs`: 후보 리스트는 `list_all_session_ids()` 로 잡되 `has_pending_chunks` dry-run pre-filter 로 실제 작업 세션만 남겨 `[i/total]` progress 가 정확. `--all` (wholesale rebuild) 은 명시적으로 `db.delete_session_vectors()` 를 선호출 — 모델 변경 / corruption recovery 의미 보존.

## 호환성

- `find_sessions_without_vectors()` 시그니처 동일. 의미만 "zero-vec only" → "missing any turn vector" 로 확장. in-tree 호출자는 `crates/secall-core/src/ingest/lint.rs:214` (lint L004) 뿐이며 메시지 의미는 자연스럽게 유지됩니다.
- `index_session()` 시그니처 동일. 공개 계약은 "rebuild" → "fill missing" 으로 변경. wholesale rebuild 호출자는 `delete_session_vectors()` 선호출 (`--all` 경로가 in-tree 예시).

## 검증

- `secall embed`: partial 세션 healing. 같은 입력 두 번째 실행은 dry-run scan 후 "All sessions already embedded." 로 빠른 종료.
- `secall embed --all`: 기존 동작 (전 세션 / 전 chunk 재구축).
- `cargo test --all` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` 클린.
