### PR TITLE
feat(lint): P54 — --fix-orphan-vault 옵션 (L002 orphan vault md 를 archive 로 이동)

### DIFF
--- a/crates/secall/src/commands/lint.rs
+++ b/crates/secall/src/commands/lint.rs
@@ -74,9 +74,10 @@ pub fn run(json: bool, errors_only: bool, fix: bool, fix_orphan_vault: bool) -> 
         run_fix_orphan_vault(&config, &report)?;
     }
 
-    // Exit with code 1 if there are errors (after fix, re-count)
-    let remaining_errors = if fix || fix_orphan_vault {
-        // Re-run lint to get updated count
+    // Exit with code 1 if there are errors (after fix, re-count).
+    // Gemini PR #63: fix_orphan_vault 만 사용 시 L002(Warn) 처리라
+    // errors 카운트에 영향 없음 → 불필요한 rerun 회피.
+    let remaining_errors = if fix {
         let updated = run_lint(&db, &config)?;
         updated.summary.errors
     } else {
@@ -142,7 +143,12 @@ fn run_fix_orphan_vault(
         return Ok(());
     }
 
-    let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    // Gemini PR #63: archive 디렉토리 날짜를 system UTC 가 아닌 config.output.timezone
+    // 기준으로 — 다른 vault 출력 (raw md frontmatter date 등) 과 일관.
+    let today = chrono::Utc::now()
+        .with_timezone(&config.timezone())
+        .format("%Y-%m-%d")
+        .to_string();
     let archive_root = config
         .vault
         .path

--- a/crates/secall/src/commands/lint.rs
+++ b/crates/secall/src/commands/lint.rs
@@ -5,7 +5,7 @@ use secall_core::{
     vault::Config,
 };
 
-pub fn run(json: bool, errors_only: bool, fix: bool) -> Result<()> {
+pub fn run(json: bool, errors_only: bool, fix: bool, fix_orphan_vault: bool) -> Result<()> {
     let config = Config::load_or_default();
     let db_path = get_default_db_path();
     let db = Database::open(&db_path)?;
@@ -16,6 +16,9 @@ pub fn run(json: bool, errors_only: bool, fix: bool) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&report)?);
         if fix {
             run_fix(&db, &report)?;
+        }
+        if fix_orphan_vault {
+            run_fix_orphan_vault(&config, &report)?;
         }
         return Ok(());
     }
@@ -66,8 +69,13 @@ pub fn run(json: bool, errors_only: bool, fix: bool) -> Result<()> {
         run_fix(&db, &report)?;
     }
 
+    // P54 --fix-orphan-vault: L002 (vault md 가 DB 에 없는 경우) 를 archive 로 이동
+    if fix_orphan_vault {
+        run_fix_orphan_vault(&config, &report)?;
+    }
+
     // Exit with code 1 if there are errors (after fix, re-count)
-    let remaining_errors = if fix {
+    let remaining_errors = if fix || fix_orphan_vault {
         // Re-run lint to get updated count
         let updated = run_lint(&db, &config)?;
         updated.summary.errors
@@ -111,4 +119,182 @@ fn run_fix(db: &Database, report: &secall_core::ingest::lint::LintReport) -> Res
     }
     eprintln!("[fix] Done. {} record(s) removed.", stale.len());
     Ok(())
+}
+
+/// P54: L002 finding 의 orphan vault md (DB 에 session 없음) 를 archive 디렉토리로 이동.
+///
+/// **삭제하지 않고 이동** — 사용자 의도 외 데이터 손실 회피. archive 경로:
+/// `<vault.path>/archive/orphan-<YYYY-MM-DD>/<원래 상대경로>`.
+/// 다시 ingest 하면 자동으로 raw/.sessions/ 에 복귀.
+fn run_fix_orphan_vault(
+    config: &Config,
+    report: &secall_core::ingest::lint::LintReport,
+) -> Result<()> {
+    let orphans: Vec<&str> = report
+        .findings
+        .iter()
+        .filter(|f| f.code == "L002")
+        .filter_map(|f| f.path.as_deref())
+        .collect();
+
+    if orphans.is_empty() {
+        eprintln!("[fix-orphan-vault] No orphan vault files.");
+        return Ok(());
+    }
+
+    let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let archive_root = config
+        .vault
+        .path
+        .join("archive")
+        .join(format!("orphan-{today}"));
+
+    eprintln!(
+        "[fix-orphan-vault] Moving {} orphan vault file(s) → {}",
+        orphans.len(),
+        archive_root.display()
+    );
+
+    let mut moved = 0usize;
+    let mut failed = 0usize;
+    for src_str in &orphans {
+        let src = std::path::PathBuf::from(src_str);
+        // relative path 추출 — vault.path 기준
+        let rel = match src.strip_prefix(&config.vault.path) {
+            Ok(r) => r.to_path_buf(),
+            // 절대경로 매칭 실패 시 파일명만 사용 (안전 fallback)
+            Err(_) => src
+                .file_name()
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|| src.clone()),
+        };
+        let dst = archive_root.join(&rel);
+        if let Some(parent) = dst.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                eprintln!("  failed to create dir {}: {e}", parent.display());
+                failed += 1;
+                continue;
+            }
+        }
+        match std::fs::rename(&src, &dst) {
+            Ok(()) => {
+                eprintln!(
+                    "  moved {} → archive/orphan-{today}/{}",
+                    src.display(),
+                    rel.display()
+                );
+                moved += 1;
+            }
+            Err(e) => {
+                eprintln!("  failed to move {}: {e}", src.display());
+                failed += 1;
+            }
+        }
+    }
+
+    eprintln!("[fix-orphan-vault] Done. {moved} moved, {failed} failed.",);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secall_core::ingest::lint::{LintFinding, LintReport, LintSummary};
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn empty_summary() -> LintSummary {
+        LintSummary {
+            total_sessions: 0,
+            errors: 0,
+            warnings: 0,
+            info: 0,
+            agents: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_run_fix_orphan_vault_moves_files_to_archive() {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path().to_path_buf();
+        std::fs::create_dir_all(vault.join("raw/.sessions/2026-05-01")).unwrap();
+        let md = vault.join("raw/.sessions/2026-05-01/claude-code_test_abc12345.md");
+        std::fs::write(&md, "---\ntype: session\n---\n# test").unwrap();
+
+        let mut config = Config::default();
+        config.vault.path = vault.clone();
+
+        let report = LintReport {
+            findings: vec![LintFinding {
+                code: "L002".to_string(),
+                severity: Severity::Warn,
+                message: "vault file exists but no DB record".to_string(),
+                session_id: Some("abc12345".to_string()),
+                path: Some(md.to_string_lossy().to_string()),
+            }],
+            summary: empty_summary(),
+        };
+
+        run_fix_orphan_vault(&config, &report).unwrap();
+
+        // 원본 파일이 사라졌는지
+        assert!(!md.exists(), "원본 md 가 이동됐어야 함");
+
+        // archive/orphan-{today}/raw/.sessions/.../ 로 옮겨졌는지
+        let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        let moved = vault
+            .join("archive")
+            .join(format!("orphan-{today}"))
+            .join("raw/.sessions/2026-05-01/claude-code_test_abc12345.md");
+        assert!(moved.exists(), "archive 안으로 이동: {}", moved.display());
+    }
+
+    #[test]
+    fn test_run_fix_orphan_vault_no_findings_does_nothing() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.vault.path = tmp.path().to_path_buf();
+
+        let report = LintReport {
+            findings: vec![],
+            summary: empty_summary(),
+        };
+
+        run_fix_orphan_vault(&config, &report).unwrap();
+
+        // L002 finding 없으면 archive 디렉토리도 만들지 않음
+        assert!(!tmp.path().join("archive").exists());
+    }
+
+    #[test]
+    fn test_run_fix_orphan_vault_ignores_non_l002_findings() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.vault.path = tmp.path().to_path_buf();
+
+        // L001 / L003 만 있으면 무시
+        let report = LintReport {
+            findings: vec![
+                LintFinding {
+                    code: "L001".to_string(),
+                    severity: Severity::Error,
+                    message: "vault file missing".to_string(),
+                    session_id: Some("xyz".to_string()),
+                    path: None,
+                },
+                LintFinding {
+                    code: "L003".to_string(),
+                    severity: Severity::Error,
+                    message: "duplicate".to_string(),
+                    session_id: Some("dup".to_string()),
+                    path: None,
+                },
+            ],
+            summary: empty_summary(),
+        };
+
+        run_fix_orphan_vault(&config, &report).unwrap();
+
+        assert!(!tmp.path().join("archive").exists());
+    }
 }

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -166,7 +166,7 @@ enum Commands {
         #[arg(long)]
         fix: bool,
 
-        /// Auto-fix orphan vault files (L002) — vault md 가 DB 에 없으면 archive 로 이동
+        /// Auto-fix orphan vault files (L002) — move vault md to archive if not in DB
         #[arg(long)]
         fix_orphan_vault: bool,
     },

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -165,6 +165,10 @@ enum Commands {
         /// Auto-fix: delete stale DB records for missing vault files (L001)
         #[arg(long)]
         fix: bool,
+
+        /// Auto-fix orphan vault files (L002) — vault md 가 DB 에 없으면 archive 로 이동
+        #[arg(long)]
+        fix_orphan_vault: bool,
     },
 
     /// Start MCP server
