### PR TITLE
feat(llm): P65 — backend 별 model discovery + cache + REST endpoint

### DIFF
--- a/crates/secall-core/src/lib.rs
+++ b/crates/secall-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod ingest;
 pub mod jobs;
 pub mod llm {
     pub mod defaults;
+    pub mod model_discovery;
 }
 pub mod mcp;
 pub mod search;

--- a/crates/secall-core/src/llm/model_discovery.rs
+++ b/crates/secall-core/src/llm/model_discovery.rs
@@ -1,0 +1,468 @@
+//! P65 — backend 별 모델 dynamic discovery + cache.
+//!
+//! tunaFlow 의 `src-tauri/src/commands/model_discovery.rs` 패턴을 따라하되,
+//! secall 은 async tokio 환경이므로 `reqwest::Client` (async) 와
+//! `tokio::sync::RwLock` 으로 옮긴다.
+//!
+//! 핵심 원칙:
+//! - **Dynamic primary**: 각 backend 의 실 source 에서 fetch
+//!   (HTTP `/v1/models`, `/api/tags`, `~/.codex/models_cache.json`,
+//!   claude binary scan 등)
+//! - **Hardcoded fallback**: discovery 실패 시 fallback list.
+//!   fallback 자체도 `llm::defaults` 의 상수와 일관되게 유지한다.
+//! - **In-memory cache**: TTL 3600s. claude 만 binary mtime 무효화 추가.
+//! - **Force refresh** 옵션.
+//!
+//! 노출 함수:
+//! - [`discover_models`] — async API, [`DiscoveryResult`] 반환.
+//! - [`invalidate_cache`] — 단일 backend 또는 전체 cache flush.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant, SystemTime};
+
+use serde::Serialize;
+use tokio::sync::RwLock;
+
+use crate::llm::defaults::{
+    GRAPH_ANTHROPIC_DEFAULT, GRAPH_LMSTUDIO_DEFAULT, GRAPH_OLLAMA_CLOUD_DEFAULT,
+    GRAPH_OLLAMA_DEFAULT, LOG_OLLAMA_CLOUD_DEFAULT, WIKI_CODEX_DEFAULT,
+    WIKI_REVIEW_OLLAMA_CLOUD_DEFAULT,
+};
+
+const CACHE_TTL: Duration = Duration::from_secs(3600);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// discovery 결과 source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DiscoverySource {
+    /// 실 backend 에서 가져왔다 (HTTP, file, binary scan 등).
+    Dynamic,
+    /// dynamic 실패 또는 의도적으로 비활성 — hardcoded fallback list 사용.
+    Fallback,
+    /// 이전 호출 결과를 cache 에서 재사용.
+    Cached,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DiscoveryResult {
+    pub backend: String,
+    pub models: Vec<String>,
+    pub source: DiscoverySource,
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    models: Vec<String>,
+    at: Instant,
+    /// claude binary scan 시 사용. 이외 backend 에서는 None.
+    binary_stamp: Option<(PathBuf, SystemTime)>,
+}
+
+fn cache() -> &'static RwLock<HashMap<String, CacheEntry>> {
+    static CACHE: OnceLock<RwLock<HashMap<String, CacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// 단일 backend 또는 전체 cache 를 비운다.
+pub async fn invalidate_cache(backend: Option<&str>) {
+    let mut guard = cache().write().await;
+    match backend {
+        Some(b) => {
+            guard.remove(b);
+        }
+        None => guard.clear(),
+    }
+}
+
+/// public API. dynamic 우선, 실패 시 fallback. cache TTL 3600s.
+///
+/// `force=true` 면 cache 를 무시하고 항상 새로 가져온다 (성공 시 cache 갱신).
+pub async fn discover_models(backend: &str, force: bool) -> anyhow::Result<DiscoveryResult> {
+    // 1. cache lookup (force=false 일 때만)
+    if !force {
+        let guard = cache().read().await;
+        if let Some(entry) = guard.get(backend) {
+            let ttl_ok = entry.at.elapsed() < CACHE_TTL;
+            let stamp_fresh = match &entry.binary_stamp {
+                None => true,
+                Some((path, stamp)) => std::fs::metadata(path)
+                    .and_then(|m| m.modified())
+                    .map(|now| now == *stamp)
+                    .unwrap_or(false),
+            };
+            if ttl_ok && stamp_fresh {
+                return Ok(DiscoveryResult {
+                    backend: backend.to_string(),
+                    models: entry.models.clone(),
+                    source: DiscoverySource::Cached,
+                });
+            }
+        }
+    }
+
+    // 2. dynamic discovery
+    let (discovered, binary_stamp): (Option<Vec<String>>, Option<(PathBuf, SystemTime)>) =
+        match backend {
+            "ollama" => (discover_ollama(None, None).await, None),
+            "ollama_cloud" => (
+                discover_ollama(Some("https://ollama.com"), env_cloud_api_key().as_deref()).await,
+                None,
+            ),
+            "lmstudio" => (discover_lmstudio(None).await, None),
+            "anthropic" => match discover_anthropic_with_stamp() {
+                Some((m, p, t)) => (Some(m), Some((p, t))),
+                None => (None, None),
+            },
+            "codex" => (discover_codex(), None),
+            // OpenAI: discovery 생략 (API 호출 비용). 항상 fallback.
+            "openai" => (None, None),
+            // wiki claude alias backend ("haiku") — static, dynamic 무의미.
+            "haiku" => (None, None),
+            // wiki review: claude alias 라 dynamic 불필요.
+            "claude" => (None, None),
+            // disabled 는 모델 선택 자체가 의미 없음.
+            "disabled" => (None, None),
+            _ => (None, None),
+        };
+
+    if let Some(models) = discovered {
+        if !models.is_empty() {
+            let entry = CacheEntry {
+                models: models.clone(),
+                at: Instant::now(),
+                binary_stamp,
+            };
+            let mut guard = cache().write().await;
+            guard.insert(backend.to_string(), entry);
+            return Ok(DiscoveryResult {
+                backend: backend.to_string(),
+                models,
+                source: DiscoverySource::Dynamic,
+            });
+        }
+    }
+
+    // 3. fallback
+    let models = fallback_models(backend);
+    let entry = CacheEntry {
+        models: models.clone(),
+        at: Instant::now(),
+        binary_stamp: None,
+    };
+    let mut guard = cache().write().await;
+    guard.insert(backend.to_string(), entry);
+    Ok(DiscoveryResult {
+        backend: backend.to_string(),
+        models,
+        source: DiscoverySource::Fallback,
+    })
+}
+
+// ─── Fallback registry ──────────────────────────────────────────────────────
+
+/// backend 별 hardcoded fallback list. dynamic 실패 시에만 사용한다.
+/// `llm::defaults` 의 상수를 우선 기반으로 하고, 실용 모델 몇 개 더 추가.
+fn fallback_models(backend: &str) -> Vec<String> {
+    match backend {
+        "ollama" => vec![
+            GRAPH_OLLAMA_DEFAULT.to_string(),
+            "gemma3:12b".to_string(),
+            "qwen3:8b".to_string(),
+            "llama3.3:latest".to_string(),
+        ],
+        "ollama_cloud" => vec![
+            GRAPH_OLLAMA_CLOUD_DEFAULT.to_string(),
+            LOG_OLLAMA_CLOUD_DEFAULT.to_string(),
+            WIKI_REVIEW_OLLAMA_CLOUD_DEFAULT.to_string(),
+        ],
+        "lmstudio" => vec![
+            GRAPH_LMSTUDIO_DEFAULT.to_string(),
+            "qwen2.5-coder-7b-instruct".to_string(),
+        ],
+        "anthropic" => vec![
+            GRAPH_ANTHROPIC_DEFAULT.to_string(),
+            "claude-sonnet-4-5".to_string(),
+            "haiku".to_string(),
+            "sonnet".to_string(),
+            "opus".to_string(),
+        ],
+        "openai" => vec![
+            "text-embedding-3-small".to_string(),
+            "text-embedding-3-large".to_string(),
+        ],
+        "codex" => vec![
+            WIKI_CODEX_DEFAULT.to_string(),
+            "gpt-5.4-mini".to_string(),
+            "gpt-5.3-codex".to_string(),
+        ],
+        // claude alias backend (wiki review 용): static 3개 — dynamic 불가.
+        "claude" | "haiku" => {
+            vec![
+                "haiku".to_string(),
+                "sonnet".to_string(),
+                "opus".to_string(),
+            ]
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn env_cloud_api_key() -> Option<String> {
+    std::env::var("OLLAMA_CLOUD_API_KEY").ok()
+}
+
+// ─── Discovery 구현 ──────────────────────────────────────────────────────────
+
+/// Ollama (local 또는 cloud): `GET {base}/api/tags`.
+///
+/// - `base` 기본값: `http://localhost:11434`. cloud 의 경우 `https://ollama.com`.
+/// - `bearer` Some 이면 `Authorization: Bearer {token}` 헤더 추가.
+async fn discover_ollama(base: Option<&str>, bearer: Option<&str>) -> Option<Vec<String>> {
+    let base = base.unwrap_or("http://localhost:11434");
+    let url = format!("{}/api/tags", base.trim_end_matches('/'));
+    let client = reqwest::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .ok()?;
+    let mut req = client.get(&url);
+    if let Some(token) = bearer {
+        req = req.bearer_auth(token);
+    }
+    let resp = req.send().await.ok()?;
+    if !resp.status().is_success() {
+        tracing::debug!(target: "secall::model_discovery", "ollama {} → {}", url, resp.status());
+        return None;
+    }
+    let body: serde_json::Value = resp.json().await.ok()?;
+    let arr = body.get("models")?.as_array()?;
+    let mut models: Vec<String> = arr
+        .iter()
+        .filter_map(|m| m.get("name").and_then(|v| v.as_str()).map(String::from))
+        .collect();
+    models.sort();
+    models.dedup();
+    if models.is_empty() {
+        None
+    } else {
+        Some(models)
+    }
+}
+
+/// LM Studio: OpenAI-compatible `GET {base}/v1/models`.
+async fn discover_lmstudio(base: Option<&str>) -> Option<Vec<String>> {
+    let base = base.unwrap_or("http://localhost:1234");
+    let url = format!("{}/v1/models", base.trim_end_matches('/'));
+    let client = reqwest::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .ok()?;
+    let resp = client.get(&url).send().await.ok()?;
+    if !resp.status().is_success() {
+        tracing::debug!(target: "secall::model_discovery", "lmstudio {} → {}", url, resp.status());
+        return None;
+    }
+    let body: serde_json::Value = resp.json().await.ok()?;
+    let data = body.get("data")?.as_array()?;
+    let mut models: Vec<String> = data
+        .iter()
+        .filter_map(|m| m.get("id").and_then(|v| v.as_str()).map(String::from))
+        .collect();
+    models.sort();
+    models.dedup();
+    if models.is_empty() {
+        None
+    } else {
+        Some(models)
+    }
+}
+
+/// Codex: `~/.codex/models_cache.json` read.
+fn discover_codex() -> Option<Vec<String>> {
+    let path = dirs::home_dir()?.join(".codex").join("models_cache.json");
+    if !path.exists() {
+        return None;
+    }
+    let text = std::fs::read_to_string(&path).ok()?;
+    let data: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let arr = data.get("models")?.as_array()?;
+    let mut models = Vec::new();
+    for m in arr {
+        let slug = m.get("slug").and_then(|v| v.as_str()).unwrap_or("");
+        let vis = m.get("visibility").and_then(|v| v.as_str()).unwrap_or("");
+        if !slug.is_empty() && vis != "hide" {
+            models.push(slug.to_string());
+        }
+    }
+    if models.is_empty() {
+        None
+    } else {
+        Some(models)
+    }
+}
+
+/// `which claude` 후 symlink resolve.
+fn resolve_anthropic_binary() -> Option<PathBuf> {
+    let (lookup, arg) = if cfg!(windows) {
+        ("where", "claude")
+    } else {
+        ("which", "claude")
+    };
+    let output = std::process::Command::new(lookup).arg(arg).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let first = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()?
+        .trim()
+        .to_string();
+    if first.is_empty() {
+        return None;
+    }
+    std::fs::canonicalize(PathBuf::from(first)).ok()
+}
+
+/// 바이트 시퀀스에서 claude 모델 ID 문자열만 추출 (printable ASCII run 기준).
+///
+/// 정규식: `\bclaude-(opus|sonnet|haiku)-\d+(-\d+)?(-\d{8})?\b`.
+pub(crate) fn extract_claude_model_ids(bytes: &[u8]) -> std::collections::BTreeSet<String> {
+    use regex::Regex;
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"\bclaude-(?:opus|sonnet|haiku)-\d+(?:-\d+)?(?:-\d{8})?\b")
+            .expect("claude model ID regex must compile (P65 model_discovery)")
+    });
+    let mut out = std::collections::BTreeSet::new();
+    let is_printable = |b: u8| (32..127).contains(&b);
+    let mut start = 0usize;
+    for i in 0..bytes.len() {
+        if !is_printable(bytes[i]) {
+            if i > start {
+                if let Ok(s) = std::str::from_utf8(&bytes[start..i]) {
+                    for m in re.find_iter(s) {
+                        out.insert(m.as_str().to_string());
+                    }
+                }
+            }
+            start = i + 1;
+        }
+    }
+    if start < bytes.len() {
+        if let Ok(s) = std::str::from_utf8(&bytes[start..]) {
+            for m in re.find_iter(s) {
+                out.insert(m.as_str().to_string());
+            }
+        }
+    }
+    out
+}
+
+/// claude binary 를 스캔하여 모델 ID + 바이너리 mtime 반환.
+fn discover_anthropic_with_stamp() -> Option<(Vec<String>, PathBuf, SystemTime)> {
+    let path = resolve_anthropic_binary()?;
+    let meta = std::fs::metadata(&path).ok()?;
+    let mtime = meta.modified().ok()?;
+    // 300MB guard (tunaFlow 동일)
+    const MAX_BIN_SIZE: u64 = 300 * 1024 * 1024;
+    if meta.len() > MAX_BIN_SIZE {
+        tracing::warn!(
+            target: "secall::model_discovery",
+            size = meta.len(),
+            "claude binary too large, skipping scan"
+        );
+        return None;
+    }
+    let bytes = std::fs::read(&path).ok()?;
+    let ids = extract_claude_model_ids(&bytes);
+    if ids.is_empty() {
+        return None;
+    }
+    let mut models: Vec<String> = ids.into_iter().collect();
+    // 정렬: family 우선 + 버전 내림차순. 단순화를 위해 알파벳 desc sort 사용
+    // (claude-opus-4-7 > claude-opus-4-6 > claude-sonnet-* 와 같이 family
+    // prefix 가 일정해서 일관된 순서가 나옴).
+    models.sort_by(|a, b| b.cmp(a));
+    // alias 도 prepend — CLI 가 항상 인식.
+    for alias in ["haiku", "sonnet", "opus"] {
+        if !models.iter().any(|m| m == alias) {
+            models.insert(0, alias.to_string());
+        }
+    }
+    Some((models, path, mtime))
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn unknown_backend_returns_empty_fallback() {
+        let r = discover_models("nope_xyz", false).await.unwrap();
+        assert_eq!(r.backend, "nope_xyz");
+        assert_eq!(r.source, DiscoverySource::Fallback);
+        assert!(r.models.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ollama_offline_falls_back_to_static_list() {
+        // discover_ollama 가 localhost:11434 로 시도하지만 대부분의 CI/test
+        // 환경에서는 ollama 가 떠 있지 않다 → fallback 경로를 탄다.
+        // (만약 떠 있어도 dynamic 결과가 비어있지 않으면 그대로 통과)
+        invalidate_cache(Some("ollama")).await;
+        let r = discover_models("ollama", true).await.unwrap();
+        assert_eq!(r.backend, "ollama");
+        assert!(!r.models.is_empty(), "ollama models must never be empty");
+        // GRAPH_OLLAMA_DEFAULT 가 fallback 또는 dynamic 결과에 들어있는지는
+        // 환경 의존이므로 강제 assert 하지 않는다.
+    }
+
+    #[tokio::test]
+    async fn cache_hit_returns_cached_source() {
+        invalidate_cache(Some("openai")).await;
+        // openai 는 discovery 없이 항상 fallback.
+        let first = discover_models("openai", false).await.unwrap();
+        assert_eq!(first.source, DiscoverySource::Fallback);
+        let second = discover_models("openai", false).await.unwrap();
+        assert_eq!(second.source, DiscoverySource::Cached);
+        assert_eq!(first.models, second.models);
+    }
+
+    #[tokio::test]
+    async fn force_bypasses_cache() {
+        invalidate_cache(Some("openai")).await;
+        let _ = discover_models("openai", false).await.unwrap();
+        let forced = discover_models("openai", true).await.unwrap();
+        // force=true 면 cache 무시 → fallback (openai 는 dynamic 없음).
+        assert_eq!(forced.source, DiscoverySource::Fallback);
+    }
+
+    #[test]
+    fn extract_claude_ids_basic() {
+        let haystack = b"random\nclaude-opus-4-7 mid claude-sonnet-4-6 tail\nclaude-foo-1-0";
+        let ids = extract_claude_model_ids(haystack);
+        assert!(ids.contains("claude-opus-4-7"));
+        assert!(ids.contains("claude-sonnet-4-6"));
+        assert!(!ids.iter().any(|s| s.contains("foo")));
+    }
+
+    #[test]
+    fn fallback_models_known_backends_non_empty() {
+        for b in [
+            "ollama",
+            "ollama_cloud",
+            "lmstudio",
+            "anthropic",
+            "openai",
+            "codex",
+            "claude",
+        ] {
+            let m = fallback_models(b);
+            assert!(!m.is_empty(), "fallback for {} must not be empty", b);
+        }
+    }
+}

--- a/crates/secall-core/src/llm/model_discovery.rs
+++ b/crates/secall-core/src/llm/model_discovery.rs
@@ -66,6 +66,18 @@ fn cache() -> &'static RwLock<HashMap<String, CacheEntry>> {
     CACHE.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
+/// 공유 reqwest::Client — connection pool 재사용 (Gemini PR #78 리뷰 반영).
+/// builder 매 호출마다 만들면 keep-alive / TLS handshake 마다 새로 — 비효율.
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            .expect("reqwest client build should not fail with default config")
+    })
+}
+
 /// 단일 backend 또는 전체 cache 를 비운다.
 pub async fn invalidate_cache(backend: Option<&str>) {
     let mut guard = cache().write().await;
@@ -83,15 +95,20 @@ pub async fn invalidate_cache(backend: Option<&str>) {
 pub async fn discover_models(backend: &str, force: bool) -> anyhow::Result<DiscoveryResult> {
     // 1. cache lookup (force=false 일 때만)
     if !force {
-        let guard = cache().read().await;
-        if let Some(entry) = guard.get(backend) {
+        // entry 를 clone 으로 받아 read lock 빨리 해제 + 이후 async I/O 가능.
+        let cached_entry: Option<CacheEntry> = {
+            let guard = cache().read().await;
+            guard.get(backend).cloned()
+        };
+        if let Some(entry) = cached_entry {
             let ttl_ok = entry.at.elapsed() < CACHE_TTL;
+            // P78 follow-up: 동기 fs::metadata 차단 → tokio::fs::metadata 비동기.
             let stamp_fresh = match &entry.binary_stamp {
                 None => true,
-                Some((path, stamp)) => std::fs::metadata(path)
-                    .and_then(|m| m.modified())
-                    .map(|now| now == *stamp)
-                    .unwrap_or(false),
+                Some((path, stamp)) => match tokio::fs::metadata(path).await {
+                    Ok(m) => m.modified().map(|now| now == *stamp).unwrap_or(false),
+                    Err(_) => false,
+                },
             };
             if ttl_ok && stamp_fresh {
                 return Ok(DiscoveryResult {
@@ -112,11 +129,11 @@ pub async fn discover_models(backend: &str, force: bool) -> anyhow::Result<Disco
                 None,
             ),
             "lmstudio" => (discover_lmstudio(None).await, None),
-            "anthropic" => match discover_anthropic_with_stamp() {
+            "anthropic" => match discover_anthropic_with_stamp().await {
                 Some((m, p, t)) => (Some(m), Some((p, t))),
                 None => (None, None),
             },
-            "codex" => (discover_codex(), None),
+            "codex" => (discover_codex().await, None),
             // OpenAI: discovery 생략 (API 호출 비용). 항상 fallback.
             "openai" => (None, None),
             // wiki claude alias backend ("haiku") — static, dynamic 무의미.
@@ -223,11 +240,8 @@ fn env_cloud_api_key() -> Option<String> {
 async fn discover_ollama(base: Option<&str>, bearer: Option<&str>) -> Option<Vec<String>> {
     let base = base.unwrap_or("http://localhost:11434");
     let url = format!("{}/api/tags", base.trim_end_matches('/'));
-    let client = reqwest::Client::builder()
-        .timeout(HTTP_TIMEOUT)
-        .build()
-        .ok()?;
-    let mut req = client.get(&url);
+    // P78 follow-up: 공유 client 사용 (connection pool 재사용).
+    let mut req = http_client().get(&url);
     if let Some(token) = bearer {
         req = req.bearer_auth(token);
     }
@@ -255,11 +269,8 @@ async fn discover_ollama(base: Option<&str>, bearer: Option<&str>) -> Option<Vec
 async fn discover_lmstudio(base: Option<&str>) -> Option<Vec<String>> {
     let base = base.unwrap_or("http://localhost:1234");
     let url = format!("{}/v1/models", base.trim_end_matches('/'));
-    let client = reqwest::Client::builder()
-        .timeout(HTTP_TIMEOUT)
-        .build()
-        .ok()?;
-    let resp = client.get(&url).send().await.ok()?;
+    // P78 follow-up: 공유 client 사용.
+    let resp = http_client().get(&url).send().await.ok()?;
     if !resp.status().is_success() {
         tracing::debug!(target: "secall::model_discovery", "lmstudio {} → {}", url, resp.status());
         return None;
@@ -280,12 +291,12 @@ async fn discover_lmstudio(base: Option<&str>) -> Option<Vec<String>> {
 }
 
 /// Codex: `~/.codex/models_cache.json` read.
-fn discover_codex() -> Option<Vec<String>> {
+///
+/// P78 follow-up: async + tokio::fs (Tokio worker 블로킹 회피), sort+dedup
+/// (다른 discover 함수와 일관성).
+async fn discover_codex() -> Option<Vec<String>> {
     let path = dirs::home_dir()?.join(".codex").join("models_cache.json");
-    if !path.exists() {
-        return None;
-    }
-    let text = std::fs::read_to_string(&path).ok()?;
+    let text = tokio::fs::read_to_string(&path).await.ok()?;
     let data: serde_json::Value = serde_json::from_str(&text).ok()?;
     let arr = data.get("models")?.as_array()?;
     let mut models = Vec::new();
@@ -296,6 +307,8 @@ fn discover_codex() -> Option<Vec<String>> {
             models.push(slug.to_string());
         }
     }
+    models.sort();
+    models.dedup();
     if models.is_empty() {
         None
     } else {
@@ -361,9 +374,12 @@ pub(crate) fn extract_claude_model_ids(bytes: &[u8]) -> std::collections::BTreeS
 }
 
 /// claude binary 를 스캔하여 모델 ID + 바이너리 mtime 반환.
-fn discover_anthropic_with_stamp() -> Option<(Vec<String>, PathBuf, SystemTime)> {
+///
+/// P78 follow-up: async + tokio::fs — claude binary 가 최대 300MB 라
+/// 동기 read 시 Tokio worker 가 길게 차단됨.
+async fn discover_anthropic_with_stamp() -> Option<(Vec<String>, PathBuf, SystemTime)> {
     let path = resolve_anthropic_binary()?;
-    let meta = std::fs::metadata(&path).ok()?;
+    let meta = tokio::fs::metadata(&path).await.ok()?;
     let mtime = meta.modified().ok()?;
     // 300MB guard (tunaFlow 동일)
     const MAX_BIN_SIZE: u64 = 300 * 1024 * 1024;
@@ -375,7 +391,7 @@ fn discover_anthropic_with_stamp() -> Option<(Vec<String>, PathBuf, SystemTime)>
         );
         return None;
     }
-    let bytes = std::fs::read(&path).ok()?;
+    let bytes = tokio::fs::read(&path).await.ok()?;
     let ids = extract_claude_model_ids(&bytes);
     if ids.is_empty() {
         return None;

--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -162,6 +162,8 @@ pub fn rest_router(server: SeCallMcpServer, executor: Arc<JobExecutor>) -> Route
         .route("/api/jobs/{id}", get(api_get_job))
         .route("/api/jobs/{id}/stream", get(api_job_stream))
         .route("/api/jobs/{id}/cancel", post(api_cancel_job))
+        // P65 — backend 별 모델 dynamic discovery
+        .route("/api/models", get(api_list_models))
         .layer(cors)
         .with_state(state);
 
@@ -347,6 +349,38 @@ async fn api_config_patch(
                 error_response(e)
             }
         }
+    }
+}
+
+/// P65 — `GET /api/models?backend=<name>&force=<bool>`.
+///
+/// 응답: `{ "backend": "...", "models": [...], "source": "dynamic"|"fallback"|"cached" }`.
+#[derive(Debug, Deserialize)]
+struct ListModelsQuery {
+    backend: Option<String>,
+    #[serde(default)]
+    force: Option<bool>,
+}
+
+async fn api_list_models(
+    axum::extract::Query(q): axum::extract::Query<ListModelsQuery>,
+) -> impl IntoResponse {
+    let Some(backend) = q
+        .backend
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "backend query param required"})),
+        )
+            .into_response();
+    };
+    let force = q.force.unwrap_or(false);
+    match crate::llm::model_discovery::discover_models(backend, force).await {
+        Ok(result) => (StatusCode::OK, Json(result)).into_response(),
+        Err(e) => error_response(e),
     }
 }
 

--- a/web/src/components/settings/ModelInput.tsx
+++ b/web/src/components/settings/ModelInput.tsx
@@ -1,0 +1,96 @@
+import { useId } from "react";
+import { Loader2, RefreshCw } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { useModels, useModelsRefresh } from "@/hooks/useModels";
+
+/**
+ * P65 — backend 별 모델 입력 컴포넌트.
+ *
+ * - `useModels(backend)` 로 `/api/models` 호출 결과를 `<datalist>` 옵션으로 노출.
+ * - dynamic 실패 시 서버가 fallback list 를 돌려주므로 빈 옵션 상황은 거의 없음.
+ * - 사용자는 자유 입력 가능 (모델 ID 가 비공개/실험적일 수 있어 강제 선택 X).
+ * - source 가 `fallback` 이면 작은 힌트 텍스트로 알림.
+ */
+export function ModelInput({
+  backend,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  ariaLabel,
+}: {
+  backend: string | null | undefined;
+  value: string;
+  onChange: (next: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  ariaLabel?: string;
+}) {
+  const id = useId();
+  const listId = `models-${id}`;
+  const enabled = !!backend && backend !== "disabled";
+  const { data, isLoading, isError, refetch, isFetching } = useModels(backend, {
+    enabled,
+  });
+  const refresh = useModelsRefresh();
+
+  const models = data?.models ?? [];
+  const source = data?.source;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        <Input
+          aria-label={ariaLabel}
+          value={value}
+          list={enabled && models.length > 0 ? listId : undefined}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder={placeholder}
+          autoComplete="off"
+        />
+        {enabled && (
+          <button
+            type="button"
+            onClick={async () => {
+              if (!backend) return;
+              await refresh(backend);
+              // useQuery 쪽도 동기화
+              await refetch();
+            }}
+            disabled={disabled || isFetching}
+            className="inline-flex h-9 items-center justify-center rounded-md border border-hairline px-2 text-text-3 hover:text-text disabled:opacity-50"
+            aria-label="모델 목록 새로고침"
+            title="모델 목록 새로고침"
+          >
+            {isFetching ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3.5" />
+            )}
+          </button>
+        )}
+      </div>
+      {enabled && models.length > 0 && (
+        <datalist id={listId}>
+          {models.map((m) => (
+            <option key={m} value={m} />
+          ))}
+        </datalist>
+      )}
+      {enabled && isLoading && (
+        <p className="text-t-meta text-text-3">모델 목록 로드 중…</p>
+      )}
+      {enabled && !isLoading && isError && (
+        <p className="text-t-meta text-status-danger">
+          모델 목록 조회 실패 — 직접 입력하세요.
+        </p>
+      )}
+      {enabled && source === "fallback" && (
+        <p className="text-t-meta text-text-3">
+          fallback 목록 표시 중 (backend 응답 없음 — 직접 입력 가능)
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/useModels.ts
+++ b/web/src/hooks/useModels.ts
@@ -1,0 +1,31 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type { ModelsResponse } from "@/lib/types";
+
+/**
+ * P65 — backend 별 모델 목록 dynamic discovery.
+ *
+ * `/api/models?backend=<name>` 결과를 캐시한다. 서버 자체도 TTL 3600s 캐시 →
+ * 클라이언트 staleTime 은 그보다 짧게 (10분) 잡아 UI 변경이 빠르게 반영되도록.
+ * `enabled=false` 인 backend (예: 빈 문자열) 는 호출하지 않는다.
+ */
+export function useModels(backend: string | null | undefined, opts?: { enabled?: boolean }) {
+  return useQuery<ModelsResponse>({
+    queryKey: ["models", backend ?? ""],
+    queryFn: () => api.listModels(backend as string),
+    enabled: !!backend && (opts?.enabled ?? true),
+    staleTime: 10 * 60 * 1000,
+    // 백그라운드 실패해도 fallback 응답이 오기 때문에 retry 1회면 충분.
+    retry: 1,
+  });
+}
+
+/** 강제 새로고침 (server cache 도 무효화). */
+export function useModelsRefresh() {
+  const qc = useQueryClient();
+  return async (backend: string) => {
+    const fresh = await api.listModels(backend, true);
+    qc.setQueryData<ModelsResponse>(["models", backend], fresh);
+    return fresh;
+  };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,6 +3,7 @@ import type {
   IngestArgs,
   JobStartResponse,
   JobState,
+  ModelsResponse,
   RecallResponse,
   SessionDetail,
   SessionListPage,
@@ -238,4 +239,13 @@ export const api = {
     jfetch<unknown>(`/api/jobs/${encodeURIComponent(id)}/cancel`, {
       method: "POST",
     }),
+
+  /**
+   * P65 — backend 별 모델 dynamic discovery.
+   * `force=true` 면 서버 캐시 무시.
+   */
+  listModels: (backend: string, force?: boolean) =>
+    jfetch<ModelsResponse>(
+      `/api/models?backend=${encodeURIComponent(backend)}${force ? "&force=true" : ""}`,
+    ),
 };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -262,3 +262,18 @@ export interface SessionsListParams extends SessionFilterState {
   page?: number;
   page_size?: number;
 }
+
+/**
+ * `/api/models?backend=<name>&force=<bool>` 응답 (P65).
+ *
+ * - `dynamic`: 실 backend 에서 fetch 성공
+ * - `fallback`: dynamic 실패 → hardcoded fallback list
+ * - `cached`: 이전 호출 결과 재사용 (TTL 3600s)
+ */
+export type ModelDiscoverySource = "dynamic" | "fallback" | "cached";
+
+export interface ModelsResponse {
+  backend: string;
+  models: string[];
+  source: ModelDiscoverySource;
+}

--- a/web/src/routes/SettingsRoute.tsx
+++ b/web/src/routes/SettingsRoute.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { MaskedKeyInfoModal } from "@/components/settings/MaskedKeyInfoModal";
+import { ModelInput } from "@/components/settings/ModelInput";
 import { useConfig, useConfigPatch } from "@/hooks/useConfig";
 import type { AppConfig, ConfigBackendConfig } from "@/lib/api";
 import { validateHttpUrl, validateModelName } from "@/lib/validators";
@@ -271,13 +272,15 @@ export default function SettingsRoute() {
                     label="Review model"
                     error={fieldError(validateModelName(wikiForm.review_model ?? ""))}
                   >
-                    <Input
+                    <ModelInput
+                      backend="claude"
                       value={wikiForm.review_model ?? ""}
-                      onChange={(e) =>
-                        setWikiForm((prev) => (prev ? { ...prev, review_model: e.target.value } : prev))
+                      onChange={(next) =>
+                        setWikiForm((prev) => (prev ? { ...prev, review_model: next } : prev))
                       }
                       disabled={readOnly}
                       placeholder="sonnet"
+                      ariaLabel="Wiki review model"
                     />
                   </Field>
                   {["claude", "codex", "haiku", "ollama", "lmstudio"].map((backend) => {
@@ -362,24 +365,28 @@ export default function SettingsRoute() {
                       label="Ollama model"
                       error={fieldError(validateModelName(graphForm.ollama_model ?? ""))}
                     >
-                      <Input
+                      <ModelInput
+                        backend="ollama"
                         value={graphForm.ollama_model ?? ""}
-                        onChange={(e) =>
-                          setGraphForm((prev) => (prev ? { ...prev, ollama_model: e.target.value } : prev))
+                        onChange={(next) =>
+                          setGraphForm((prev) => (prev ? { ...prev, ollama_model: next } : prev))
                         }
                         disabled={readOnly}
+                        ariaLabel="Graph ollama model"
                       />
                     </Field>
                     <Field
                       label="Anthropic model"
                       error={fieldError(validateModelName(graphForm.anthropic_model ?? ""))}
                     >
-                      <Input
+                      <ModelInput
+                        backend="anthropic"
                         value={graphForm.anthropic_model ?? ""}
-                        onChange={(e) =>
-                          setGraphForm((prev) => (prev ? { ...prev, anthropic_model: e.target.value } : prev))
+                        onChange={(next) =>
+                          setGraphForm((prev) => (prev ? { ...prev, anthropic_model: next } : prev))
                         }
                         disabled={readOnly}
+                        ariaLabel="Graph anthropic model"
                       />
                     </Field>
                     <Field
@@ -400,14 +407,15 @@ export default function SettingsRoute() {
                       label="Cloud model"
                       error={fieldError(validateModelName(graphForm.cloud_model ?? ""))}
                     >
-                      <Input
-                        aria-label="Cloud model"
+                      <ModelInput
+                        backend="ollama_cloud"
                         value={graphForm.cloud_model ?? ""}
-                        onChange={(e) =>
-                          setGraphForm((prev) => (prev ? { ...prev, cloud_model: e.target.value } : prev))
+                        onChange={(next) =>
+                          setGraphForm((prev) => (prev ? { ...prev, cloud_model: next } : prev))
                         }
                         disabled={readOnly}
                         placeholder="gemma4:31b-cloud"
+                        ariaLabel="Cloud model"
                       />
                     </Field>
                   </SettingsGrid>
@@ -461,12 +469,14 @@ export default function SettingsRoute() {
                   </Field>
                   <SettingsGrid>
                     <Field label="Model" error={fieldError(validateModelName(logForm.model ?? ""))}>
-                      <Input
+                      <ModelInput
+                        backend={logForm.backend ?? null}
                         value={logForm.model ?? ""}
-                        onChange={(e) =>
-                          setLogForm((prev) => (prev ? { ...prev, model: e.target.value } : prev))
+                        onChange={(next) =>
+                          setLogForm((prev) => (prev ? { ...prev, model: next } : prev))
                         }
                         disabled={readOnly}
+                        ariaLabel="Log model"
                       />
                     </Field>
                     <Field label="API URL" error={fieldError(validateHttpUrl(logForm.api_url ?? ""))}>
@@ -509,14 +519,15 @@ export default function SettingsRoute() {
                       label="Cloud model"
                       error={fieldError(validateModelName(logForm.cloud_model ?? ""))}
                     >
-                      <Input
-                        aria-label="Log cloud model"
+                      <ModelInput
+                        backend="ollama_cloud"
                         value={logForm.cloud_model ?? ""}
-                        onChange={(e) =>
-                          setLogForm((prev) => (prev ? { ...prev, cloud_model: e.target.value } : prev))
+                        onChange={(next) =>
+                          setLogForm((prev) => (prev ? { ...prev, cloud_model: next } : prev))
                         }
                         disabled={readOnly}
                         placeholder="kimi-k2.6:cloud"
+                        ariaLabel="Log cloud model"
                       />
                     </Field>
                   </SettingsGrid>
@@ -567,24 +578,32 @@ export default function SettingsRoute() {
                       label="Ollama model"
                       error={fieldError(validateModelName(embeddingForm.ollama_model ?? ""))}
                     >
-                      <Input
+                      <ModelInput
+                        backend="ollama"
                         value={embeddingForm.ollama_model ?? ""}
-                        onChange={(e) =>
-                          setEmbeddingForm((prev) => (prev ? { ...prev, ollama_model: e.target.value } : prev))
+                        onChange={(next) =>
+                          setEmbeddingForm((prev) =>
+                            prev ? { ...prev, ollama_model: next } : prev,
+                          )
                         }
                         disabled={readOnly}
+                        ariaLabel="Embedding ollama model"
                       />
                     </Field>
                     <Field
                       label="OpenAI model"
                       error={fieldError(validateModelName(embeddingForm.openai_model ?? ""))}
                     >
-                      <Input
+                      <ModelInput
+                        backend="openai"
                         value={embeddingForm.openai_model ?? ""}
-                        onChange={(e) =>
-                          setEmbeddingForm((prev) => (prev ? { ...prev, openai_model: e.target.value } : prev))
+                        onChange={(next) =>
+                          setEmbeddingForm((prev) =>
+                            prev ? { ...prev, openai_model: next } : prev,
+                          )
                         }
                         disabled={readOnly}
+                        ariaLabel="Embedding openai model"
                       />
                     </Field>
                     <Field label="OpenVINO device">
@@ -634,13 +653,16 @@ export default function SettingsRoute() {
                       label="Embedding cloud model"
                       error={fieldError(validateModelName(embeddingForm.cloud_model ?? ""))}
                     >
-                      <Input
-                        aria-label="Embedding cloud model"
+                      <ModelInput
+                        backend="ollama_cloud"
                         value={embeddingForm.cloud_model ?? ""}
-                        onChange={(e) =>
-                          setEmbeddingForm((prev) => (prev ? { ...prev, cloud_model: e.target.value } : prev))
+                        onChange={(next) =>
+                          setEmbeddingForm((prev) =>
+                            prev ? { ...prev, cloud_model: next } : prev,
+                          )
                         }
                         disabled={readOnly}
+                        ariaLabel="Embedding cloud model"
                       />
                     </Field>
                     <Field label="Ollama Cloud API key">
@@ -683,10 +705,12 @@ function BackendCard({
       <div className="mb-ds-3 text-t-h2 font-medium">{backend}</div>
       <div className="grid grid-cols-1 gap-ds-3 md:grid-cols-3">
         <Field label="Model" error={fieldError(validateModelName(config.model ?? ""))}>
-          <Input
+          <ModelInput
+            backend={backend}
             value={config.model ?? ""}
-            onChange={(e) => onChange({ ...config, model: e.target.value })}
+            onChange={(next) => onChange({ ...config, model: next })}
             disabled={readOnly}
+            ariaLabel={`${backend} model`}
           />
         </Field>
         <Field label="API URL" error={fieldError(validateHttpUrl(config.api_url ?? ""))}>


### PR DESCRIPTION
## Summary

P65 (LLM config 모델 입력 드롭다운) 을 **dynamic discovery 기반**으로 재구현. 이전 hardcoded `models.ts` 폐기. tunaFlow 의 `model_discovery.rs` 패턴 참고.

## 변경

### server (`crates/secall-core/src/llm/model_discovery.rs` 신설)
- **6 discovery 함수**:
  - `discover_ollama` (async HTTP `GET {api_url}/api/tags`)
  - `discover_lmstudio` (async HTTP `GET {host}/v1/models`)
  - `discover_codex` (`~/.codex/models_cache.json` read)
  - `discover_anthropic_with_stamp` (claude CLI binary 정규식 스캔 — auto-updater 대응 mtime)
  - `ollama_cloud` (ollama discovery 재사용 + Bearer auth)
  - 그 외 (openai / claude alias / disabled / haiku) 는 항상 fallback
- **Cache**: `OnceLock<RwLock<HashMap>>` + TTL 3600s, anthropic 은 binary mtime stamp 로 추가 무효화
- **fallback**: discovery 실패 시 `defaults.rs` 기반 합리적 모음

### REST (`crates/secall-core/src/mcp/rest.rs`)
- `GET /api/models?backend=<name>&force=<bool>` → `{backend, models, source: "dynamic"|"fallback"|"cached"}`

### web
- `useModels` hook + `ModelInput` 컴포넌트 신설
- SettingsRoute 의 **9개 model 입력** (wiki 5 backend + review + graph 3 + log 2 + embedding 3) 일괄 적용
- `<datalist>` 자동완성 + 자유 입력 + refresh 버튼

## tunaFlow 패턴 차용
- **Dynamic primary, hardcoded fallback** (정말 fallback only)
- in-process cache + TTL + binary mtime invalidation
- force refresh 옵션

## 한계 (별도 plan / backlog)
- `ollama_cloud` 의 `/api/tags` 가 실제 cloud 에서 동작하는지 미검증 — 안 되면 fallback 으로 떨어지므로 UX 는 안전
- OpenAI / Gemini 의 `models` API 호출은 비용 / 인증 문제로 미구현

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace -D warnings`
- [x] `cargo test` 풀 통과
- [x] `pnpm typecheck` + `pnpm build`
- [ ] CI ubuntu/windows/web 통과
- [ ] (수동) `curl 'http://localhost:8090/api/models?backend=ollama_cloud'` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)