### PR TITLE
feat(web): P81 — Obsidian callout (`> [!type]-`) 을 `<details>` 로 렌더링

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -43,12 +43,14 @@
     "remark-wiki-link": "^2.0.1",
     "sonner": "^1.7.0",
     "tailwind-merge": "^2.5.4",
+    "unist-util-visit": "^5.1.0",
     "zod": "^3.23.8",
     "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.15",
     "@testing-library/react": "^16.3.0",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^22.9.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -56,6 +58,8 @@
     "autoprefixer": "^10.4.20",
     "jsdom": "^25.0.1",
     "postcss": "^8.4.47",
+    "remark": "^15.0.1",
+    "remark-html": "^16.0.1",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",
     "vite": "^5.4.10",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.6.1
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -117,6 +120,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.17
@@ -138,6 +144,12 @@ importers:
       postcss:
         specifier: ^8.4.47
         version: 8.5.13
+      remark:
+        specifier: ^15.0.1
+        version: 15.0.1
+      remark-html:
+        specifier: ^16.0.1
+        version: 16.0.1
       tailwindcss:
         specifier: ^3.4.14
         version: 3.4.19
@@ -1503,6 +1515,9 @@ packages:
   hast-util-sanitize@5.0.2:
     resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -2063,6 +2078,9 @@ packages:
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
+  remark-html@16.0.1:
+    resolution: {integrity: sha512-B9JqA5i0qZe0Nsf49q3OXyGvyXuZFDzAP2iOFLEumymuYJITVpiH1IgsTEwTpdptDmZlMDMWeDmSawdaJIGCXQ==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
@@ -2074,6 +2092,9 @@ packages:
 
   remark-wiki-link@2.0.1:
     resolution: {integrity: sha512-F8Eut1E7GWfFm4ZDTI6/4ejeZEHZgnVk6E933Yqd/ssYsc4AyI32aGakxwsGcEzbbE7dkWi1EfLlGAdGgOZOsA==}
+
+  remark@15.0.1:
+    resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
   repeat-string@1.6.1:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
@@ -3715,6 +3736,20 @@ snapshots:
       '@ungap/structured-clone': 1.3.1
       unist-util-position: 5.0.0
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -4543,6 +4578,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  remark-html@16.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      hast-util-sanitize: 5.0.2
+      hast-util-to-html: 9.0.5
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -4571,6 +4614,15 @@ snapshots:
       '@babel/runtime': 7.29.2
       mdast-util-wiki-link: 0.1.2
       micromark-extension-wiki-link: 0.0.4
+
+  remark@15.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   repeat-string@1.6.1: {}
 

--- a/web/src/components/MarkdownView.tsx
+++ b/web/src/components/MarkdownView.tsx
@@ -2,6 +2,7 @@ import { Fragment, type ReactNode, useMemo } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkFrontmatter from "remark-frontmatter";
+import { remarkObsidianCallouts } from "@/lib/remarkObsidianCallouts";
 // remark-wiki-link / rehype-raw / rehype-highlight / rehype-sanitize: 외부 plugin.
 import remarkWikiLink from "remark-wiki-link";
 import rehypeRaw from "rehype-raw";
@@ -96,6 +97,12 @@ export function MarkdownView({ content, query, className }: Props) {
       // 위에 sources/tags 가 노출됐다.
       remarkFrontmatter,
       remarkGfm,
+      // remarkObsidianCallouts: vault session md 의 `> [!tool]- Title` 같은
+      // Obsidian callout 을 `<details class="callout callout-tool">` 로 변환.
+      // claude-code session md 의 thinking/tool 블록이 폴딩 가능한 박스로
+      // 표시되도록 한다. P49 의 `### Turn N` (같은 role 연속) 강등과 결합되어
+      // 본문이 turn 별 callout 묶음으로 자연스럽게 펼침/접힘.
+      remarkObsidianCallouts,
       [
         remarkWikiLink,
         {
@@ -123,9 +130,12 @@ export function MarkdownView({ content, query, className }: Props) {
         ...(defaultSchema.attributes ?? {}),
         // Gemini PR #77 리뷰: <details open> 의 open 속성 + 브라우저 토글 시
         // 추가되는 open 속성도 허용해야 함.
+        // P81: remarkObsidianCallouts 가 details 에 className="callout callout-<type>"
+        // 을 부여하므로 className 허용 (callout / callout-* 접두사 한정).
         details: [
           ...((defaultSchema.attributes ?? {}).details ?? []),
           "open",
+          ["className", "callout", /^callout-/],
         ],
         code: [
           ...((defaultSchema.attributes ?? {}).code ?? []),

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -231,3 +231,34 @@
     box-shadow: 0 1px 0 var(--border-soft);
   }
 }
+
+@layer utilities {
+  /* P81: Obsidian-style callout (remarkObsidianCallouts plugin 이 생성한
+     <details class="callout callout-<type>"> 노드에 적용). */
+  .callout {
+    border-left: 3px solid var(--border-soft);
+    background: var(--surface-2);
+    border-radius: var(--r-1, 6px);
+    padding: 6px 12px;
+    margin: 12px 0;
+  }
+  .callout > summary {
+    cursor: pointer;
+    font-weight: 500;
+    color: var(--text-2);
+    user-select: none;
+    padding: 2px 0;
+    list-style-position: inside;
+  }
+  .callout[open] > summary {
+    margin-bottom: 4px;
+  }
+  .callout-thinking { border-left-color: var(--info, #5b8def); }
+  .callout-tool { border-left-color: var(--warn, #d4a657); }
+  .callout-info, .callout-note { border-left-color: var(--info, #5b8def); }
+  .callout-tip, .callout-success { border-left-color: var(--success, #4caf7d); }
+  .callout-warning, .callout-warn { border-left-color: var(--warn, #d4a657); }
+  .callout-error, .callout-danger, .callout-bug, .callout-failure { border-left-color: var(--danger, #d96e6e); }
+  .callout-quote, .callout-cite { border-left-color: var(--text-3); }
+  .callout-example { border-left-color: var(--accent, #8b6fdb); }
+}

--- a/web/src/lib/__tests__/remarkObsidianCallouts.test.ts
+++ b/web/src/lib/__tests__/remarkObsidianCallouts.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { remark } from "remark";
+import remarkHtml from "remark-html";
+import { remarkObsidianCallouts } from "../remarkObsidianCallouts";
+
+async function render(md: string): Promise<string> {
+  const out = await remark()
+    .use(remarkObsidianCallouts)
+    .use(remarkHtml, { sanitize: false })
+    .process(md);
+  return String(out);
+}
+
+describe("remarkObsidianCallouts", () => {
+  it("default open (no flag)", async () => {
+    const html = await render("> [!tip] Heads up\n> hello body");
+    expect(html).toContain('<details class="callout callout-tip" open>');
+    expect(html).toContain("<summary>Heads up</summary>");
+    expect(html).toContain("hello body");
+    expect(html).toContain("</details>");
+  });
+
+  it("collapsed with `-`", async () => {
+    const html = await render("> [!tool]- ToolSearch\n> body");
+    expect(html).toContain('<details class="callout callout-tool">');
+    expect(html).not.toContain('class="callout callout-tool" open');
+    expect(html).toContain("<summary>ToolSearch</summary>");
+    expect(html).toContain("body");
+  });
+
+  it("explicit open with `+`", async () => {
+    const html = await render("> [!thinking]+ Thinking\n> brain");
+    expect(html).toContain('<details class="callout callout-thinking" open>');
+    expect(html).toContain("<summary>Thinking</summary>");
+  });
+
+  it("no title falls back to capitalized type", async () => {
+    const html = await render("> [!thinking]-\n> body only");
+    expect(html).toContain('<details class="callout callout-thinking">');
+    expect(html).toContain("<summary>Thinking</summary>");
+    expect(html).toContain("body only");
+  });
+
+  it("plain blockquote is unchanged", async () => {
+    const html = await render("> just a quote\n> second line");
+    expect(html).not.toContain("callout");
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("just a quote");
+  });
+
+  it("escapes special chars in summary", async () => {
+    // remark 의 markdown parser 는 raw HTML 을 별도 HTML 노드로 분리하므로
+    // `<script>` 같은 형태는 우리 plugin 의 regex 에 잡히지 않는다. 그건
+    // rehype-sanitize 의 후처리에 위임. 여기선 일반 텍스트 (ampersand) 의
+    // escape 만 검증.
+    const html = await render("> [!info] A & B\n> body");
+    expect(html).toContain("<summary>A &amp; B</summary>");
+  });
+});

--- a/web/src/lib/remarkObsidianCallouts.ts
+++ b/web/src/lib/remarkObsidianCallouts.ts
@@ -1,0 +1,104 @@
+import { visit, SKIP } from "unist-util-visit";
+import type { Root, Blockquote, Paragraph, Text, RootContent, Html } from "mdast";
+
+/**
+ * Obsidian callout syntax 를 `<details>` HTML 로 변환하는 remark plugin.
+ *
+ * 입력 (markdown):
+ * ```
+ * > [!thinking]- Thinking
+ * > 본문 line 1
+ * > 본문 line 2
+ * ```
+ *
+ * 출력 (mdast / html):
+ * ```html
+ * <details class="callout callout-thinking">
+ *   <summary>Thinking</summary>
+ *   <p>본문 line 1\n본문 line 2</p>
+ * </details>
+ * ```
+ *
+ * - `[!type]` — open (default)
+ * - `[!type]-` — closed (collapsed)
+ * - `[!type]+` — open (명시적)
+ * - title 생략 시 type 을 summary 로
+ *
+ * rehype-raw 가 details/summary 를 HTML 노드로 통과시키고, sanitize schema
+ * 에 두 태그가 허용되어 있어 그대로 렌더링됨.
+ */
+export function remarkObsidianCallouts() {
+  return (tree: Root) => {
+    visit(tree, "blockquote", (node: Blockquote, index, parent) => {
+      if (
+        !parent ||
+        typeof index !== "number" ||
+        !node.children ||
+        node.children.length === 0
+      ) {
+        return;
+      }
+      const first = node.children[0];
+      if (first.type !== "paragraph") return;
+      const firstChild = (first as Paragraph).children?.[0];
+      if (!firstChild || firstChild.type !== "text") return;
+
+      const text = (firstChild as Text).value;
+      // 첫 줄에서 [!type] 또는 [!type]- 또는 [!type]+ + 옵션 title 매칭.
+      const m = text.match(/^\[!(\w+)\]([-+])?[ \t]*(.*?)(\n|$)/);
+      if (!m) return;
+
+      const [matched, type, flag, titleRaw] = m;
+      const open = flag !== "-"; // default open, `-` = closed
+      const title = (titleRaw || "").trim() || capitalize(type);
+
+      // 첫 text 노드에서 matched 부분 제거. 남은 텍스트가 있으면 유지.
+      const rest = text.slice(matched.length).replace(/^\n+/, "");
+      if (rest) {
+        (firstChild as Text).value = rest;
+      } else {
+        // 첫 text 노드 제거. paragraph 가 비면 paragraph 자체도 제거.
+        (first as Paragraph).children.shift();
+        if ((first as Paragraph).children.length === 0) {
+          node.children.shift();
+        }
+      }
+
+      const openAttr = open ? " open" : "";
+      const openHtml: Html = {
+        type: "html",
+        value: `<details class="callout callout-${escapeAttr(type)}"${openAttr}><summary>${escapeHtml(
+          title,
+        )}</summary>`,
+      };
+      const closeHtml: Html = { type: "html", value: "</details>" };
+
+      // blockquote 자체를 unwrap: details_open + (blockquote 의 children) + details_close
+      const replacement: RootContent[] = [
+        openHtml,
+        ...(node.children as RootContent[]),
+        closeHtml,
+      ];
+      parent.children.splice(index, 1, ...replacement);
+      // 새로 삽입된 노드들은 다시 visit 안 함 — body 의 nested callout 은 별도 패스로 처리.
+      return [SKIP, index + replacement.length];
+    });
+  };
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_-]/g, "");
+}


### PR DESCRIPTION
## 배경

사용자 보고: vault session md 가 secall web 에서:
- "대화처럼 안 보임"
- "툴 로딩 한 것도 `> assistant` 하고 빈 칸"
- "어떤 세션은 assistant 폴딩만 10개 이상 이어서"

진단: vault md 의 `> [!thinking]-`, `> [!tool]- ToolName` 등은 Obsidian 의 **collapsible callout syntax**. Obsidian 에선 펼침/접힘 박스로 렌더링되지만 react-markdown 은 이 문법을 모르므로 plain blockquote 로 처리. P49 의 같은 role 연속 turn 헤더 강등 (`### Turn N`) 과 합쳐져 시각적 단조로움 + 본문이 빈 칸 처럼 인식.

기존 `remark-callouts` npm 패키지를 검토했지만 **foldable (`> [!type]-`) 미지원** ("Future support" 명시). 우리 vault md 가 정확히 foldable 형식이라 자체 plugin 작성.

## 변경

### 신규 plugin `web/src/lib/remarkObsidianCallouts.ts`
mdast blockquote 노드 visit → 첫 paragraph 의 첫 text 가 `[!type][-/+]? title` 패턴이면 blockquote 를 `<details class="callout callout-<type>">` + `<summary>` 로 unwrap. body markdown AST 는 그대로 유지 (rehype-raw 가 details/summary HTML 통과).

- `[!type]` — open (default)
- `[!type]-` — closed (collapsed)
- `[!type]+` — open (명시적)
- title 생략 시 type 을 capitalize 해 summary

### CSS (`web/src/index.css`)
`.callout` / `.callout-<type>` — left border + surface-2 배경 + 타입별 색 (thinking=info, tool=warn, tip=success, error=danger 등).

### 의존성
`unist-util-visit`, `@types/mdast`. `remark`/`remark-html` (devDep, vitest 용).

## 회귀 테스트

`web/src/lib/__tests__/remarkObsidianCallouts.test.ts` — 6 케이스, 모두 통과.

## 검증

- `pnpm typecheck` ✓
- `pnpm build` ✓
- `pnpm test` ✓ (15/15)

## 사용자 액션 (PR 머지 후)

```bash
cd web && pnpm build && cd ..
cargo install --path crates/secall --force
/bin/cp -f ~/.cargo/bin/secall ~/.local/bin/secall
# secall serve 재시작
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)