### PR TITLE
feat(wiki): P56 — WikiBackendConfig cloud_* 필드 + claude CLI haiku alias

### DIFF
--- a/crates/secall-core/src/vault/config.rs
+++ b/crates/secall-core/src/vault/config.rs
@@ -115,6 +115,11 @@ pub struct WikiBackendConfig {
     /// 최대 생성 토큰 수
     #[serde(default = "default_wiki_max_tokens")]
     pub max_tokens: u32,
+    /// P56: ollama_cloud backend 의 bearer auth 키. 없으면 OLLAMA_CLOUD_API_KEY env
+    /// 또는 graph/log 의 cloud_api_key 로 fallback.
+    pub cloud_api_key: Option<String>,
+    /// P56: ollama_cloud backend 의 base URL (default `https://ollama.com`).
+    pub cloud_host: Option<String>,
 }
 
 fn default_wiki_max_tokens() -> u32 {
@@ -127,6 +132,8 @@ impl Default for WikiBackendConfig {
             api_url: None,
             model: None,
             max_tokens: default_wiki_max_tokens(),
+            cloud_api_key: None,
+            cloud_host: None,
         }
     }
 }

--- a/crates/secall-core/src/wiki/claude.rs
+++ b/crates/secall-core/src/wiki/claude.rs
@@ -25,8 +25,12 @@ impl WikiBackend for ClaudeBackend {
             );
         }
 
+        // P56: review default (WIKI_REVIEW_DEFAULT="haiku") 가 claude CLI 에서
+        // 의도대로 동작하도록 alias 추가. 이전엔 "haiku" → fallback sonnet 으로
+        // 매핑되어 review default 효과 없었음.
         let model_id = match self.model.as_str() {
             "opus" => "claude-opus-4-6",
+            "haiku" => "claude-haiku-4-5",
             _ => "claude-sonnet-4-6",
         };
 

--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -633,23 +633,27 @@ fn build_wiki_backend(
             }))
         }
         // P55 Gemini #64: build_reviewer 와 일관되게 ollama_cloud 도 지원.
-        // `default_backend = "ollama_cloud"` 시 build_wiki_backend / build_reviewer
-        // 양쪽이 동일 backend 인식.
+        // P56: wiki backend config 의 cloud_api_key / cloud_host 우선 (graph/log
+        // 와 분리해 wiki 전용 키 / 엔드포인트 가능, Gemini PR #64 MEDIUM 반영).
         "ollama_cloud" => {
             let cfg = config.wiki_backend_config("ollama_cloud");
-            let api_key = std::env::var("OLLAMA_CLOUD_API_KEY")
-                .ok()
+            let api_key = cfg
+                .cloud_api_key
+                .clone()
+                .or_else(|| std::env::var("OLLAMA_CLOUD_API_KEY").ok())
                 .or_else(|| config.graph.cloud_api_key.clone())
                 .or_else(|| config.log.cloud_api_key.clone())
                 .ok_or_else(|| {
                     anyhow::anyhow!(
                         "ollama cloud api key not set \
-                         (set OLLAMA_CLOUD_API_KEY env or [graph].cloud_api_key in config.toml)"
+                         (set [wiki.backends.ollama_cloud].cloud_api_key, \
+                         OLLAMA_CLOUD_API_KEY env, or [graph].cloud_api_key in config.toml)"
                     )
                 })?;
             Ok(Box::new(secall_core::wiki::OllamaBackend {
                 api_url: cfg
                     .api_url
+                    .or(cfg.cloud_host)
                     .or_else(|| config.graph.cloud_host.clone())
                     .unwrap_or_else(|| "https://ollama.com".to_string()),
                 model: cfg.model.unwrap_or_else(|| {
@@ -1239,23 +1243,26 @@ fn build_reviewer(
             model: model.to_string(),
             api_key: None,
         })),
-        // P55: Ollama Cloud backend for wiki review. OLLAMA_CLOUD_API_KEY 또는
-        // config 의 cloud_api_key 필요. graph 의 cloud_host 와 같은 endpoint 사용.
+        // P55: Ollama Cloud backend for wiki review.
+        // P56: wiki backend config 의 cloud_api_key / cloud_host 우선 (Gemini PR #64 MEDIUM).
         "ollama_cloud" => {
-            let api_key = std::env::var("OLLAMA_CLOUD_API_KEY")
-                .ok()
+            let cfg = config.wiki_backend_config("ollama_cloud");
+            let api_key = cfg
+                .cloud_api_key
+                .clone()
+                .or_else(|| std::env::var("OLLAMA_CLOUD_API_KEY").ok())
                 .or_else(|| config.graph.cloud_api_key.clone())
                 .or_else(|| config.log.cloud_api_key.clone())
                 .ok_or_else(|| {
                     anyhow::anyhow!(
                         "ollama cloud api key not set \
-                         (set OLLAMA_CLOUD_API_KEY env or [graph].cloud_api_key in config.toml)"
+                         (set [wiki.backends.ollama_cloud].cloud_api_key, \
+                         OLLAMA_CLOUD_API_KEY env, or [graph].cloud_api_key in config.toml)"
                     )
                 })?;
-            let api_url = config
-                .graph
+            let api_url = cfg
                 .cloud_host
-                .clone()
+                .or_else(|| config.graph.cloud_host.clone())
                 .unwrap_or_else(|| "https://ollama.com".to_string());
             Ok(Box::new(secall_core::wiki::OllamaReviewer {
                 api_url,


### PR DESCRIPTION
## Summary

v0.5.0 release 후 follow-up. 두 fix 묶음.

### 1. WikiBackendConfig cloud_api_key / cloud_host 필드 (Gemini PR #64 MEDIUM)

P55 의 ollama_cloud backend 가 graph/log 의 cloud_* 만 봐서 wiki 전용 키/엔드포인트 지정 불가. 이제 wiki backend config 우선:

```
[wiki.backends.ollama_cloud]
cloud_api_key = "..."           # 우선
cloud_host = "https://ollama.com"  # 우선
```

Fallback: `OLLAMA_CLOUD_API_KEY` env → `[graph].cloud_api_key` → `[log].cloud_api_key`.

### 2. claude CLI `"haiku"` alias

`WIKI_REVIEW_DEFAULT = "haiku"` (P51) 가 claude CLI 환경에서 fallback sonnet 으로 매핑되어 review default 효과 잃었음. `"haiku"` → `claude-haiku-4-5` alias 추가 → ANTHROPIC_API_KEY 없어도 claude CLI subscription 으로 haiku 활용 가능.

## Test plan

- [x] `cargo test` 전체 0 failed
- [x] `RUSTFLAGS=-Dwarnings cargo check` 경고 0
- [x] `cargo fmt --all -- --check` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)