### PR TITLE
feat(wiki): P58 follow-up — claude stdout line-stream 으로 진행 상황 실시간 표시

### DIFF
--- a/crates/secall-core/src/vault/config.rs
+++ b/crates/secall-core/src/vault/config.rs
@@ -583,12 +583,17 @@ pub fn default_graph_anthropic_model() -> &'static str {
     GRAPH_ANTHROPIC_DEFAULT
 }
 
+/// 환경변수(`SECALL_CONFIG_PATH`, `OLLAMA_CLOUD_API_KEY` 등)를 변경하는 테스트들이
+/// 같은 lib binary 내에서 병렬 실행될 때 서로 간섭하지 않도록 직렬화한다.
+///
+/// `vault::config::tests` 외 `vault::tests::test_config_load_or_default` 처럼 다른
+/// 모듈에서도 동일 env 를 건드리므로 `pub(crate)` 로 노출해 공유한다.
+#[cfg(test)]
+pub(crate) static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// 환경변수를 변경하는 테스트들이 병렬 실행될 때 서로 간섭하지 않도록 직렬화
-    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn test_timezone_default_is_utc() {

--- a/crates/secall-core/src/vault/mod.rs
+++ b/crates/secall-core/src/vault/mod.rs
@@ -321,7 +321,13 @@ mod tests {
 
     #[test]
     fn test_config_load_or_default() {
-        // No config file → returns default without panic
+        // No config file → returns default without panic.
+        // SECALL_CONFIG_PATH 를 set/remove 하는 동안 vault::config::tests 의
+        // ENV_MUTEX 와 race 가 발생하면 다른 테스트가 엉뚱한 path 를 보게 된다.
+        // 같은 mutex 를 잡아 직렬화한다.
+        let _guard = super::config::ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("SECALL_CONFIG_PATH", "/nonexistent/path/config.toml");
         let config = Config::load_or_default();
         assert!(config.ingest.tool_output_max_chars > 0);

--- a/crates/secall-core/src/wiki/claude.rs
+++ b/crates/secall-core/src/wiki/claude.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::process::Stdio;
 
 use async_trait::async_trait;
-use tokio::io::AsyncWriteExt as _;
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
 
 use super::WikiBackend;
 
@@ -50,20 +50,37 @@ impl WikiBackend for ClaudeBackend {
             stdin.shutdown().await?;
         }
 
-        // P52: claude CLI 가 stream / internal lock 으로 hang 하는 사례 회피.
-        // wiki 생성은 review 보다 출력이 길어 300s 한도. kill_on_drop=true 라
-        // timeout 시 자동 SIGKILL.
-        let output = tokio::time::timeout(
-            std::time::Duration::from_secs(300),
-            child.wait_with_output(),
-        )
-        .await
-        .map_err(|_| anyhow::anyhow!("claude wiki generation timed out after 300s"))??;
-        if !output.status.success() {
-            anyhow::bail!("claude exited with code {:?}", output.status.code());
-        }
+        // P58: claude stdout 을 line stream 으로 stderr 에 echo + buffer 누적.
+        // 이전 (P52) 의 wait_with_output 은 모든 출력이 모이고 나서야 사용자가
+        // 봤음 → 5분 timeout 동안 사용자는 "아무 반응 없음" 으로 인식 + Ctrl+C
+        // 유혹. 이제 매 line 받는 즉시 `[claude]` prefix 로 stderr 에 echo,
+        // 동시에 buffer 에 누적해 wiki page 본문으로 반환.
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("claude stdout pipe missing"))?;
+        let mut reader = BufReader::new(stdout).lines();
 
-        String::from_utf8(output.stdout)
-            .map_err(|e| anyhow::anyhow!("claude stdout was not UTF-8: {e}"))
+        // P52: 300s timeout 유지. kill_on_drop=true 라 timeout 시 자동 SIGKILL.
+        let stream_and_wait = async {
+            let mut buf = String::new();
+            while let Some(line) = reader.next_line().await? {
+                eprintln!("  [claude] {}", line);
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+            let status = child.wait().await?;
+            Ok::<_, anyhow::Error>((status, buf))
+        };
+
+        let (status, buffer) =
+            tokio::time::timeout(std::time::Duration::from_secs(300), stream_and_wait)
+                .await
+                .map_err(|_| anyhow::anyhow!("claude wiki generation timed out after 300s"))??;
+
+        if !status.success() {
+            anyhow::bail!("claude exited with code {:?}", status.code());
+        }
+        Ok(buffer)
     }
 }

--- a/crates/secall-core/src/wiki/claude.rs
+++ b/crates/secall-core/src/wiki/claude.rs
@@ -54,20 +54,32 @@ impl WikiBackend for ClaudeBackend {
         // 이전 (P52) 의 wait_with_output 은 모든 출력이 모이고 나서야 사용자가
         // 봤음 → 5분 timeout 동안 사용자는 "아무 반응 없음" 으로 인식 + Ctrl+C
         // 유혹. 이제 매 line 받는 즉시 `[claude]` prefix 로 stderr 에 echo,
-        // 동시에 buffer 에 누적해 wiki page 본문으로 반환.
+        // 동시에 buffer 에 원본 line 그대로 누적해 wiki page 본문으로 반환.
+        //
+        // Gemini PR #68: `Lines::next_line()` 은 매 line 마다 새 String 할당 +
+        // 줄바꿈 (`\r\n` vs `\n`) 손실. `read_line` 으로 buffer 재사용 + 원본
+        // 보존 (Windows CRLF 환경 호환).
         let stdout = child
             .stdout
             .take()
             .ok_or_else(|| anyhow::anyhow!("claude stdout pipe missing"))?;
-        let mut reader = BufReader::new(stdout).lines();
+        let mut reader = BufReader::new(stdout);
 
         // P52: 300s timeout 유지. kill_on_drop=true 라 timeout 시 자동 SIGKILL.
         let stream_and_wait = async {
             let mut buf = String::new();
-            while let Some(line) = reader.next_line().await? {
-                eprintln!("  [claude] {}", line);
-                buf.push_str(&line);
-                buf.push('\n');
+            let mut line_buf = String::new();
+            loop {
+                line_buf.clear();
+                let n = reader.read_line(&mut line_buf).await?;
+                if n == 0 {
+                    break;
+                }
+                // stderr echo 는 trailing newline 제거한 형태 (eprintln 이 추가).
+                let trimmed = line_buf.trim_end_matches(['\r', '\n']);
+                eprintln!("  [claude] {}", trimmed);
+                // buffer 는 원본 line ending 보존.
+                buf.push_str(&line_buf);
             }
             let status = child.wait().await?;
             Ok::<_, anyhow::Error>((status, buf))


### PR DESCRIPTION
## Summary

사용자 보고: wiki update 실행 시 5분 동안 화면에 아무 출력 없어 hang 으로 오인 + Ctrl+C 유혹. P52 의 `wait_with_output` 은 출력이 모두 모이고 나서야 보여줌.

이제 claude CLI 의 stdout 을 line-by-line 받아 **즉시 stderr 에 echo + 동시에 buffer 누적**. 사용자는 진행 상황 실시간 확인.

## 변경

`wiki/claude.rs` ClaudeBackend.generate():
- `child.stdout.take()` → `BufReader::new(_).lines()`
- async block 안에서 `next_line()` 루프:
  - 매 line `  [claude] <line>` 으로 stderr echo
  - 동시에 buffer push
- 종료 시 `(status, buffer)` 반환 — buffer 가 wiki page 본문
- P52 300s timeout 유지 + `kill_on_drop=true` SIGKILL

## 범위

이번 PR 은 **claude backend 만**.

- **codex**: stdout 을 file 로 출력 (`--output-last-message <path>`) → stream 안 됨. stderr 은 이미 inherit (codex CLI 자체 progress 표시)
- **ollama / lmstudio**: HTTP 라 별도 streaming API (`stream: true`) 필요. ollama 의 `/api/chat` 은 NDJSON stream 가능 — 별도 PR

## Test plan

- [x] `cargo test` 전체 0 failed
- [x] `RUSTFLAGS=-Dwarnings cargo check` 경고 0
- [x] `cargo fmt --all -- --check` OK
- [ ] (manual) `secall wiki update --backend claude --session <id>` 실행 시 stderr 에 `[claude]` prefix 의 진행 상황 line 들 실시간 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)