### PR TITLE
feat(wiki): P60 — ollama/lmstudio HTTP response streaming

### DIFF
--- a/crates/secall-core/src/wiki/lmstudio.rs
+++ b/crates/secall-core/src/wiki/lmstudio.rs
@@ -146,7 +146,11 @@ mod tests {
         };
 
         let result = backend.generate("test prompt").await;
-        assert!(result.is_ok(), "generate should succeed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "generate should succeed: {:?}",
+            result.err()
+        );
         assert_eq!(result.unwrap(), "wiki content");
         mock.assert_async().await;
     }

--- a/crates/secall-core/src/wiki/lmstudio.rs
+++ b/crates/secall-core/src/wiki/lmstudio.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_util::StreamExt as _;
 
 use super::WikiBackend;
 
@@ -17,6 +18,7 @@ impl WikiBackend for LmStudioBackend {
     async fn generate(&self, prompt: &str) -> anyhow::Result<String> {
         // P52/P59: LM Studio server hang 회피. wiki 생성은 출력이 길어 1800s
         // 한도 (P59 에서 5분 → 30분 상향).
+        // P60: stream=true (OpenAI-compatible SSE) 로 전환. delta.content 누적.
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(1800))
             .build()?;
@@ -26,25 +28,176 @@ impl WikiBackend for LmStudioBackend {
                 "model": self.model,
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": self.max_tokens,
-                "stream": false
+                "stream": true
             }))
             .send()
             .await
             .map_err(|e| anyhow::anyhow!("LM Studio request failed: {}", e))?;
 
         if !resp.status().is_success() {
+            let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("LM Studio API error: {body}");
+            anyhow::bail!("LM Studio API error ({}): {}", status, body);
         }
 
-        let json: serde_json::Value = resp
-            .json()
-            .await
-            .map_err(|e| anyhow::anyhow!("LM Studio response parse error: {}", e))?;
+        consume_sse_stream(resp).await
+    }
+}
 
