### PR TITLE
docs(backlog): P63 — core-backlog 신설 + web 전수 조사 결과 반영

### DIFF
--- a/docs/reference/core-backlog.md
+++ b/docs/reference/core-backlog.md
@@ -1,0 +1,41 @@
+---
+type: reference
+status: in_progress
+updated_at: 2026-05-16
+---
+
+# secall-core 백로그 / 알려진 이슈
+
+> secall-core (Rust lib + CLI + REST API) 관련 미해결 / 추적 항목.
+> web 전용 항목은 `web-backlog.md` 참조.
+
+---
+
+## hot
+
+### cargo test 가 production config.toml 을 덮어쓰는 회귀
+- **위치**: `crates/secall-core/src/vault/config.rs#tests` (`save_*` 류 테스트)
+- **현상**: `save_preserves_top_level_comments`, `save_removes_optional_keys_when_cleared` 등이 `Config::save()` 를 호출. `SECALL_CONFIG_PATH` env 를 tempdir 로 set 한 상태에서 호출하지만, 다른 테스트와 race / 또는 panic 으로 인한 unwind 시 `SECALL_CONFIG_PATH` 가 unset 된 채 save 가 실행되면 **production config (`~/Library/Application Support/secall/config.toml`) 를 덮어씀**.
+- **재현 (2026-05-16)**: P58 race fix 머지 전 vault::config flaky test 재현 시도 (5회 반복) 도중 한 시점에 production config.toml 의 `[vault].path` 가 `/tmp/changed` (`save_preserves_top_level_comments` 의 hardcoded 값) 로 변경됨. 사용자가 web UI 에서 wiki 빈 화면 / graph 멈춤으로 인지.
+- **위험도**: HIGH — 사용자의 실 환경을 깨뜨리는 부수효과. 단 P58 race fix 머지 후엔 race 자체는 차단.
+- **남은 위험**: panic / 강제 종료 시 `SECALL_CONFIG_PATH` unset → save 가 production 으로 흘러갈 가능성. 테스트가 `Config::save()` 를 호출하는 한 구조적 위험 잔존.
+- **후속 액션 후보**:
+  1. `Config::save()` 가 `SECALL_CONFIG_PATH` 이 set 되어 있지 않으면 **production path 대신 명시 에러 또는 noop** 으로 동작하는 `#[cfg(test)]` 가드 추가
+  2. 또는 test 만의 `Config::save_to_path(&path)` 헬퍼 신설해 save() 호출 자체 회피
+  3. 또는 `serial_test` crate 도입해 env mutation 테스트 전체를 process-level serial 화 (현 ENV_MUTEX 는 panic 복구 불가)
+
+## debt
+
+(현재 없음)
+
+## watch
+
+(현재 없음)
+
+---
+
+## 처리 절차
+
+1. 새 항목 발견 → 분류 (hot / debt / watch) 후 본 문서 해당 섹션에 추가
+2. 항목 처리 시 별도 PR + 커밋 메시지에 본 문서의 항목 명시
+3. PR 머지 후 본 문서에서 항목 제거 (또는 done 섹션으로 잠시 이동)

--- a/docs/reference/web-backlog.md
+++ b/docs/reference/web-backlog.md
@@ -25,7 +25,20 @@ updated_at: 2026-05-16
 
 ## hot
 
