### PR TITLE
ci: P80 — CI 시간 단축 (binary install + nextest + --all-features 제거)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      # P80: cargo-audit / cargo-nextest 를 pre-built binary 로 install — 매
+      # run 마다 cargo install 의 컴파일 (~1~2분) 회피.
+      - name: Install cargo binaries (audit + nextest)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit,cargo-nextest
+
       - name: Download web/dist
         uses: actions/download-artifact@v4
         with:
@@ -76,14 +83,19 @@ jobs:
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
 
+      # P80: `--all-features` 제거. openvino / coreml feature 는 platform-
+      # specific SDK 필요 + 빌드 시간 큼. default (web-ui) 만 검사로 충분.
       - name: cargo clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --workspace --all-targets
 
-      - name: cargo test
-        run: cargo test --all
+      # P80: cargo-nextest 사용 — parallel test runner, 전통 cargo test 대비
+      # ~30% 빠름. doctest 는 별도 step (nextest 미지원).
+      - name: cargo nextest run
+        run: cargo nextest run --workspace --no-fail-fast
+
+      - name: cargo test --doc
+        run: cargo test --doc --workspace
 
       - name: cargo audit
-        run: |
-          cargo install cargo-audit --locked || true
-          cargo audit
+        run: cargo audit
         continue-on-error: true


### PR DESCRIPTION
## Summary

PR 당 CI 시간 단축. ubuntu 5~7분 / windows 10~14분 → 예상 ubuntu 3~4분 / windows 7~10분.

## 변경

| 항목 | 변경 | 효과 |
|---|---|---|
| cargo-audit | `cargo install` (deps 컴파일 ~1~2분) → `taiki-e/install-action` pre-built binary (~5s) | -1~2분 |
| cargo-nextest | 신규 도입, `cargo test` 대신 사용 | -30% test 시간 |
| clippy `--all-features` | 제거 (default `web-ui` 만 검사) | openvino/coreml 컴파일 회피 |
| doctest | 별도 step (`cargo test --doc --workspace`) | nextest 가 doctest 미지원 |

## 검증 (로컬)

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets` ✓ (warnings 0)
- `cargo nextest run --workspace --no-fail-fast` ✓ (649 passed, 10 skipped)
- `cargo test --doc --workspace` ✓

## 미적용 (별도 plan 후보)

- **Windows lld linker** — `rust-lld.exe` 사용 시 windows 추가 ~30% 단축. 단 rust toolchain 의 windows lld 동작 환경 검증 필요해 별도 PR 로 분리.
- **sccache** — deps + 자체 crate 모두 cache. 큰 효과지만 설정 복잡.

🤖 Generated with [Claude Code](https://claude.com/claude-code)