### PR TITLE
fix(wiki): P52 — 4 백엔드 generate() 에 300s timeout 추가 (hang 회피)

### DIFF
--- a/crates/secall-core/src/wiki/claude.rs
+++ b/crates/secall-core/src/wiki/claude.rs
@@ -46,7 +46,15 @@ impl WikiBackend for ClaudeBackend {
             stdin.shutdown().await?;
         }
 
-        let output = child.wait_with_output().await?;
+        // P52: claude CLI 가 stream / internal lock 으로 hang 하는 사례 회피.
+        // wiki 생성은 review 보다 출력이 길어 300s 한도. kill_on_drop=true 라
+        // timeout 시 자동 SIGKILL.
+        let output = tokio::time::timeout(
+            std::time::Duration::from_secs(300),
+            child.wait_with_output(),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("claude wiki generation timed out after 300s"))??;
         if !output.status.success() {
             anyhow::bail!("claude exited with code {:?}", output.status.code());
         }

--- a/crates/secall-core/src/wiki/codex.rs
+++ b/crates/secall-core/src/wiki/codex.rs
@@ -47,7 +47,10 @@ impl WikiBackend for CodexBackend {
             stdin.shutdown().await?;
         }
 
-        let status = child.wait().await?;
+        // P52: codex CLI 가 hang 하는 사례 회피. 300s 한도, kill_on_drop=true.
+        let status = tokio::time::timeout(std::time::Duration::from_secs(300), child.wait())
+            .await
+            .map_err(|_| anyhow::anyhow!("codex wiki generation timed out after 300s"))??;
         if !status.success() {
             anyhow::bail!("codex exited with code {:?}", status.code());
         }

--- a/crates/secall-core/src/wiki/lmstudio.rs
+++ b/crates/secall-core/src/wiki/lmstudio.rs
@@ -15,7 +15,10 @@ impl WikiBackend for LmStudioBackend {
     }
 
     async fn generate(&self, prompt: &str) -> anyhow::Result<String> {
-        let client = reqwest::Client::new();
+        // P52: LM Studio server hang 회피. wiki 생성은 출력이 길어 300s 한도.
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(300))
+            .build()?;
         let resp = client
             .post(format!("{}/v1/chat/completions", self.api_url))
             .json(&serde_json::json!({

--- a/crates/secall-core/src/wiki/ollama.rs
+++ b/crates/secall-core/src/wiki/ollama.rs
@@ -16,7 +16,10 @@ impl WikiBackend for OllamaBackend {
     }
 
     async fn generate(&self, prompt: &str) -> anyhow::Result<String> {
-        let client = reqwest::Client::new();
+        // P52: ollama server hang 회피. wiki 생성은 출력이 길어 300s 한도.
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(300))
+            .build()?;
         let mut req =
             client
                 .post(format!("{}/api/generate", self.api_url))


### PR DESCRIPTION
## Summary

wiki 생성이 CLI / HTTP server 의 hang 으로 **무한 대기**하는 사례를 차단. 사용자 보고: "sonnet 이 계속 로딩됐다" 의 root cause.

## 직전 상태 (4 backend 모두 timeout 없음)

| Backend | 호출 | timeout |
|---------|------|---------|
| `ClaudeBackend.generate()` | `child.wait_with_output().await?` | ❌ |
| `CodexBackend.generate()` | `child.wait().await?` | ❌ |
| `OllamaBackend.generate()` | `reqwest::Client::new()` | ❌ |
| `LmStudioBackend.generate()` | `reqwest::Client::new()` | ❌ |

(비교: `wiki/reviewers/claude.rs` 60s ✓, `wiki/haiku.rs` 120s ✓, `graph/llm.rs` 120s ✓ — review/graph 만 timeout 적용돼 있고 generation 만 누락)

## 변경

4 backend 모두 **300s timeout**:
- subprocess: `tokio::time::timeout(300s, child.wait_with_output()/wait())`
- HTTP: `reqwest::Client::builder().timeout(300s).build()?`
- `kill_on_drop(true)` 이미 설정 → timeout 시 자동 SIGKILL
- timeout 만료 시 명시 에러 (`"... wiki generation timed out after 300s"`)

300s 선정: review (60s) 보다 출력 길고, graph llm.rs (120s) 보다 wiki 본문 더 김. claude/codex CLI 의 큰 페이지 생성 + ollama 긴 prompt 처리 마진.

## Test plan

- [x] `cargo test` (전체) — 0 failed
- [x] `RUSTFLAGS=-Dwarnings cargo check` — 경고 0
- [x] `cargo fmt --all -- --check` — 형식 OK
- [ ] CI ubuntu/windows pass
- [ ] (manual) `secall wiki update` 실행 시 정상 종료
- [ ] (manual) 의도적 hang 시뮬레이션 시 300s 후 명시 에러

🤖 Generated with [Claude Code](https://claude.com/claude-code)