### PR TITLE
fix(web): P66 follow-up — Gemini PR #75 security/a11y 리뷰 반영

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -37,6 +37,7 @@
     "react-router": "^7.0.0",
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.0",
     "remark-wiki-link": "^2.0.1",
     "sonner": "^1.7.0",
@@ -58,5 +59,10 @@
     "typescript": "^5.6.3",
     "vite": "^5.4.10",
     "vitest": "^2.1.9"
+  },
+  "pnpm": {
+    "overrides": {
+      "@ungap/structured-clone": "^1.3.1"
+    }
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@ungap/structured-clone': ^1.3.1
+
 importers:
 
   .:
@@ -83,6 +86,9 @@ importers:
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.1
@@ -1044,9 +1050,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1484,6 +1489,9 @@ packages:
 
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
@@ -2029,6 +2037,9 @@ packages:
 
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -3206,7 +3217,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@ungap/structured-clone@1.3.0': {}
+  '@ungap/structured-clone@1.3.1': {}
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.19.17))':
     dependencies:
@@ -3661,7 +3672,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.1
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.1
       html-void-elements: 3.0.0
@@ -3672,6 +3683,12 @@ snapshots:
       vfile: 6.0.3
       web-namespaces: 2.0.1
       zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.1
+      unist-util-position: 5.0.0
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
@@ -3999,7 +4016,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.1
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -4457,6 +4474,11 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-raw: 9.1.0
       vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   remark-gfm@4.0.1:
     dependencies:

