### PR TITLE
feat(config): P51 — graph/log 디폴트 백엔드를 ollama_cloud 로 + wiki review 를 haiku

### DIFF
--- a/crates/secall-core/src/llm/defaults.rs
+++ b/crates/secall-core/src/llm/defaults.rs
@@ -7,7 +7,8 @@ pub const GRAPH_ANTHROPIC_DEFAULT: &str = "claude-haiku-4-5-20251001";
 pub const GRAPH_OLLAMA_CLOUD_DEFAULT: &str = "gemma4:31b-cloud";
 pub const WIKI_CLAUDE_DEFAULT: &str = "sonnet";
 pub const WIKI_CODEX_DEFAULT: &str = "gpt-5.4";
-pub const WIKI_REVIEW_DEFAULT: &str = "sonnet";
+// P51: review 는 짧은 issue 분류 작업이라 sonnet → haiku 로 강등 (속도/비용↓).
+pub const WIKI_REVIEW_DEFAULT: &str = "haiku";
 pub const LOG_OLLAMA_DEFAULT: &str = GRAPH_OLLAMA_DEFAULT;
 pub const LOG_OLLAMA_CLOUD_DEFAULT: &str = "kimi-k2.6:cloud";
 pub const LOG_CONTEXT_CHAR_LIMIT: usize = 400_000;

