### PR TITLE
feat(wiki): P55 — ollama_cloud wiki review backend 추가

### DIFF
--- a/crates/secall-core/src/llm/defaults.rs
+++ b/crates/secall-core/src/llm/defaults.rs
@@ -9,6 +9,9 @@ pub const WIKI_CLAUDE_DEFAULT: &str = "sonnet";
 pub const WIKI_CODEX_DEFAULT: &str = "gpt-5.4";
 // P51: review 는 짧은 issue 분류 작업이라 sonnet → haiku 로 강등 (속도/비용↓).
 pub const WIKI_REVIEW_DEFAULT: &str = "haiku";
+// P55: ollama_cloud backend 사용 시 review 디폴트 모델 (kimi-k2.6 의 long context +
+// JSON 출력 안정성). ANTHROPIC_API_KEY 가 없는 환경에서 cloud 키로 대체 가능.
+pub const WIKI_REVIEW_OLLAMA_CLOUD_DEFAULT: &str = "kimi-k2.6:cloud";
 pub const LOG_OLLAMA_DEFAULT: &str = GRAPH_OLLAMA_DEFAULT;
 pub const LOG_OLLAMA_CLOUD_DEFAULT: &str = "kimi-k2.6:cloud";
 pub const LOG_CONTEXT_CHAR_LIMIT: usize = 400_000;