@@ -547,8 +551,9 @@ async fn main() -> anyhow::Result<()> {
             json,
             errors_only,
             fix,
+            fix_orphan_vault,
         } => {
-            commands::lint::run(json, errors_only, fix)?;
+            commands::lint::run(json, errors_only, fix, fix_orphan_vault)?;
         }
         Commands::Mcp { http } => {
             commands::mcp::run(http).await?;


### PR DESCRIPTION
## Summary

`secall lint --fix` 가 L001 (DB→vault missing) 만 처리하고 L002 (vault→DB missing) 는 finding 만 보고 자동 fix 가 없었음. P49 prune 후 vault md 514 orphan 발견 + sync-monitor (2026-05-15) 보고서의 D 항목.

## 변경

신규 CLI 옵션 **`--fix-orphan-vault`**:

```
secall lint --fix-orphan-vault          # L002 → archive 이동
secall lint --fix --fix-orphan-vault    # L001 삭제 + L002 archive 동시
```

동작:
- L002 finding 의 각 vault md 를 `<vault.path>/archive/orphan-<YYYY-MM-DD>/<원래 상대경로>` 로 **이동** (`std::fs::rename`)
- delete 가 아닌 이동 — 사용자 의도 외 데이터 손실 회피
- 다시 ingest 시 자동 raw/.sessions/ 로 복귀 가능
- archive 디렉토리는 자동 생성

## 안전성

- ✅ delete 가 아닌 archive 이동
- ✅ vault.path 기준 상대경로 보존
- ✅ rename 실패 시 카운트하고 다음 진행 (전체 실패로 안 종료)
- ✅ L002 0 건이면 archive 디렉토리도 만들지 않음

## Test plan

- [x] `cargo test commands::lint` — 3/3 회귀 테스트 pass
- [x] `cargo test` 전체 — 0 failed
- [x] `RUSTFLAGS=-Dwarnings cargo check` — 경고 0
- [ ] CI ubuntu/windows pass
- [ ] (manual) 운영 vault 에서 `secall lint --fix-orphan-vault` 실행 — 514 orphan 이동 + DB lint 재실행 시 L002 0 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)