--- a/crates/secall-core/src/vault/config.rs
+++ b/crates/secall-core/src/vault/config.rs
@@ -188,7 +188,10 @@ impl Default for GraphConfig {
     fn default() -> Self {
         GraphConfig {
             semantic: true,
-            semantic_backend: "ollama".to_string(),
+            // P51: cloud 우선 (`OLLAMA_CLOUD_API_KEY` 또는 `[graph].cloud_api_key`
+            // 가 설정돼 있어야 동작). 키 없으면 호출 시 명시 에러로 실패한다.
+            // local 강제 시 config 에 `semantic_backend = "ollama"` 명시.
+            semantic_backend: "ollama_cloud".to_string(),
             ollama_url: None,
             ollama_model: None,
             anthropic_model: None,
@@ -199,10 +202,14 @@ impl Default for GraphConfig {
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct LogConfig {
-    /// Daily log backend (None이면 graph.semantic_backend → "ollama" 폴백)
+    /// Daily log backend.
+    ///
+    /// P51: 디폴트는 `Some("ollama_cloud")` — cloud 우선. None 이면 호출자가
+    /// `graph.semantic_backend` 로 폴백한다. config 에 명시한 값이 있으면 그것을
+    /// 사용한다.
     pub backend: Option<String>,
     /// Model override for the selected log backend
     pub model: Option<String>,
@@ -216,6 +223,21 @@ pub struct LogConfig {
     pub cloud_model: Option<String>,
     /// Ollama Cloud API key (config field; env OLLAMA_CLOUD_API_KEY 우선)
     pub cloud_api_key: Option<String>,
+}
+
+impl Default for LogConfig {
+    fn default() -> Self {
+        LogConfig {
+            // P51: cloud 우선. `OLLAMA_CLOUD_API_KEY` 가 설정돼 있어야 실 동작.
+            backend: Some("ollama_cloud".to_string()),
+            model: None,
+            api_url: None,
+            max_tokens: None,
+            cloud_host: None,
+            cloud_model: None,
+            cloud_api_key: None,
+        }
+    }
 }
 
 /// 단일 세션 분류 규칙

--- a/crates/secall-core/tests/llm_defaults.rs
+++ b/crates/secall-core/tests/llm_defaults.rs
@@ -12,7 +12,7 @@ fn llm_default_constants_match_expected_values() {
     assert_eq!(GRAPH_OLLAMA_CLOUD_DEFAULT, "gemma4:31b-cloud");
     assert_eq!(WIKI_CLAUDE_DEFAULT, "sonnet");
     assert_eq!(WIKI_CODEX_DEFAULT, "gpt-5.4");
-    assert_eq!(WIKI_REVIEW_DEFAULT, "sonnet");
+    assert_eq!(WIKI_REVIEW_DEFAULT, "haiku");
     assert_eq!(LOG_OLLAMA_DEFAULT, GRAPH_OLLAMA_DEFAULT);
     assert_eq!(LOG_OLLAMA_CLOUD_DEFAULT, "kimi-k2.6:cloud");
 }


### PR DESCRIPTION
## Summary

사용자 환경에 `OLLAMA_CLOUD_API_KEY` 보유 + Ollama Cloud 사용량이 후하므로 **graph 추출 / log 일기 생성 디폴트를 cloud 백엔드로 변경**. 또 wiki review 는 짧은 issue 분류 작업이라 **sonnet → haiku 로 강등**.

## 변경

### Cloud 우선 디폴트 (`vault/config.rs`)

| 영역 | Before | After | Cloud 모델 (기존 `GRAPH/LOG_OLLAMA_CLOUD_DEFAULT`) |
|------|--------|-------|---|
| `GraphConfig::default().semantic_backend` | `"ollama"` (local) | **`"ollama_cloud"`** | `gemma4:31b-cloud` (256K context, multimodal) |
| `LogConfig::default().backend` | `None` (→ graph fallback) | **`Some("ollama_cloud")`** | `kimi-k2.6:cloud` (128K context, 한국어 강함, MoE) |

### 디폴트 모델 강등 (`llm/defaults.rs`)

| 상수 | Before | After |
|------|--------|-------|
| `WIKI_REVIEW_DEFAULT` | `"sonnet"` | **`"haiku"`** |

## 이유 / 배경

- 사용자가 검토 의뢰: 디폴트 모델이 적당한지 평가
- local `gemma4:e4b` (4B effective) 가 graph 의 구조화 JSON 출력 + relation 분류 정확도 우려, 같은 모델 fallback 으로 log 의 한국어 일기 (400k char 컨텍스트) 처리도 부담
- Ollama Cloud 의 사용량 정책이 후함 + 사용자가 키 보유 → cloud 디폴트가 합리
- review 는 짧은 분류라 sonnet 풀파워 불필요. haiku 가 속도 2-3배 + 비용↓

## Cloud 모델 후보 (검토 후 선택)

`https://ollama.com/search?c=cloud` 의 cloud 태그 모델들 (2026-05 기준):
- **kimi-k2.6:cloud** (3주 전, 멀티모달 agentic) — log 디폴트 ✓
- **gemma4:31b-cloud** (1개월 전, 256K context) — graph 디폴트 ✓
- deepseek-v4-flash:cloud (2주 전, 1M context) — 향후 옵션
- deepseek-v4-pro:cloud (2주 전, frontier) — 향후 옵션
- qwen3.5 (cloud 변종 확인 중)

## Breaking change

디폴트 변경으로 `OLLAMA_CLOUD_API_KEY` 없는 외부 사용자는 첫 graph/log 호출 시 명시 에러로 실패. 키 없는 환경에서는 config 에 명시 필요:

```toml
[graph]
semantic_backend = "ollama"

[log]
backend = "ollama"
```

local 디폴트 상수 (`GRAPH_OLLAMA_DEFAULT = "gemma4:e4b"`, `LOG_OLLAMA_DEFAULT = "gemma4:e4b"`) 는 그대로 유지 — 명시적 local 사용 시 fallback. README 안내는 후속 PR.

## Test plan

- [x] `cargo test --lib -p secall-core` — 407/407 pass
- [x] `cargo test --lib -p secall` — 27/27 pass
- [x] `RUSTFLAGS=-Dwarnings cargo check` — 경고 0
- [ ] CI ubuntu/windows pass
- [ ] (manual) `secall sync` 실행 시 graph extraction 이 cloud 로 호출되는지 + log 가 cloud 로 생성되는지 확인
- [ ] (manual) `secall wiki update --review` 시 review 가 haiku 로 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)