-(현재 없음 — P62 에서 `APP_VERSION` hardcode SSOT 통합으로 해결됨)
+### Graph snapshot 대용량 응답 → "멈춤 화면"
+- **위치**: `crates/secall-core/src/mcp/server.rs:do_graph_snapshot` + `web/src/lib/api.ts:183` (`graphSnapshot(sessionLimit=80)`) + `web/src/routes/GraphRoute.tsx` (ObsidianGraph)
+- **현상**: server 응답에 **edge 개수 제한이 없음**. `session_limit=80` 만 있고 그 안의 모든 관계 (`by_agent` / `belongs_to` / `discusses_topic` / `same_project` / `same_day`) 가 직렬화됨. 2026-05-16 시점 응답 약 **1246 edges / ~600KB**. web 측은 D3 force-simulation + SVG 로 모든 노드/엣지를 DOM 렌더링 (virtualization 없음). 사용자 보고 "그래프 거의 멈춤화면" 과 직접 연결됨.
+- **권장 fix**:
+  - server: `/api/graph/snapshot` 에 `edge_limit` 파라미터 (또는 relation 별 cap) 추가
+  - client: edge 수 임계값 (예: 300+) 이면 자동 filter / cluster / canvas-mode 전환
+
+### LLM config 모델 자유 입력 (드롭다운 부재)
+- **위치**: `web/src/routes/SettingsRoute.tsx` 7곳 — `review_model:275` / `ollama_model:366` / `anthropic_model:371` / `cloud_model:376` / `log.model:122` / `log.cloud_model:127` / `embedding.openai_model:137`
+- **현상**: 모델 필드가 모두 `<Input type="text">` 자유 입력. 검증은 `validateModelName()` (정규식 `/^[a-zA-Z0-9._:-]+$/`) 만. backend 별 (ollama/ollama_cloud/lmstudio/anthropic/openai/gemini) 추천 모델 hardcode 미존재. 반면 `semantic_backend` 는 정상적으로 `<select>` 드롭다운 사용. 타이포 위험 + 사용자가 가용 모델 모를 때 시행착오.
+- **권장 fix**:
+  - 옵션 a: `web/src/lib/api.ts` 에 backend 별 모델 목록 상수 + `<datalist>` 패턴 (드롭다운 + 자유 입력 fallback)
+  - 옵션 b: server 측 `/api/config/models?backend=...` endpoint 신설 (SSOT)
+  - graph / wiki / log / embedding 4 섹션 모두 동일 패턴 적용
 
 ## debt
 
@@ -39,6 +52,21 @@ updated_at: 2026-05-16
   - 또는 `cargo xtask build` 류 wrapper 가 pnpm build + cargo build 묶어 실행
   - 또는 release 절차에 "pnpm build 후 cargo install" 체크리스트 박제
 
+### Markdown 폴딩/언폴딩 미구현
+- **위치**: `web/src/components/MarkdownView.tsx`
+- **현상**: `react-markdown` + `remarkGfm` 만 로드. `<details>`/`<summary>` 컴포넌트 override 없음. heading 클릭으로 섹션 접기 없음. 비교: `NoteEditor.tsx:57` / `SessionHeader.tsx:61` 은 `<details>` 직접 사용해 동작. 사용자 보고 "폴딩 제대로 안 됨" 과 일치.
+- **권장 fix**: `components` 객체에 `h1/h2/h3` override (click handler + collapsed state) 또는 `remark-collapse` 류 플러그인. 동시에 `details` override 로 click 동작 명시화.
+
+### `jfetch<unknown>` 타입 미해결 6 endpoints
+- **위치**: `web/src/lib/api.ts` — `daily:162` / `graphSearch:176` / `wikiSearch:179` / `graphSnapshot:183` / `wikiList:188` / `cancelJob:238`
+- **현상**: 응답 타입이 모두 `unknown`. 사용처에서 assertion / `as any` 처리. P62 에서 `StatusResponse` 만 정의됐고 나머지는 방치.
+- **권장 fix**: `web/src/lib/types.ts` 에 `DailyResponse` / `WikiSearchResponse` / `WikiListResponse` / `GraphSearchResponse` / `GraphSnapshot` / `JobCancelResponse` 추가 후 `jfetch<...>` 갱신.
+
+### SessionsRoute 좌측 리스트 에러 표시 없음
+- **위치**: `web/src/routes/SessionsRoute.tsx` (없음) vs `SessionList.tsx:110-119` / `SessionDetailRoute.tsx:18-23` / `DailyRoute.tsx:91` / `WikiRoute.tsx:78,128,176` (있음)
+- **현상**: keyword/semantic search 실패가 SessionsRoute 최상위에 표시되지 않음. SessionList 내부에서만 isError 체크 — 빈 결과와 구분 어려움. 다른 라우트는 모두 error banner 표시.
+- **권장 fix**: SessionList 에서 error state 를 prop 으로 expose 또는 SessionsRoute 가 `useInfiniteSessions` / `useSemanticRecall` 의 error 를 직접 catch 해 상단 alert.
+
 ### `/api/status` 가 stats 쿼리와 묶임
 - **위치**: `crates/secall-core/src/mcp/server.rs:do_status`
 - **현상**: version 만 확인하려는 client 도 DB lock + stats 쿼리 (sessions/turns/vectors count) 비용을 지불.
@@ -46,6 +74,21 @@ updated_at: 2026-05-16
 - **우선순위**: 현재 호출 빈도 낮음 (TopNav mount 시 1회). 회귀 모니터링 후 결정.
 
 ## watch