-        json["choices"][0]["message"]["content"]
-            .as_str()
-            .map(|s| s.to_string())
-            .ok_or_else(|| anyhow::anyhow!("LM Studio response missing content field"))
+/// LM Studio (OpenAI-compatible) `/v1/chat/completions` 의 SSE 응답을 파싱.
+///
+/// 각 이벤트는 `data: <json>\n` 한 줄 (보통 `\n\n` 으로 구분되지만 라인 단위로
+/// 처리해도 된다). `data: [DONE]` 으로 종료. JSON 의 `choices[0].delta.content`
+/// 가 매 토큰의 증분이며 누적해 본문을 만든다. 라인 경계 cross-chunk 대응을
+/// 위해 buffer 에 누적.
+async fn consume_sse_stream(resp: reqwest::Response) -> anyhow::Result<String> {
+    let mut stream = resp.bytes_stream();
+    let mut line_buf = String::new();
+    let mut full = String::new();
+    let mut echo_pending = String::new();
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk.map_err(|e| anyhow::anyhow!("LM Studio stream chunk error: {}", e))?;
+        let text = std::str::from_utf8(&bytes)
+            .map_err(|e| anyhow::anyhow!("LM Studio stream UTF-8 error: {}", e))?;
+        line_buf.push_str(text);
+        while let Some(idx) = line_buf.find('\n') {
+            let line = line_buf[..idx].trim_end_matches('\r').to_string();
+            line_buf.drain(..=idx);
+            let payload = match line.strip_prefix("data: ") {
+                Some(p) => p,
+                None => continue, // empty / comment / heartbeat line
+            };
+            if payload == "[DONE]" {
+                flush_echo(&mut echo_pending, true);
+                return Ok(full);
+            }
+            let value: serde_json::Value = serde_json::from_str(payload).map_err(|e| {
+                anyhow::anyhow!("LM Studio SSE parse error: {} (data: {})", e, payload)
+            })?;
+            if let Some(piece) = value
+                .pointer("/choices/0/delta/content")
+                .and_then(|v| v.as_str())
+            {
+                full.push_str(piece);
+                echo_pending.push_str(piece);
+                flush_echo(&mut echo_pending, false);
+            }
+        }
+    }
+    flush_echo(&mut echo_pending, true);
+    if full.is_empty() {
+        anyhow::bail!("LM Studio stream ended without any content");
+    }
+    Ok(full)
+}
+
+/// stderr echo 정책 (ollama.rs 와 동일 톤): 80자 누적 또는 `\n` 시 flush.
+fn flush_echo(pending: &mut String, force: bool) {
+    loop {
+        if let Some(idx) = pending.find('\n') {
+            let line = pending[..idx].to_string();
+            pending.drain(..=idx);
+            if !line.trim().is_empty() {
+                eprintln!("  [lmstudio] {}", line);
+            }
+            continue;
+        }
+        if pending.chars().count() >= 80 {
+            let line = std::mem::take(pending);
+            eprintln!("  [lmstudio] {}", line);
+            continue;
+        }
+        break;
+    }
+    if force && !pending.trim().is_empty() {
+        eprintln!("  [lmstudio] {}", pending);
+        pending.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+
+    /// SSE body — 3 delta 합쳐 "wiki content" + [DONE].
+    fn lmstudio_sse_body() -> String {
+        let line1 = r#"data: {"choices":[{"delta":{"content":"wiki "}}]}"#;
+        let line2 = r#"data: {"choices":[{"delta":{"content":"content"}}]}"#;
+        let done = "data: [DONE]";
+        format!("{line1}\n\n{line2}\n\n{done}\n\n")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_lmstudio_backend_generate_streams_delta_content() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/v1/chat/completions")
+            .with_status(200)
+            .with_header("content-type", "text/event-stream")
+            .with_body(lmstudio_sse_body())
+            .create_async()
+            .await;
+
+        let backend = LmStudioBackend {
+            api_url: server.url(),
+            model: "qwen3-coder-32b".to_string(),
+            max_tokens: 4096,
+        };
+
+        let result = backend.generate("test prompt").await;
+        assert!(result.is_ok(), "generate should succeed: {:?}", result.err());
+        assert_eq!(result.unwrap(), "wiki content");
+        mock.assert_async().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_lmstudio_backend_generate_propagates_4xx_error() {
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/v1/chat/completions")
+            .with_status(400)
+            .with_body(r#"{"error":"bad request"}"#)
+            .create_async()
+            .await;
+
+        let backend = LmStudioBackend {
+            api_url: server.url(),
+            model: "qwen3-coder-32b".to_string(),
+            max_tokens: 4096,
+        };
+
+        let result = backend.generate("test prompt").await;
+        assert!(result.is_err(), "4xx response should return Err");
+    }
+
+    /// SSE 라인이 chunk 중간에 잘려도 누적되는지 (mockito 는 chunked 직접 제어
+    /// 안 되지만 단일 body 안에 cross-line 형식을 그대로 둬도 line buffer 가
+    /// 처리해야 함).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_lmstudio_stream_accumulates_across_deltas() {
+        let body = format!(
+            "{a}\n\n{b}\n\n{c}\n\ndata: [DONE]\n\n",
+            a = r#"data: {"choices":[{"delta":{"content":"hello "}}]}"#,
+            b = r#"data: {"choices":[{"delta":{"content":"world"}}]}"#,
+            c = r#"data: {"choices":[{"delta":{"content":"!"}}]}"#,
+        );
+
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/v1/chat/completions")
+            .with_status(200)
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let backend = LmStudioBackend {
+            api_url: server.url(),
+            model: "qwen3-coder-32b".to_string(),
+            max_tokens: 4096,
+        };
+
+        let result = backend.generate("test prompt").await.unwrap();
+        assert_eq!(result, "hello world!");
     }
 }

--- a/crates/secall-core/src/wiki/ollama.rs
+++ b/crates/secall-core/src/wiki/ollama.rs
@@ -74,18 +74,15 @@ async fn consume_ndjson_stream(resp: reqwest::Response) -> anyhow::Result<String
             if line.trim().is_empty() {
                 continue;
             }
-            let value: serde_json::Value = serde_json::from_str(&line)
-                .map_err(|e| anyhow::anyhow!("Ollama NDJSON parse error: {} (line: {})", e, line))?;
+            let value: serde_json::Value = serde_json::from_str(&line).map_err(|e| {
+                anyhow::anyhow!("Ollama NDJSON parse error: {} (line: {})", e, line)
+            })?;
             if let Some(piece) = value.get("response").and_then(|v| v.as_str()) {
                 full.push_str(piece);
                 echo_pending.push_str(piece);
                 flush_echo(&mut echo_pending, false);
             }
-            if value
-                .get("done")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false)
-            {
+            if value.get("done").and_then(|v| v.as_bool()).unwrap_or(false) {
                 flush_echo(&mut echo_pending, true);
                 return Ok(full);
             }

--- a/crates/secall-core/src/wiki/ollama.rs
+++ b/crates/secall-core/src/wiki/ollama.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_util::StreamExt as _;
 
 use super::WikiBackend;
 
@@ -18,6 +19,9 @@ impl WikiBackend for OllamaBackend {
     async fn generate(&self, prompt: &str) -> anyhow::Result<String> {
         // P52/P59: ollama server hang 회피. wiki 생성은 출력이 길어 1800s 한도
         // (P59 에서 5분 → 30분 상향 — 정상 케이스도 5분 넘는 사례 관측).
+        // P60: stream=true 로 전환 + bytes_stream() 로 NDJSON 라인 파싱.
+        // claude.rs 의 line-stream 과 동일 톤으로 stderr 에 `[ollama] ...` echo
+        // 하여 사용자가 진행 상황을 본다.
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(1800))
             .build()?;
@@ -27,7 +31,7 @@ impl WikiBackend for OllamaBackend {
                 .json(&serde_json::json!({
                     "model": self.model,
                     "prompt": prompt,
-                    "stream": false,
+                    "stream": true,
                     "options": { "num_predict": self.max_tokens }
                 }));
         if let Some(key) = &self.api_key {
@@ -39,19 +43,99 @@ impl WikiBackend for OllamaBackend {
             .map_err(|e| anyhow::anyhow!("Ollama request failed: {}", e))?;
 
         if !resp.status().is_success() {
+            let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Ollama API error: {body}");
+            anyhow::bail!("Ollama API error ({}): {}", status, body);
         }
 
-        let json: serde_json::Value = resp
-            .json()
-            .await
-            .map_err(|e| anyhow::anyhow!("Ollama response parse error: {}", e))?;
+        consume_ndjson_stream(resp).await
+    }
+}
 
-        json["response"]
-            .as_str()
-            .map(|s| s.to_string())
-            .ok_or_else(|| anyhow::anyhow!("Ollama response missing 'response' field"))
+/// Ollama `/api/generate` 의 stream 응답 (NDJSON) 을 파싱한다.
+///
+/// 각 라인은 `{"response": "<chunk>", "done": false}` 형식. 마지막 라인이
+/// `{"done": true, ...}`. chunk 경계가 라인 중간을 가를 수 있어 buffer 에 누적
+/// 후 `\n` split. 누적된 응답 텍스트가 80자 이상 쌓이거나 라인 단위 break 가
+/// 나타나면 stderr 에 echo 한다.
+async fn consume_ndjson_stream(resp: reqwest::Response) -> anyhow::Result<String> {
+    let mut stream = resp.bytes_stream();
+    let mut line_buf = String::new();
+    let mut full = String::new();
+    let mut echo_pending = String::new();
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk.map_err(|e| anyhow::anyhow!("Ollama stream chunk error: {}", e))?;
+        let text = std::str::from_utf8(&bytes)
+            .map_err(|e| anyhow::anyhow!("Ollama stream UTF-8 error: {}", e))?;
+        line_buf.push_str(text);
+        while let Some(idx) = line_buf.find('\n') {
+            let line = line_buf[..idx].to_string();
+            line_buf.drain(..=idx);
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value: serde_json::Value = serde_json::from_str(&line)
+                .map_err(|e| anyhow::anyhow!("Ollama NDJSON parse error: {} (line: {})", e, line))?;
+            if let Some(piece) = value.get("response").and_then(|v| v.as_str()) {
+                full.push_str(piece);
+                echo_pending.push_str(piece);
+                flush_echo(&mut echo_pending, false);
+            }
+            if value
+                .get("done")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                flush_echo(&mut echo_pending, true);
+                return Ok(full);
+            }
+        }
+    }
+    // EOF. line_buf 에 newline 없는 잔여 라인이 남아있을 수 있다 (일부 서버가
+    // 마지막 라인에 \n 미부착). non-stream 응답 (단일 JSON object) 으로 응답하는
+    // mock / proxy 환경 호환을 위해 처리.
+    let trailing = line_buf.trim();
+    if !trailing.is_empty() {
+        let value: serde_json::Value = serde_json::from_str(trailing).map_err(|e| {
+            anyhow::anyhow!(
+                "Ollama trailing line parse error: {} (line: {})",
+                e,
+                trailing
+            )
+        })?;
+        if let Some(piece) = value.get("response").and_then(|v| v.as_str()) {
+            full.push_str(piece);
+            echo_pending.push_str(piece);
+        }
+    }
+    flush_echo(&mut echo_pending, true);
+    if full.is_empty() {
+        anyhow::bail!("Ollama stream ended without any response");
+    }
+    Ok(full)
+}
+
+/// stderr echo 정책: 80자 누적되거나 `\n` 포함 시 flush. `force=true` 면 잔여 모두.
+fn flush_echo(pending: &mut String, force: bool) {
+    loop {
+        if let Some(idx) = pending.find('\n') {
+            let line = pending[..idx].to_string();
+            pending.drain(..=idx);
+            if !line.trim().is_empty() {
+                eprintln!("  [ollama] {}", line);
+            }
+            continue;
+        }
+        if pending.chars().count() >= 80 {
+            let line = std::mem::take(pending);
+            eprintln!("  [ollama] {}", line);
+            continue;
+        }
+        break;
+    }
+    if force && !pending.trim().is_empty() {
+        eprintln!("  [ollama] {}", pending);
+        pending.clear();
     }
 }
 
@@ -60,8 +144,15 @@ mod tests {
     use super::*;
     use mockito::{Matcher, Server};
 
-    fn ollama_generate_response() -> String {
-        serde_json::json!({ "response": "wiki content" }).to_string()
+    /// NDJSON stream 응답 — 3 chunks 합쳐 "wiki content".
+    fn ollama_stream_body() -> String {
+        [
+            r#"{"response":"wiki ","done":false}"#,
+            r#"{"response":"content","done":false}"#,
+            r#"{"response":"","done":true}"#,
+        ]
+        .join("\n")
+            + "\n"
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -71,7 +162,7 @@ mod tests {
             .mock("POST", "/api/generate")
             .match_header("Authorization", "Bearer cloud-key")
             .with_status(200)
-            .with_body(ollama_generate_response())
+            .with_body(ollama_stream_body())
             .create_async()
             .await;
 
@@ -99,7 +190,7 @@ mod tests {
             .mock("POST", "/api/generate")
             .match_header("Authorization", Matcher::Missing)
             .with_status(200)
-            .with_body(ollama_generate_response())
+            .with_body(ollama_stream_body())
             .create_async()
             .await;
 
@@ -138,5 +229,36 @@ mod tests {
 
         let result = backend.generate("test prompt").await;
         assert!(result.is_err(), "4xx response should return Err");
+    }
+
+    /// stream 의 chunk 경계가 JSON 라인 중간을 잘라도 정확히 누적되는지.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_ollama_stream_accumulates_across_chunks() {
+        // 의도적으로 한 라인을 여러 토큰으로 쪼개 done=true 로 종료.
+        let body = [
+            r#"{"response":"hello ","done":false}"#,
+            r#"{"response":"world","done":false}"#,
+            r#"{"response":"!","done":true}"#,
+        ]
+        .join("\n")
+            + "\n";
+
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/api/generate")
+            .with_status(200)
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let backend = OllamaBackend {
+            api_url: server.url(),
+            model: "local-model".to_string(),
+            max_tokens: 4096,
+            api_key: None,
+        };
+
+        let result = backend.generate("test prompt").await.unwrap();
+        assert_eq!(result, "hello world!");
     }
 }

--- a/crates/secall/tests/log_backend_resolve.rs
+++ b/crates/secall/tests/log_backend_resolve.rs
@@ -96,8 +96,15 @@ async fn ollama_cloud_api_key_env_sets_both_graph_and_log() {
 
 // ─── P48: generate_log_body ollama_cloud arm 통합 회귀 테스트 ────────────────
 
+/// P60: ollama 백엔드가 stream=true 로 전환되어 응답이 NDJSON 라인 스트림.
 fn ollama_generate_response() -> String {
-    serde_json::json!({ "response": "생성된 일기 내용" }).to_string()
+    [
+        r#"{"response":"생성된 ","done":false}"#,
+        r#"{"response":"일기 내용","done":false}"#,
+        r#"{"response":"","done":true}"#,
+    ]
+    .join("\n")
+        + "\n"
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

- **Ollama** `/api/generate` 를 `stream=true` NDJSON 으로 전환 → 라인 단위 파싱 + stderr `[ollama] ...` echo
- **LM Studio** `/v1/chat/completions` 를 `stream=true` SSE 로 전환 → `data: {...}` 라인 + `delta.content` 누적 + stderr `[lmstudio] ...` echo
- P58 의 `claude.rs` line-stream 패턴을 HTTP 백엔드로 확장 — wiki update 가 10~20분 걸려도 사용자가 stuck 으로 오인하지 않게

## 배경

P58 에서 claude CLI 의 stdout 을 line-stream 으로 echo 했지만 ollama/lmstudio 는 동기 HTTP 호출이라 응답 받기 전까지 어떤 진행 상황도 안 보였음. P59 에서 timeout 을 1800s 로 상향한 이후 더더욱 "stuck 인가" 의심 구간이 길어졌다. 본 PR 은 두 HTTP 백엔드도 동일 톤으로 progress echo.

## 변경

| 파일 | 변경 |
|---|---|
| `crates/secall-core/src/wiki/ollama.rs` | `stream=true` + `bytes_stream()` NDJSON 파서 + EOF 잔여 라인 처리 + stderr echo |
| `crates/secall-core/src/wiki/lmstudio.rs` | `stream=true` + SSE 파서 (`data: {...}` / `data: [DONE]`) + stderr echo |
| `crates/secall/tests/log_backend_resolve.rs` | mock body 를 NDJSON 형식으로 갱신 (`log` 명령이 `wiki::OllamaBackend` 재사용) |

## Echo 정책

`[ollama] <chunk>` / `[lmstudio] <chunk>` 형식. 80자 누적 또는 `\n` 마다 flush — 토큰마다 echo 하면 너무 시끄러우므로 합리적 단위로.

## 회귀

- `wiki::ollama` 기존 3 → 4 테스트 (stream 응답 형식으로 갱신 + cross-chunk 누적 신규)
- `wiki::lmstudio` 0 → 3 테스트 (정상 SSE / 4xx / cross-delta)
- 풀 `cargo test` 통과

## Test plan

- [x] `cargo check --workspace -D warnings` 통과
- [x] `cargo test --lib -p secall-core wiki` — 50 passed
- [x] `cargo test --test log_backend_resolve` — 7 passed
- [x] `cargo test` 풀 — 모든 테스트 통과
- [ ] CI ubuntu / windows / web 통과 확인
- [ ] (수동) `secall wiki update` 실 ollama_cloud 환경에서 stderr echo 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)