--- a/crates/secall-core/src/wiki/reviewers/ollama.rs
+++ b/crates/secall-core/src/wiki/reviewers/ollama.rs
@@ -6,12 +6,16 @@ use crate::wiki::{load_review_system_prompt, ReviewResult, ReviewerKind, WikiRev
 pub struct OllamaReviewer {
     pub api_url: String,
     pub model: String,
+    /// P55: Ollama Cloud 호출 시 bearer auth 사용. None 이면 local Ollama.
+    pub api_key: Option<String>,
 }
 
 #[async_trait]
 impl WikiReviewer for OllamaReviewer {
     async fn review(&self, page_content: &str, source_summary: &str) -> Result<ReviewResult> {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .build()?;
 
         for strict in [false, true] {
             let body = serde_json::json!({
@@ -31,9 +35,11 @@ impl WikiReviewer for OllamaReviewer {
             });
 
             let url = format!("{}/api/chat", self.api_url.trim_end_matches('/'));
-            let resp = client
-                .post(&url)
-                .json(&body)
+            let mut req = client.post(&url).json(&body);
+            if let Some(key) = &self.api_key {
+                req = req.bearer_auth(key);
+            }
+            let resp = req
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("Ollama review request failed: {}", e))?;

--- a/crates/secall-core/tests/wiki_reviewers.rs
+++ b/crates/secall-core/tests/wiki_reviewers.rs
@@ -18,6 +18,7 @@ async fn ollama_reviewer_parses_valid_response() {
     let result = OllamaReviewer {
         api_url: server.url(),
         model: "gemma4".into(),
+        api_key: None,
     }
     .review("page", "summary")
     .await
@@ -56,6 +57,7 @@ async fn ollama_reviewer_retries_on_parse_failure() {
     let result = OllamaReviewer {
         api_url: server.url(),
         model: "gemma4".into(),
+        api_key: None,
     }
     .review("page", "summary")
     .await
@@ -115,6 +117,7 @@ async fn ollama_reviewer_fails_after_two_parse_failures() {
     let err = OllamaReviewer {
         api_url: server.url(),
         model: "gemma4".into(),
+        api_key: None,
     }
     .review("page", "summary")
     .await

--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -1126,6 +1126,14 @@ pub fn resolve_review_model(cli: Option<&str>, config: &Config, backend_name: &s
             .ollama_model
             .clone()
             .unwrap_or_else(|| "gemma4:e4b".to_string()),
+        // P55: ollama_cloud review default 는 kimi-k2.6:cloud (long context + JSON).
+        "ollama_cloud" => config.graph.cloud_model.clone().unwrap_or_else(|| {
+            warn_using_default(
+                "wiki.review_model",
+                secall_core::llm::defaults::WIKI_REVIEW_OLLAMA_CLOUD_DEFAULT,
+            );
+            secall_core::llm::defaults::WIKI_REVIEW_OLLAMA_CLOUD_DEFAULT.to_string()
+        }),
         _ => {
             warn_using_default("wiki.review_model", WIKI_REVIEW_DEFAULT);
             WIKI_REVIEW_DEFAULT.to_string()
@@ -1143,7 +1151,7 @@ pub fn resolve_review_backend(cli: Option<&str>, config: &Config) -> String {
     }
     if matches!(
         config.wiki.default_backend.as_str(),
-        "claude" | "codex" | "haiku" | "ollama" | "lmstudio"
+        "claude" | "codex" | "haiku" | "ollama" | "ollama_cloud" | "lmstudio"
     ) {
         return config.wiki.default_backend.clone();
     }
@@ -1195,7 +1203,32 @@ fn build_reviewer(
                 .or_else(|| config.graph.ollama_url.clone())
                 .unwrap_or_else(|| "http://localhost:11434".to_string()),
             model: model.to_string(),
+            api_key: None,
         })),
+        // P55: Ollama Cloud backend for wiki review. OLLAMA_CLOUD_API_KEY 또는
+        // config 의 cloud_api_key 필요. graph 의 cloud_host 와 같은 endpoint 사용.
+        "ollama_cloud" => {
+            let api_key = std::env::var("OLLAMA_CLOUD_API_KEY")
+                .ok()
+                .or_else(|| config.graph.cloud_api_key.clone())
+                .or_else(|| config.log.cloud_api_key.clone())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "ollama cloud api key not set \
+                         (set OLLAMA_CLOUD_API_KEY env or [graph].cloud_api_key in config.toml)"
+                    )
+                })?;
+            let api_url = config
+                .graph
+                .cloud_host
+                .clone()
+                .unwrap_or_else(|| "https://ollama.com".to_string());
+            Ok(Box::new(secall_core::wiki::OllamaReviewer {
+                api_url,
+                model: model.to_string(),
+                api_key: Some(api_key),
+            }))
+        }
         "lmstudio" => Ok(Box::new(secall_core::wiki::LmStudioReviewer {
             api_url: config
                 .wiki

--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -638,6 +638,33 @@ fn build_wiki_backend(
                 api_key: None,
             }))
         }
+        // P55 Gemini #64: build_reviewer 와 일관되게 ollama_cloud 도 지원.
+        // `default_backend = "ollama_cloud"` 시 build_wiki_backend / build_reviewer
+        // 양쪽이 동일 backend 인식.
+        "ollama_cloud" => {
+            let cfg = config.wiki_backend_config("ollama_cloud");
+            let api_key = std::env::var("OLLAMA_CLOUD_API_KEY")
+                .ok()
+                .or_else(|| config.graph.cloud_api_key.clone())
+                .or_else(|| config.log.cloud_api_key.clone())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "ollama cloud api key not set \
+                         (set OLLAMA_CLOUD_API_KEY env or [graph].cloud_api_key in config.toml)"
+                    )
+                })?;
+            Ok(Box::new(secall_core::wiki::OllamaBackend {
+                api_url: cfg
+                    .api_url
+                    .or_else(|| config.graph.cloud_host.clone())
+                    .unwrap_or_else(|| "https://ollama.com".to_string()),
+                model: cfg.model.unwrap_or_else(|| {
+                    secall_core::llm::defaults::WIKI_REVIEW_OLLAMA_CLOUD_DEFAULT.to_string()
+                }),
+                max_tokens: cfg.max_tokens,
+                api_key: Some(api_key),
+            }))
+        }
         "lmstudio" => {
             let cfg = config.wiki_backend_config("lmstudio");
             Ok(Box::new(secall_core::wiki::LmStudioBackend {
@@ -657,7 +684,7 @@ fn build_wiki_backend(
             vault_path: config.vault.path.clone(),
         })),
         _ => anyhow::bail!(
-            "Unknown backend '{}'. Supported: claude, codex, haiku, ollama, lmstudio",
+            "Unknown backend '{}'. Supported: claude, codex, haiku, ollama, ollama_cloud, lmstudio",
             backend_name
         ),
     }


### PR DESCRIPTION
## Summary

P51 의 `WIKI_REVIEW_DEFAULT = "haiku"` 가 ANTHROPIC_API_KEY 없는 환경에서 fail. 사용자 환경에는 OLLAMA_CLOUD_API_KEY 보유 — cloud reviewer 로 review 가능하게 backend 추가.

(2026-05-15 sync-monitor 보고서 의 "추가 발견" 후속 fix)

## 변경

| 파일 | 변경 |
|------|------|
| `wiki/reviewers/ollama.rs` | `OllamaReviewer.api_key: Option<String>` field + bearer auth + 120s timeout |
| `llm/defaults.rs` | `WIKI_REVIEW_OLLAMA_CLOUD_DEFAULT = "kimi-k2.6:cloud"` 신규 |
| `commands/wiki.rs build_reviewer` | `"ollama_cloud"` branch (OLLAMA_CLOUD_API_KEY env 또는 config cloud_api_key, cloud_host default `https://ollama.com`) |
| `commands/wiki.rs resolve_review_backend` | matches! 에 `"ollama_cloud"` 추가 |
| `commands/wiki.rs resolve_review_model` | `"ollama_cloud"` 분기 → cloud_model 또는 WIKI_REVIEW_OLLAMA_CLOUD_DEFAULT |
| `tests/wiki_reviewers.rs` | fixture 3건 `api_key: None` 추가 |

## 사용법

```toml
# config.toml
[wiki]
review_backend = "ollama_cloud"
```

또는 CLI: `secall wiki update --review --review-backend ollama_cloud`.

## Test plan

- [x] `cargo test` 전체 — 0 failed
- [x] `RUSTFLAGS=-Dwarnings cargo check` — 경고 0
- [x] `cargo fmt --all -- --check` OK
- [ ] CI ubuntu/windows pass
- [ ] (manual) `secall wiki update --review --review-backend ollama_cloud` 실행 시 bearer auth + kimi-k2.6:cloud 호출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)