--- a/web/src/components/MarkdownView.tsx
+++ b/web/src/components/MarkdownView.tsx
@@ -123,6 +123,12 @@ export function MarkdownView({ content, query, className }: Props) {
       tagNames: [...(defaultSchema.tagNames ?? []), "details", "summary"],
       attributes: {
         ...(defaultSchema.attributes ?? {}),
+        // Gemini PR #77 리뷰: <details open> 의 open 속성 + 브라우저 토글 시
+        // 추가되는 open 속성도 허용해야 함.
+        details: [
+          ...((defaultSchema.attributes ?? {}).details ?? []),
+          "open",
+        ],
         code: [
           ...((defaultSchema.attributes ?? {}).code ?? []),
           ["className", /^language-/, /^hljs/],
@@ -208,11 +214,15 @@ function CollapsibleHeading({
   // P66 follow-up (Gemini PR #75 a11y 리뷰):
   // role="button" + tabIndex=0 만으론 키보드 사용자가 폴딩 못 함.
   // Enter / Space 가 onClick 과 동일하게 작동하도록.
+  //
+  // Gemini PR #77 추가 리뷰: heading 내부 link (`<a>`) 의 Enter 키 동작 보전을
+  // 위해 onClick 과 동일하게 target 이 a/code 면 early return.
   const onKeyDown = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      onClick(e as unknown as MouseEvent<HTMLElement>);
-    }
+    if (e.key !== "Enter" && e.key !== " ") return;
+    const target = e.target as HTMLElement;
+    if (target.closest("a") || target.closest("code")) return;
+    e.preventDefault();
+    onClick(e as unknown as MouseEvent<HTMLElement>);
   };
   const marker = collapsed ? "▶" : "▼";
   const props = {

--- a/web/src/components/MarkdownView.tsx
+++ b/web/src/components/MarkdownView.tsx
@@ -4,13 +4,15 @@ import {
   useMemo,
   useState,
   type MouseEvent,
+  type KeyboardEvent,
 } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
-// remark-wiki-link / rehype-raw / rehype-highlight: 외부 plugin, 일부는 자체 d.ts 가 부정확.
+// remark-wiki-link / rehype-raw / rehype-highlight / rehype-sanitize: 외부 plugin.
 import remarkWikiLink from "remark-wiki-link";
 import rehypeRaw from "rehype-raw";
 import rehypeHighlight from "rehype-highlight";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { NavLink } from "react-router";
 import "highlight.js/styles/github-dark.css";
 import { highlightTerms, tokenizeQuery } from "@/lib/highlight";
@@ -108,11 +110,35 @@ export function MarkdownView({ content, query, className }: Props) {
     [],
   );
 
-  const rehypePlugins = useMemo(
-    // rehype-raw 가 먼저 raw HTML 을 hast 노드로 변환 → rehype-highlight 가 코드블록 처리.
-    () => [rehypeRaw, rehypeHighlight],
-    [],
-  );
+  const rehypePlugins = useMemo(() => {
+    // P66 follow-up (Gemini PR #75 보안 리뷰):
+    // rehype-raw 가 raw HTML 을 hast 노드로 변환 → rehype-sanitize 가 XSS
+    // 위험 태그/속성 제거 (rehypeRaw 직후, highlight 전에 sanitize 해야 함) →
+    // rehype-highlight 가 코드블록 syntax 처리.
+    //
+    // sanitize schema: defaultSchema (script/style/event handler 차단) 에
+    // <details>/<summary> 와 highlight.js 의 class 속성 허용 추가.
+    const schema = {
+      ...defaultSchema,
+      tagNames: [...(defaultSchema.tagNames ?? []), "details", "summary"],
+      attributes: {
+        ...(defaultSchema.attributes ?? {}),
+        code: [
+          ...((defaultSchema.attributes ?? {}).code ?? []),
+          ["className", /^language-/, /^hljs/],
+        ],
+        span: [
+          ...((defaultSchema.attributes ?? {}).span ?? []),
+          ["className", /^hljs-/],
+        ],
+      },
+    };
+    // unified 의 PluggableList 타입이 tuple form ([plugin, options]) 을 정확히
+    // 매칭하지 못해 cast. plugin/option 호환성은 rehype-sanitize 의 런타임 시그
+    // 니처와 일치.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return [rehypeRaw, [rehypeSanitize, schema], rehypeHighlight] as any;
+  }, []);
 
   return (
     <div
@@ -179,9 +205,19 @@ function CollapsibleHeading({
       next = next.nextElementSibling as HTMLElement | null;
     }
   };
+  // P66 follow-up (Gemini PR #75 a11y 리뷰):
+  // role="button" + tabIndex=0 만으론 키보드 사용자가 폴딩 못 함.
+  // Enter / Space 가 onClick 과 동일하게 작동하도록.
+  const onKeyDown = (e: KeyboardEvent<HTMLElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClick(e as unknown as MouseEvent<HTMLElement>);
+    }
+  };
   const marker = collapsed ? "▶" : "▼";
   const props = {
     onClick,
+    onKeyDown,
     "aria-expanded": !collapsed,
     role: "button",
     tabIndex: 0,


### PR DESCRIPTION
## Summary

Gemini PR #75 리뷰의 보안 / 접근성 finding 3건 반영.

| Finding | 분류 | 처리 |
|---|---|---|
| `rehype-raw` XSS 위험 | HIGH security | `rehype-sanitize` 중간 단계 추가 |
| `@ungap/structured-clone@1.3.0` CWE-502 | HIGH security | pnpm overrides → 1.3.1+ |
| heading collapse `onKeyDown` 누락 | MEDIUM a11y | Enter/Space 핸들러 추가 |
| heading collapse DOM 직접 조작 | MEDIUM | 별도 plan (state-driven 재설계) |

## sanitize schema

`defaultSchema` 베이스에:
- `<details>` / `<summary>` 태그 허용 (폴딩 동작)
- highlight.js 의 className (`hljs-*`, `language-*`) 허용 (syntax highlight)
- 그 외 script/style/event handler 등은 default 가 차단

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm build`
- [ ] CI 통과
- [ ] (수동) `<script>` 태그가 포함된 md 렌더링 시 차단되는지 확인

## 미해결 (별도 plan)

CollapsibleHeading 의 DOM 직접 조작 (`nextElementSibling` + `style.display`) → AST 분석 후 state 기반 재설계가 필요. web-backlog 항목으로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)