+
+### react-query `staleTime` 보수적
+- **위치**: `web/src/hooks/useSessions.ts:20` (projects/agents `staleTime: 60_000`) + `web/src/hooks/useWiki.ts:40` (`60_000`)
+- **현상**: projects / agents / wiki list 가 자주 변하지 않는데 1분마다 refetch. 네트워크 비용 / 불필요한 backend 호출.
+- **권장 fix**: `staleTime: 5 * 60_000` (5분) 으로 상향 + mutation 시점에 `queryClient.invalidateQueries` 명시 호출.
+
+### Mobile / tablet 미지원
+- **위치**: `web/src/routes/SessionDetailRoute.tsx:42` `grid grid-cols-1 lg:grid-cols-[...]` (md breakpoint 없음)
+- **현상**: tailwind breakpoint 가 `lg` (1024px) 만. 태블릿 (768~1023px) 구간은 1열 collapse 또는 미정의 layout.
+- **권장 fix**: `md:` breakpoint 추가 (`md:grid-cols-[minmax(0,var(--read-w))_300px]`) 또는 mobile-first 패턴 점진 도입.
+
+### Markdown link 컴포넌트 미커스텀
+- **위치**: `web/src/components/MarkdownView.tsx`
+- **현상**: `[text](url)` 이 그냥 `<a href=...>` 로. vault 내부 path / `[[wikilink]]` obsidian syntax 미지원. 외부 URL 만 동작.
+- **권장 fix**: `components: { a: CustomLink }` 추가 (vault path detection + react-router navigation) + 필요 시 `remark-wiki-link` 플러그인.
 
 ### server-side version 과 web build 시점 version 불일치
 - **시나리오**: server 만 `cargo install --force` 로 새 버전 깔고 `secall serve` 띄우면 — server 의 `/api/status` 는 새 버전, web bundle (dist) 은 옛 빌드 시점에 박힌 자산 (CSS/JS layout). 표시되는 version 은 server 가 SSOT 이므로 일치하지만, 실제 화면 동작은 옛 dist 기준.


### PR DESCRIPTION
## Summary

- `docs/reference/core-backlog.md` **신설** — secall-core (Rust lib / CLI / REST) 의 미해결 항목 SSOT
- `docs/reference/web-backlog.md` **갱신** — 서브에이전트 전수 조사 결과 6 신규 항목 추가
- production `config.toml` 의 `vault.path` 복구 작업 + 메모리 정리 (system files, git 외)

## 발견 항목 분류

### secall-core (1 hot)
- **cargo test 가 production config.toml 덮어쓰는 회귀**: 2026-05-16 vault::config flaky test 재현 시도가 사용자 환경의 `[vault].path` 를 `/tmp/changed` 로 set 한 사고. P58 race fix 머지 후 race 자체는 차단됐지만 panic / 강제 종료 시 잔여 위험.

### secall-web (2 hot / 5 debt / 4 watch)
**hot:**
- Graph snapshot 대용량 응답 → "멈춤 화면" (사용자 보고 직접 연결, 약 1246 edges / ~600KB)
- LLM config 모델 자유 입력 (`SettingsRoute.tsx` 7곳 모두 `<Input type=text>`, 드롭다운 없음)

**debt (신규):**
- Markdown 폴딩/언폴딩 미구현 (사용자 보고)
- `jfetch<unknown>` 6 endpoints 타입 미해결
- SessionsRoute 좌측 리스트 에러 표시 없음

**watch (신규):**
- react-query `staleTime` 보수적 (60s)
- mobile / tablet breakpoint 부재
- Markdown link 컴포넌트 미커스텀

## 다음 작업 단위 후보 (별도 PR)

- **P64 (hot)**: Graph snapshot edge_limit + client virtualization
- **P65 (hot)**: LLM config 모델 드롭다운 (datalist 패턴)
- **P66 (debt)**: Markdown 폴딩 (`<details>` override + heading collapse)
- **P67 (debt)**: `jfetch<unknown>` 타입 6건 정리
- **P68 (core hot)**: `Config::save()` 의 production path guard (`SECALL_CONFIG_PATH` 미설정 시 명시 에러)

## Test plan

- [x] 코드 변경 없음 (docs only)
- [x] `cargo fmt --all -- --check` 통과
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)