### PR TITLE
feat(graph): P64 — /api/graph/snapshot edge_limit + 우선순위 sampling

### DIFF
--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -271,6 +271,8 @@ async fn api_wiki_get(
 #[derive(serde::Deserialize)]
 struct GraphSnapshotQuery {
     session_limit: Option<usize>,
+    /// P64: edge_limit. default 500, clamp(50, 5000). 미설정 시 default.
+    edge_limit: Option<usize>,
 }
 
 async fn api_graph_snapshot(
@@ -278,8 +280,10 @@ async fn api_graph_snapshot(
     axum::extract::Query(q): axum::extract::Query<GraphSnapshotQuery>,
 ) -> impl IntoResponse {
     let session_limit = q.session_limit.unwrap_or(80).clamp(10, 500);
+    let edge_limit = q.edge_limit.unwrap_or(500).clamp(50, 5000);
     // 동기 fs / SQLite I/O 라 spawn_blocking 으로 wrap.
-    match tokio::task::spawn_blocking(move || s.do_graph_snapshot(session_limit)).await {
+    match tokio::task::spawn_blocking(move || s.do_graph_snapshot(session_limit, edge_limit)).await
+    {
         Ok(Ok(json)) => (StatusCode::OK, Json(json)).into_response(),
         Ok(Err(e)) => error_response(e),
         Err(e) => error_response(anyhow::anyhow!("graph_snapshot task join: {e}")),

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -432,18 +432,22 @@ impl SeCallMcpServer {
     /// — secall-web 의 좌측 wiki 리스트가 sessions DB 의 distinct project 가 아닌
     ///   실제 wiki 페이지 기준으로 표시되도록 분리된 endpoint.
     /// 의미 있는 그래프 subset 한 번에 반환 (Stage 9).
+    ///
     /// - project / topic / agent / tool 노드는 전부
     /// - session 노드는 degree 상위 `session_limit` 개만 (default 80)
     /// - 위 노드 ID 집합 안의 엣지를 우선순위별 sort 후 `edge_limit` 까지
     ///
     /// P64: `edge_limit` 추가. 이전엔 모든 in-set edges 가 응답됨 → 사용자 환경
     /// 에서 1246 edges / ~600KB 응답으로 web force-simulation 이 멈춤 화면.
-    /// 우선순위:
-    ///   0. session ↔ session 관계 (same_project / same_day / cluster_*) —
-    ///      그래프 구조 파악에 가장 valuable
-    ///   1. session → topic / tool (rich label)
-    ///   2. session → agent / project (cardinality 높아 중복적)
-    ///   3. 그 외
+    ///
+    /// 우선순위 (priority 0 = 최상위):
+    ///
+    /// - 0: session ↔ session 관계 (same_project / same_day / cluster_*) —
+    ///   그래프 구조 파악에 가장 valuable
+    /// - 1: session → topic / tool (rich label)
+    /// - 2: session → agent / project (cardinality 높아 중복적)
+    /// - 3: 그 외
+    ///
     /// 같은 우선순위 내에선 입력 순서 유지 (DB rowid 기준 stable).
     ///
     /// 응답: `{"nodes": [...], "edges": [...], "node_count", "edge_count",
@@ -482,10 +486,9 @@ impl SeCallMcpServer {
             .collect();
         all_nodes.extend(session_rows);
 
-        let id_set: std::collections::HashSet<String> =
-            all_nodes.iter().map(|n| n.0.clone()).collect();
-
-        // node id → type 매핑: 우선순위 결정 시 endpoint type 빠르게 조회.
+        // node id → type 매핑: 우선순위 결정 + in-set 존재 여부 동시 처리 (Gemini PR #76 리뷰 반영).
+        // `HashMap<&str, &str>` 는 stable Rust 에서 `get(&str)` 의 trait resolution
+        // (issue #130366) 으로 어색하므로 K=String 유지, 별도 id_set 만 제거.
         let type_of: std::collections::HashMap<String, String> = all_nodes
             .iter()
             .map(|(id, ty, _)| (id.clone(), ty.clone()))
@@ -503,7 +506,7 @@ impl SeCallMcpServer {
                 ))
             })?
             .filter_map(|r| r.ok())
-            .filter(|(s, t, _)| id_set.contains(s) && id_set.contains(t))
+            .filter(|(s, t, _)| type_of.contains_key(s) && type_of.contains_key(t))
             .collect();
 
         let total_in_set = edges.len();

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -434,10 +434,25 @@ impl SeCallMcpServer {
     /// 의미 있는 그래프 subset 한 번에 반환 (Stage 9).
     /// - project / topic / agent / tool 노드는 전부
     /// - session 노드는 degree 상위 `session_limit` 개만 (default 80)
-    /// - 위 노드 ID 집합 안의 엣지만 포함
+    /// - 위 노드 ID 집합 안의 엣지를 우선순위별 sort 후 `edge_limit` 까지
     ///
-    /// 응답: `{"nodes": [{"id","type","label"}], "edges": [{"source","target","relation"}], "node_count", "edge_count"}`
-    pub fn do_graph_snapshot(&self, session_limit: usize) -> anyhow::Result<serde_json::Value> {
+    /// P64: `edge_limit` 추가. 이전엔 모든 in-set edges 가 응답됨 → 사용자 환경
+    /// 에서 1246 edges / ~600KB 응답으로 web force-simulation 이 멈춤 화면.
+    /// 우선순위:
+    ///   0. session ↔ session 관계 (same_project / same_day / cluster_*) —
+    ///      그래프 구조 파악에 가장 valuable
+    ///   1. session → topic / tool (rich label)
+    ///   2. session → agent / project (cardinality 높아 중복적)
+    ///   3. 그 외
+    /// 같은 우선순위 내에선 입력 순서 유지 (DB rowid 기준 stable).
+    ///
+    /// 응답: `{"nodes": [...], "edges": [...], "node_count", "edge_count",
+    /// "session_limit", "edge_limit", "edges_truncated": bool}`
+    pub fn do_graph_snapshot(
+        &self,
+        session_limit: usize,
+        edge_limit: usize,
+    ) -> anyhow::Result<serde_json::Value> {
         let db = self
             .db
             .lock()
@@ -470,10 +485,16 @@ impl SeCallMcpServer {
         let id_set: std::collections::HashSet<String> =
             all_nodes.iter().map(|n| n.0.clone()).collect();
 
+        // node id → type 매핑: 우선순위 결정 시 endpoint type 빠르게 조회.
+        let type_of: std::collections::HashMap<String, String> = all_nodes
+            .iter()
+            .map(|(id, ty, _)| (id.clone(), ty.clone()))
+            .collect();
+
         let mut stmt = db
             .conn()
             .prepare("SELECT source, target, relation FROM graph_edges")?;
-        let edges: Vec<(String, String, String)> = stmt
+        let mut edges: Vec<(String, String, String)> = stmt
             .query_map([], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
@@ -484,6 +505,33 @@ impl SeCallMcpServer {
             .filter_map(|r| r.ok())
             .filter(|(s, t, _)| id_set.contains(s) && id_set.contains(t))
             .collect();
+
+        let total_in_set = edges.len();
+
+        // 우선순위: session-session > session-(topic/tool) > session-(agent/project) > 그 외
+        let priority = |s: &str, t: &str| -> u8 {
+            let ts = type_of.get(s).map(String::as_str).unwrap_or("");
+            let tt = type_of.get(t).map(String::as_str).unwrap_or("");
+            let ss = ts == "session" && tt == "session";
+            if ss {
+                return 0;
+            }
+            let touches_session = ts == "session" || tt == "session";
+            if touches_session {
+                let other = if ts == "session" { tt } else { ts };
+                return match other {
+                    "topic" | "tool" => 1,
+                    "agent" | "project" => 2,
+                    _ => 3,
+                };
+            }
+            3
+        };
+
+        // stable sort_by_key: 같은 우선순위는 DB 원래 순서 유지
+        edges.sort_by_key(|(s, t, _)| priority(s, t));
+        let edges_truncated = edges.len() > edge_limit;
+        edges.truncate(edge_limit);
 
         Ok(serde_json::json!({
             "nodes": all_nodes
@@ -496,7 +544,10 @@ impl SeCallMcpServer {
                 .collect::<Vec<_>>(),
             "node_count": all_nodes.len(),
             "edge_count": edges.len(),
+            "total_edges_in_set": total_in_set,
             "session_limit": session_limit,
+            "edge_limit": edge_limit,
+            "edges_truncated": edges_truncated,
         }))
     }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -179,10 +179,11 @@ export const api = {
     jfetch<unknown>("/api/wiki", { method: "POST", body: JSON.stringify(q) }),
 
   /** 의미 있는 그래프 subset (project + topic + agent + tool + degree top sessions). */
-  graphSnapshot: (sessionLimit = 80) =>
-    jfetch<unknown>(`/api/graph/snapshot?session_limit=${sessionLimit}`, {
-      method: "GET",
-    }),
+  graphSnapshot: (sessionLimit = 80, edgeLimit = 500) =>
+    jfetch<unknown>(
+      `/api/graph/snapshot?session_limit=${sessionLimit}&edge_limit=${edgeLimit}`,
+      { method: "GET" },
+    ),
 
   /** vault/wiki/projects/*.md 실존 페이지 목록. (sessions DB 의 distinct project 와 별개) */
   wikiList: () => jfetch<unknown>("/api/wiki", { method: "GET" }),

--- a/web/src/routes/GraphRoute.tsx
+++ b/web/src/routes/GraphRoute.tsx
@@ -29,17 +29,27 @@ interface GraphSnapshot {
   edges: GraphEdge[];
   node_count: number;
   edge_count: number;
+  /** P64: filter 후 in-set 인 총 엣지 수 (truncate 전). */
+  total_edges_in_set?: number;
   session_limit: number;
+  /** P64: server 가 적용한 edge cap. */
+  edge_limit?: number;
+  /** P64: edges 가 cap 에 의해 잘렸는지. */
+  edges_truncated?: boolean;
 }
 
 export default function GraphRoute() {
   const navigate = useNavigate();
   const [sessionLimit] = useState(80);
+  // P64: edge_limit default 500 (server clamp 50~5000). 큰 그래프에서 force-
+  // simulation 멈춤 차단. 향후 사용자 조절 UI 가능.
+  const [edgeLimit] = useState(500);
   const [hiddenTypes, setHiddenTypes] = useState<Set<string>>(new Set());
 
   const { data, isLoading, error } = useQuery<GraphSnapshot>({
-    queryKey: ["graph", "snapshot", sessionLimit],
-    queryFn: () => api.graphSnapshot(sessionLimit) as Promise<GraphSnapshot>,
+    queryKey: ["graph", "snapshot", sessionLimit, edgeLimit],
+    queryFn: () =>
+      api.graphSnapshot(sessionLimit, edgeLimit) as Promise<GraphSnapshot>,
     staleTime: 60_000,
   });
 
@@ -96,6 +106,9 @@ export default function GraphRoute() {
           })
         }
         sessionLimit={data.session_limit}
+        edgeLimit={data.edge_limit}
+        totalEdgesInSet={data.total_edges_in_set}
+        edgesTruncated={data.edges_truncated}
       />
     </div>
   );
@@ -107,6 +120,9 @@ interface SidebarProps {
   hiddenTypes: Set<string>;
   onToggleType: (t: string) => void;
   sessionLimit: number;
+  edgeLimit?: number;
+  totalEdgesInSet?: number;
+  edgesTruncated?: boolean;
 }
 
 const TYPE_DOT: Record<string, string> = {
@@ -123,6 +139,9 @@ function GraphSidebar({
   hiddenTypes,
   onToggleType,
   sessionLimit,
+  edgeLimit,
+  totalEdgesInSet,
+  edgesTruncated,
 }: SidebarProps) {
   // 타입별 카운트 (전체)
   const typeCounts = useMemo(() => {
@@ -200,6 +219,22 @@ function GraphSidebar({
                 {sessionLimit}
               </span>
             </div>
+            {edgeLimit !== undefined && (
+              <div className="flex items-center justify-between">
+                <span>Edge limit</span>
+                <span className="font-mono text-text-3 tabular-nums">
+                  {edgeLimit}
+                </span>
+              </div>
+            )}
+            {edgesTruncated && totalEdgesInSet !== undefined && (
+              <div className="flex items-center justify-between text-status-warn">
+                <span>Edges truncated</span>
+                <span className="font-mono tabular-nums">
+                  {totalEdgesInSet - edges.length} 숨김
+                </span>
+              </div>
+            )}
           </div>
         </section>
 
@@ -207,6 +242,7 @@ function GraphSidebar({
           <div className="eyebrow mb-ds-2">Note</div>
           <div className="text-t-meta text-text-3 leading-relaxed">
             project / topic / agent / tool 은 전부, session 은 degree 상위 {sessionLimit} 만 표시.
+            엣지는 우선순위 (session↔session &gt; session↔topic/tool &gt; …) 로 정렬 후 상위 {edgeLimit ?? 500} 까지.
             그 외 인접 관계는 force-simulation 결과 위치에서 사라질 수 있습니다.
           </div>
         </section>


### PR DESCRIPTION
## Summary

사용자 보고 "그래프 거의 멈춤 화면" 의 server-side 원인. 응답 edges 무제한 (사용자 환경 1246 edges / ~600KB) → web D3+SVG 멈춤.

## 변경
- **server** (`mcp/server.rs:do_graph_snapshot`): 시그니처 `(session_limit, edge_limit)`. 우선순위 stable sort 후 truncate.
- 우선순위: 0=session↔session > 1=session↔topic/tool > 2=session↔agent/project > 3=그 외
- **REST**: `edge_limit` query param, default 500, clamp(50, 5000)
- **web**: `graphSnapshot(sessionLimit, edgeLimit)`, GraphRoute sidebar Stats 에 Edge limit + edges_truncated 표시

## Test plan
- [x] cargo fmt/check, cargo test 풀, pnpm typecheck 통과
- [ ] CI 통과
- [ ] (수동) 실 환경 그래프 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)