### PR TITLE
fix(wiki): P53 — --since 옵션을 target 표시에 반영

### DIFF
--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -55,13 +55,7 @@ pub async fn run_with_progress(
         .backend
         .clone()
         .unwrap_or_else(|| "(default)".to_string());
-    let target_label = if let Some(sid) = args.session.as_deref() {
-        format!("session:{}", &sid[..sid.len().min(8)])
-    } else if let Some(s) = args.since.as_deref() {
-        format!("sessions since {s}")
-    } else {
-        "all sessions".to_string()
-    };
+    let target_label = build_target_label(args.session.as_deref(), args.since.as_deref());
 
     sink.phase_start("prompt_build").await;
     sink.message(&format!(
@@ -213,13 +207,7 @@ async fn run_update_with_sink(
 
     // P53: --since 옵션을 target 표시에도 반영 (이전: session 만 보고, since 는
     // 무조건 "all sessions" 로 표시되어 사용자 혼란).
-    let target = if let Some(sid) = session {
-        format!("session {}", &sid[..sid.len().min(8)])
-    } else if let Some(s) = since {
-        format!("sessions since {s}")
-    } else {
-        "all sessions".to_string()
-    };
+    let target = build_target_label(session, since);
     eprintln!("Wiki update: {} (backend: {})", target, backend_name);
 
     // 5. WikiBackend 인스턴스 생성
@@ -1025,6 +1013,19 @@ fn resolve_session_id(db: &Database, prefix: &str) -> Result<String> {
             prefix,
             n
         ),
+    }
+}
+
+/// P53 + Gemini: wiki update 의 target 표시 라벨. session > since > "all sessions"
+/// 우선순위. `run_with_progress` (REST/job sink 측) 과 `run_update_with_sink`
+/// (CLI stderr 측) 양쪽에서 사용 — 중복 제거 + format 통일 (모두 `session {}`).
+fn build_target_label(session: Option<&str>, since: Option<&str>) -> String {
+    if let Some(sid) = session {
+        format!("session {}", &sid[..sid.len().min(8)])
+    } else if let Some(s) = since {
+        format!("sessions since {s}")
+    } else {
+        "all sessions".to_string()
     }
 }
 

--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -55,11 +55,13 @@ pub async fn run_with_progress(
         .backend
         .clone()
         .unwrap_or_else(|| "(default)".to_string());
-    let target_label = args
-        .session
-        .as_deref()
-        .map(|s| format!("session:{}", &s[..s.len().min(8)]))
-        .unwrap_or_else(|| "all sessions".to_string());
+    let target_label = if let Some(sid) = args.session.as_deref() {
+        format!("session:{}", &sid[..sid.len().min(8)])
+    } else if let Some(s) = args.since.as_deref() {
+        format!("sessions since {s}")
+    } else {
+        "all sessions".to_string()
+    };
 
     sink.phase_start("prompt_build").await;
     sink.message(&format!(
@@ -209,8 +211,12 @@ async fn run_update_with_sink(
         return Ok(pages_written);
     }
 
+    // P53: --since 옵션을 target 표시에도 반영 (이전: session 만 보고, since 는
+    // 무조건 "all sessions" 로 표시되어 사용자 혼란).
     let target = if let Some(sid) = session {
         format!("session {}", &sid[..sid.len().min(8)])
+    } else if let Some(s) = since {
+        format!("sessions since {s}")
     } else {
         "all sessions".to_string()
     };


### PR DESCRIPTION
## Summary

`secall wiki update --since 2026-05-13` 실행 시 stderr 가 `Wiki update: all sessions (backend: claude)` 로 표시되어 since 옵션이 무시되는 듯한 인상. P51/P52 실 환경 모니터링 중 발견.

## 변경

target / target_label 결정부에 since 분기 추가:

```rust
let target = if let Some(sid) = session {
    format!("session {}", &sid[..sid.len().min(8)])
} else if let Some(s) = since {
    format!("sessions since {s}")
} else {
    "all sessions".to_string()
};
```

두 위치 동일 fix:
- `run_with_progress` (P36 progress 보고 측 target_label)
- `run_update_with_sink` (stderr 메시지 측 target)

## 범위

표시만 정정. prompt 측 since 처리 (load_batch_prompt 의 append) 는 기존 그대로 — claude/codex 가 prompt 안의 since 텍스트를 어느 정도 해석하는지는 LLM 측 책임.

## Test plan

- [x] `cargo test` 전체 0 failed
- [x] `RUSTFLAGS=-Dwarnings cargo check` 경고 0
- [x] `cargo fmt --all -- --check` OK
- [ ] CI ubuntu/windows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)