### PR TITLE
docs: 문서 룰 정리 + index 보강 + web-backlog 청소 + 핸드오프

### DIFF
--- a/docs/reference/docConventions.md
+++ b/docs/reference/docConventions.md
@@ -73,7 +73,7 @@ seCall 의 `docs/` 는 다음 8개 서브디렉토리로 구성된다.
 ### Reference (`docs/reference/`)
 
 - **날짜 없는 안정 이름** 을 기본으로 한다 (예: `core-backlog.md`, `llm-config.md`).
-- 2~4 토큰의 camelCase 또는 kebab-case 가 가능하다. 기존 폴더가 kebab-case 중심이면 따른다.
+- 2~4 토큰의 camelCase를 기본으로 한다. (기존 kebab-case 파일들과의 일관성이 필요한 경우에만 예외적 허용)
 - 예외: 시간 흐름 자체가 중요한 핸드오프 문서는 `handoff_YYYY-MM-DD.md` 허용 (예: `handoff_2026-05-19.md`).
 
 ### Plan (`docs/plans/`)
@@ -106,11 +106,11 @@ seCall 의 `docs/` 는 다음 8개 서브디렉토리로 구성된다.
 
 ```yaml
 ---
-type: reference        # reference | plan | prompt | review | insight | baseline | community | agent
-status: in_progress    # 아래 §3.1 참고
+type: reference        # reference | plans | prompts | reviews | insight | baseline | community | agents
+status: done           # 아래 §3.1 참고
 updated_at: 2026-05-19 # YYYY-MM-DD
 canonical: true        # false 이면 SSOT 아님 (브레인스토밍/비교 문서)
-superseded_by: path    # 대체된 경우만
+superseded_by: docs/reference/new_file.md # 대체된 경우만
 ---
 ```
 
@@ -132,6 +132,8 @@ superseded_by: path    # 대체된 경우만
 - `supersedes: docs/reference/oldFoo.md` — 이 문서가 대체한 과거 문서
 - `superseded_by: docs/reference/newFoo.md` — 이 문서를 대체한 신규 문서
 - `read_before: [path]` — 이 문서를 읽기 전에 먼저 봐야 할 문서
+
+> 경로는 프로젝트 루트 기준 (`docs/...`)으로 통일한다.
 
 관계 메타가 있어야 에이전트가 낡은 문서를 덜 읽는다.
 

--- a/docs/reference/docConventions.md
+++ b/docs/reference/docConventions.md
@@ -1,0 +1,236 @@
+---
+type: reference
+status: done
+updated_at: 2026-05-19
+canonical: true
+---
+
+# seCall 문서 규약 (docConventions)
+
+이 문서는 `CLAUDE.md §3 Documentation Rules` 의 expanded 버전이다.
+CLAUDE.md 는 룰의 1~2줄 요약만 담고, 판단 기준·예시·체크리스트는 이 문서를 본다.
+모든 에이전트(Claude, Codex, Gemini, OpenCode)와 사람이 같은 규칙으로 문서를 만들고 유지하기 위한 기준이다.
+
+핵심 판단:
+
+- 좋은 문서 관리는 "파일을 적게 만드는 것" 이 아니라 "에이전트가 현재 문서를 빠르게 고를 수 있게 하는 것" 이다.
+- 따라서 seCall 은 `파일명 + frontmatter + index.md` 세 축으로 문서 상태를 관리한다.
+
+---
+
+## 1. 문서 타입 (8개 디렉토리)
+
+seCall 의 `docs/` 는 다음 8개 서브디렉토리로 구성된다.
+각 디렉토리의 역할과 읽는 법이 다르므로, 새 문서를 만들 때 가장 먼저 위치를 정해야 한다.
+
+### `reference/` — 현재 기준 사실 (SSOT)
+
+- 역할: 구현 현황, 데이터 모델, 설정 가이드, ADR, 백로그 등 "지금 옳다고 합의된 사실"
+- 읽는 법: 새 세션에서 가장 먼저 읽는 문서군
+- 예시: `core-backlog.md`, `web-backlog.md`, `llm-config.md`, `wiki-setup.md`, `docConventions.md`
+
+### `plans/` — 앞으로 할 일
+
+- 역할: 작업 계획, 목표/비목표/완료 기준
+- 읽는 법: 현재 작업과 관련된 plan 만 읽는다. 전체를 다 읽지 않는다.
+- 예시: `p18-rev-2-regex.md`, `p18-rev-2-regex-task-01.md`
+
+### `prompts/` — 실행 에이전트용 작업 지시문
+
+- 역할: Claude/Codex 등 실행 에이전트에게 넘기는 프롬프트
+- 읽는 법: 반드시 대응하는 `plans/` 문서와 함께 읽는다.
+- 위치: `prompts/YYYY-MM-DD/short_name.md`
+
+### `agents/` — 에이전트 역할 정의
+
+- 역할: 각 에이전트(Developer, Architect, Reviewer 등) 의 행동 규칙
+- 읽는 법: 새 에이전트 역할을 부여받을 때
+
+### `baseline/` — 기준선 데이터/스냅샷
+
+- 역할: 성능 벤치마크, 회귀 비교용 기준선
+- 읽는 법: 회귀 검증·성능 측정 시
+
+### `community/` — 외부 공개·커뮤니티용 문서
+
+- 역할: 다모앙 등 외부 공유용 글, 사용자 가이드 초안
+- 읽는 법: 외부 공개 작업 시
+
+### `insight/` — 분석·회고·인사이트
+
+- 역할: 사후 분석, 회고, 데이터 분석 결과
+- 읽는 법: 의사결정 근거가 필요할 때
+
+### `reviews/` — 코드/PR 리뷰 기록
+
+- 역할: PR 리뷰 요약, 코드 리뷰 메모
+- 읽는 법: 같은 영역 재작업 시 과거 리뷰 참고용
+
+---
+
+## 2. 파일명 규칙
+
+### Reference (`docs/reference/`)
+
+- **날짜 없는 안정 이름** 을 기본으로 한다 (예: `core-backlog.md`, `llm-config.md`).
+- 2~4 토큰의 camelCase 또는 kebab-case 가 가능하다. 기존 폴더가 kebab-case 중심이면 따른다.
+- 예외: 시간 흐름 자체가 중요한 핸드오프 문서는 `handoff_YYYY-MM-DD.md` 허용 (예: `handoff_2026-05-19.md`).
+
+### Plan (`docs/plans/`)
+
+- 기본: `{slug}.md` (예: `p18-rev-2-regex.md`)
+- 날짜 구분이 필요한 경우: `{slug}_YYYY-MM-DD.md`
+- 하위 작업 지시서: `{slug}-task-NN.md`
+
+### Prompt (`docs/prompts/`)
+
+- 위치 고정: `YYYY-MM-DD/short_name.md`
+- 같은 날 여러 프롬프트는 같은 날짜 폴더에 모은다.
+
+### Brainstorm / Review / Memo
+
+- 성격이 드러나는 이름 + 날짜 (예: `gemini-vs-anthropic-review_2026-05-15.md`)
+- frontmatter 에 `canonical: false` 명시 (3절 참고).
+
+### 피해야 할 것
+
+- 같은 주제의 reference 를 날짜 파일로 계속 복제 (`backlog_2026-05-01.md`, `backlog_2026-05-15.md` …)
+- 의미 없는 일반명 (`notes.md`, `temp.md`, `draft.md`)
+- 버전/날짜 없이 비슷한 이름이 공존 (`config.md`, `config2.md`)
+
+---
+
+## 3. 필수 frontmatter
+
+모든 문서 상단에 YAML frontmatter 를 둔다.
+
+```yaml
+---
+type: reference        # reference | plan | prompt | review | insight | baseline | community | agent
+status: in_progress    # 아래 §3.1 참고
+updated_at: 2026-05-19 # YYYY-MM-DD
+canonical: true        # false 이면 SSOT 아님 (브레인스토밍/비교 문서)
+superseded_by: path    # 대체된 경우만
+---
+```
+
+### 3.1 status 값
+
+| 값 | 의미 |
+|-----|------|
+| `draft` | 작성 중, 아직 합의 전 |
+| `in_progress` | 진행 중 (plan/prompt 주로 사용) |
+| `partial` | 일부만 완료, 잔여 작업 있음 |
+| `done` | 완료, 현재 기준으로 유효 |
+| `archived` | 더 이상 현재 기준 아님 (`superseded_by` 권장) |
+
+### 3.2 관계 메타 (선택)
+
+- `related: [path1, path2]` — 함께 읽으면 좋은 문서
+- `paired_plan: docs/plans/foo.md` — 이 prompt 와 짝인 plan
+- `paired_prompt: docs/prompts/2026-05-19/foo.md`
+- `supersedes: docs/reference/oldFoo.md` — 이 문서가 대체한 과거 문서
+- `superseded_by: docs/reference/newFoo.md` — 이 문서를 대체한 신규 문서
+- `read_before: [path]` — 이 문서를 읽기 전에 먼저 봐야 할 문서
+
+관계 메타가 있어야 에이전트가 낡은 문서를 덜 읽는다.
+
+### 3.3 canonical 사용
+
+- `canonical: true` — 현재 기준 (대부분의 reference, 완료된 plan)
+- `canonical: false` — 외부 레퍼런스, 비교 메모, 아이디어 수집, 브레인스토밍
+  - "실행 계획처럼 읽히는 표현" 을 자제하고, 현재 구현 기준 문서 경로를 명시한다.
+
+---
+
+## 4. 인덱스 규칙
+
+각 폴더의 `index.md` 는 단순 파일 목록이 아니다. 다음 네 가지를 알려줘야 한다.
+
+1. **무엇이 기준 문서인가** — 현재 SSOT 식별
+2. **무엇이 현재 유효한가** — done / partial / archived 구분
+3. **어떤 순서로 읽어야 하는가** — 추천 읽기 순서
+4. **새 문서 추가 시 링크 반영** — plan/prompt 생성 시 동시 갱신 필수
+
+### index.md 에 반드시 있어야 할 것
+
+- 짧은 폴더 설명 (1~2줄)
+- 문서별 한 줄 설명 + 상태 라벨
+- 추천 읽기 순서 (또는 카테고리 분류)
+- 아카이브 문서는 별도 섹션에 분리하거나 경고 표기
+
+---
+
+## 5. 버전관리 원칙
+
+### 5.1 Reference 는 같은 파일을 갱신한다
+
+- 대상: `docs/reference/*.md`, 프로젝트 루트 `CLAUDE.md`
+- 같은 주제의 현재 기준 문서는 하나만 유지하고 `updated_at` 만 갱신한다.
+- 새 날짜 파일을 계속 만들지 않는다.
+- 예외: 성격이 완전히 다른 새 reference 가 생길 때만 새 파일 허용.
+
+### 5.2 Plan / Prompt 는 작업 단위별 새 문서 가능
+
+- 작업 단위가 독립적이면 날짜 또는 slug 기반 새 문서 허용.
+- 단 **`index.md` 동반 갱신 필수**. 새 plan 만들고 index 안 고치면 안 된다.
+
+### 5.3 브레인스토밍은 SSOT 가 아니다
+
+- 외부 레퍼런스, 비교 메모, 아이디어 수집은 `canonical: false`.
+- 현재 구현 기준 문서 경로를 frontmatter 또는 본문 상단에 명시.
+
+### 5.4 핸드오프 문서는 예외적으로 날짜 분리
+
+- 세션 종료 시점의 스냅샷은 시간이 의미를 가지므로 `handoff_YYYY-MM-DD.md` 로 새로 만든다.
+- 단 index.md 에 최신 핸드오프를 명시한다.
+
+---
+
+## 6. 아카이브 정책
+
+오래된 문서는 **삭제보다 아카이브 우선**.
+
+### 절차
+
+1. frontmatter 의 `status: archived` 로 변경
+2. 가능하면 `superseded_by: docs/reference/newFoo.md` 로 대체 문서 연결
+3. 본문 최상단에 한 줄 경고 추가 (선택)
+   ```
+   > 이 문서는 아카이브되었습니다. 현재 기준: [newFoo.md](newFoo.md)
+   ```
+4. index.md 에서 별도 "Archived" 섹션으로 이동 (또는 명시적 라벨)
+
+### 삭제가 정당화되는 경우
+
+- 잘못된 정보가 들어가서 보존 가치도 없는 경우 (드뭄)
+- 임시 디버깅 메모처럼 처음부터 보존 의도가 없던 파일
+
+---
+
+## 7. 에이전트 작업 시 판단할 것 (체크리스트)
+
+문서를 생성·수정하기 전에 반드시 다음 4가지를 자문한다.
+
+1. **갱신 vs 신규** — 같은 주제의 기존 문서가 있나? 있으면 갱신이 맞다.
+2. **current vs 참고용** — 이 문서는 SSOT 인가, 비교/브레인스토밍인가? 후자라면 `canonical: false`.
+3. **index 업데이트 필요?** — plan/prompt 신규 생성이면 반드시 index.md 동반 수정.
+4. **supersede 관계 남겼나?** — 기존 문서를 대체한다면 `supersedes` / `superseded_by` 로 연결.
+
+### 특히 피해야 할 패턴
+
+- 같은 주제 reference 를 날짜 파일로 계속 복제
+- 새 plan/prompt 만들고 index.md 갱신 누락
+- 아카이브 문서를 현재 기준처럼 방치
+- 브레인스토밍 문서를 구현 현황처럼 작성
+
+---
+
+## 8. 최소 실무 규칙 (강제)
+
+지금 당장 모든 에이전트가 지켜야 할 최소 규칙은 다음 네 가지다.
+
+1. reference 는 **기존 파일 우선 갱신**
+2. plan/prompt 는 새 파일 가능, 단 **index 필수 업데이트**
+3. 브레인스토밍/외부 참고는 **`canonical: false`** 및 성격 명시
+4. 대체 문서는 **`superseded_by`** 또는 본문 상단 경고 추가

--- a/docs/reference/handoff_2026-05-19.md
+++ b/docs/reference/handoff_2026-05-19.md
@@ -1,0 +1,260 @@
+---
+type: reference
+status: draft
+updated_at: 2026-05-19
+canonical: true
+---
+
+# seCall 세션 핸드오프 — 2026-05-19
+
+> 작성 배경: v0.5.0 release 직후 누적된 9건의 PR (#72~#81) 머지 + Gemini 리뷰 반영 + 사용자 환경 (statusline / python hook) 보정까지 한 세션에서 끝난 시점. 컨텍스트 90% 도달로 새 세션으로 이관. cold-start 세션이 같은 흐름으로 이어갈 수 있도록 모든 결정/사고/규칙을 한 곳에 정리한다.
+
+---
+
+## 1. 환경 컨텍스트
+
+- **레포**: `/Users/d9ng/privateProject/seCall` (GitHub: `hang-in/seCall`)
+- **현재 브랜치**: `main` (작업 폴더 깨끗)
+- **마지막 머지 commit**: `065f129` (P81 — Obsidian callout)
+- **워크스페이스 버전**: `0.5.0` (`Cargo.toml: workspace.package.version`)
+- **사용자**: d9ng / hang-in
+- **언어 규칙**: 한국어 응답, 존댓말. 코드/경로/식별자는 원문.
+- **OS**: macOS aarch64
+- **memory 위치**: `~/.claude/projects/-Users-d9ng-privateProject-seCall/memory/MEMORY.md` — 11건 메모리 (user / feedback / project / reference)
+
+### 1.1 vault / 외부 자원
+
+| 항목 | 경로 |
+|---|---|
+| 실 vault | `/Users/d9ng/Documents/Obsidian Vault/seCall` |
+| DB | `~/Library/Caches/secall/index.sqlite` |
+| config | `~/Library/Application Support/secall/config.toml` |
+| installed binary (PATH 우선) | `~/.local/bin/secall` |
+| cargo install target | `~/.cargo/bin/secall` |
+
+⚠️ **PATH 우선순위**: `~/.local/bin` > `~/.cargo/bin`. `cargo install --path crates/secall --force` 후 `~/.cargo/bin/secall` 만 갱신되므로 `/bin/cp -f ~/.cargo/bin/secall ~/.local/bin/secall` 필수. 안 하면 사용자가 띄운 `secall serve` 가 옛 binary 로 동작.
+
+### 1.2 LLM 키 / 백엔드 상태 (2026-05-15 검증)
+
+- `OLLAMA_CLOUD_API_KEY` ✅ (.env autoload via dotenvy)
+- Gemini API key ❌ (삭제됨)
+- Anthropic API key ❌ (없음)
+- 기본 backend: graph/log → `ollama_cloud` (P51). wiki review → `haiku` (P51)
+- 모델 매핑: graph = `gemma4:31b-cloud`, log diary = `kimi-k2.6:cloud`, wiki review = `haiku`/`sonnet`/`opus` (claude CLI alias)
+
+---
+
+## 2. 이번 세션 (2026-05-16~19) 누적 결과
+
+### 2.1 머지된 PR (총 10건)
+
+| PR | 내용 | 머지 commit |
+|---|---|---|
+| #72 | P62 — TopNav version 표시 server SSOT 통합 + web-backlog 신설 | `ca39e31` |
+| #73 | P63 — core-backlog 신설 + web-backlog 전수 조사 결과 반영 | `0c9da73` |
+| #74 | P68 — `Config::save()` production config 덮어쓰기 차단 가드 | `cef1b2f` |
+| #75 | P66 — MarkdownView 폴딩/highlight/wikilink 확장 (`rehype-raw` / `rehype-highlight` / `remark-wiki-link`) | `daf7ce5` |
+| #76 | P64 — `/api/graph/snapshot` `edge_limit` + 우선순위 sampling | `6d81bf3` |
+| #77 | P66 follow-up — Gemini 리뷰 (rehype-sanitize / a11y onKeyDown / `<details open>` allow) | `981a0d6` |
+| #78 | P65 — backend 별 model discovery + cache + REST `/api/models?backend=` | `f142aa1` |
+| #79 | P66 follow-up — wiki frontmatter strip + heading collapse 폐기 + ModelInput dropdown (자체 UI) | `0af194e` |
+| #80 | P80 — CI 시간 단축 (`cargo-audit` / `cargo-nextest` binary install + `--all-features` 제거) | `795101e` |
+| #81 | P81 — Obsidian callout (`> [!type]-`) → `<details class="callout callout-<type>">` (자체 remark plugin) | `065f129` |
+
+### 2.2 발견 + 해결한 사고
+
+1. **production `config.toml` 손상**: `cargo test --lib -p secall-core vault::` flaky test 재현 시도 (P58 race fix 머지 전 5회 반복) 중 `[vault].path` 가 `/tmp/changed` (= `save_preserves_top_level_comments` test 의 hardcoded 값) 로 set 됨 → 사용자가 web UI 에서 wiki 빈 화면 / graph 멈춤. 복구 후 P68 (`#[cfg(test)]` 가드) 도입.
+2. **PATH 우선순위 `~/.local/bin > ~/.cargo/bin`**: 사용자가 `cargo install --force` 만 돌리면 새 binary 가 잡히지 않음. 메모리 + handoff 에 박제.
+3. **`secall serve` 새 dist 미반영**: `web/dist/` 는 `rust_embed` 로 binary build 시점에 embedded. cargo 가 dist 디렉토리 변경을 자동 감지 안 함 → `pnpm build` 선행 필수.
+4. **tunaLlama plugin `python` not found**: `hooks/hooks.json` 이 `python` 단독 호출 (macOS 는 `python3` 만 존재) → SessionStart hook 에러. 원본 + cache 5 버전 모두 `python3` 으로 patch.
+5. **CI clippy `doc_lazy_continuation`**: P64 의 doc comment 의 ordered list (`0. / 1. / 2.`) 가 indent 부족으로 위반 → unordered bullet 으로 변경 + 메모리 `feedback_local_ci_gate.md` 에 clippy 추가.
+
+### 2.3 사용자 환경 보정 (~/.claude/...)
+
+| 위치 | 변경 |
+|---|---|
+| `~/.claude/statusline.sh` | 자체 statusline 신설 (모델 / 프로젝트 / 컨텍스트 % + 그라디언트 + 토큰 k 단위 / 7d quota 잔량 + reset 시각 / 누적 사용시간). bar 는 사용자 의견으로 제거. |
+| `~/.claude/settings.json` | `statusLine.command` 가 위 script 가리킴 |
+| `/Users/d9ng/privateProject/tunaLlama/plugin/hooks/hooks.json` | `python` → `python3` (원본 + cache 0.5.3~0.5.9) |
+| `~/.claude/projects/-Users-d9ng-privateProject-seCall/memory/` | 11건 메모리 (특히 `project_vault_path.md`, `feedback_local_ci_gate.md` 신설) |
+
+### 2.4 신설 문서
+
+- `docs/reference/core-backlog.md` (P63, 1 hot: `cargo test` 가 production config 덮어쓰는 회귀 → P68 가드는 unit test 한정, integration tests 는 여전히 위험)
+- `docs/reference/web-backlog.md` (P62 신설, P63 에서 전수 조사 반영. 현재 hot 0 / debt 5 / watch 4)
+- `docs/reference/handoff_2026-05-19.md` (본 문서)
+
+### 2.5 P81 신설 컴포넌트
+
+- `web/src/lib/remarkObsidianCallouts.ts` — Obsidian `> [!type][-/+]? title` 을 `<details class="callout callout-<type>">` 로 변환하는 자체 remark plugin
+- `web/src/lib/__tests__/remarkObsidianCallouts.test.ts` — 6 vitest cases
+- `web/src/components/settings/ModelInput.tsx` — 자체 dropdown (chevron + click toggle + ↓↑ nav + click outside)
+- `web/src/lib/remarkObsidianCallouts.ts` 의 sanitize schema 가 `details` className `callout` + `callout-*` 허용
+
+---
+
+## 3. 미해결 / 다음 우선순위
+
+### 3.1 docs/reference/web-backlog.md 의 미처리 항목
+
+**debt (5건)**:
+
+- **dist 빌드 누락 회귀** — `cargo:rerun-if-changed=../../web/dist/index.html` 도입 또는 cargo xtask wrapper. 매번 사용자가 `pnpm build && cargo install` 순서 지켜야 하는 부담.
+- **`/api/status` 가 stats 쿼리와 묶임** — version 만 필요한 client 도 DB lock + count 비용. 별도 `/api/version` 분리 후보.
+- **CollapsibleHeading DOM 직접 조작** (P79 에서 폐기됨, 항목 제거 가능)
+- **(P79 머지로 해소된 항목들 정리 필요)** — backlog 의 `jfetch<unknown>` / SessionsRoute error 표시 / Markdown 폴딩 등은 이미 해결. 다음 작업 시 backlog 청소부터.
+
+**watch (4건)**:
+
+- react-query `staleTime` 60s → 5m 상향
+- mobile / tablet (`md:` breakpoint) 미지원
+- Markdown link `[](url)` 커스텀 미적용 (vault 경로 / wikilink 일관성)
+- server-side version 과 web build dist 시점 version 불일치 가능
+
+### 3.2 docs/reference/core-backlog.md (1 hot)
+
+- **`Config::save()` integration test 가드** — P68 은 `#[cfg(test)]` 한정 (lib unit test 만 보호). `crates/secall-core/tests/*.rs` 의 integration test 에서 호출 시 cfg(test) false → 가드 미적용. 옵션: runtime guard (`SECALL_TEST_MODE` env), `Config::save_to_path(&path)` helper 분리, `serial_test` crate 도입.
+
+### 3.3 CI 추가 최적화 후보 (P80 후속)
+
+- **Windows lld linker** (`rust-lld.exe`) — windows 추가 ~30% 단축 가능. rust toolchain 의 windows lld 동작 환경 검증 필요해 별도 PR 로 분리해둠.
+- **sccache** — deps + 자체 crate 모두 cache. 큰 효과지만 설정 복잡.
+
+### 3.4 ollama/lmstudio HTTP streaming 후속 (P60 후속)
+
+- P60 에서 HTTP backend 도 stream + stderr echo 적용 완료. 단 사용자 검증은 ollama_cloud 실 호출 못 했음 (수동 검증 항목으로 남음).
+
+---
+
+## 4. 사용자 환경 / 운영 규칙 (반드시 따를 것)
+
+### 4.1 메모리 정책 (`~/.claude/projects/-Users-d9ng-privateProject-seCall/memory/MEMORY.md`)
+
+- **Local CI gate**: push 전 반드시 `cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings && cargo check --workspace && cargo test` 풀 통과. web 변경 시 추가로 `cd web && pnpm typecheck && pnpm build`.
+- **Git ops delegation**: 사용자는 git/shell 직접 안 함. agent 가 판단해서 정리. destructive (`rm -rf`, `git push --force-with-lease`, hard reset, branch delete 등) 만 confirm. push / PR 생성 / 머지 자체는 OK.
+- **PR commit 시 tests/ 누락 방지**: 시그니처 변경 PR 만들 때 `git add` 에서 `tests/` 디렉토리 동반 파일 누락 안 되도록.
+- **Architect/Developer 경계**: task 문서에 구현 코드 본문 미리 작성 X (설계만).
+- **REST API secret 필터링**: `PATCH /api/config/{section}` 에서 `cloud_api_key` 는 모든 섹션 (graph/log/embedding) 에서 동일하게 차단.
+
+### 4.2 destructive 작업 시 confirm
+
+- `rm`: macOS 의 `rm` 은 `-i` alias 가능 → `/bin/rm -f` 사용
+- `cp`: 동일. `/bin/cp -f`
+- 사용자 working tree 의 untracked 파일 (예: handoff / sync-monitor) 은 의도된 작업 결과물일 수 있으므로 `git clean` 자제
+
+### 4.3 CLAUDE.md 준수 사항
+
+- **Plan before implementing**: 큰 작업은 plan 보여주고 사용자 OK 받기
+- **Single-path modification**: 한 PR 에 여러 도메인 묶지 말 것 (CLAUDE.md `Work Safety Rules`)
+- **No 추측**: 코드/응답으로 확인 후 답. 모를 땐 명시.
+- **Only modify what was requested**: 주변 코드 cleanup 금지
+
+### 4.4 사용자 statusline 형식
+
+```
+📁 seCall  ◆ Opus 4.7 (1M context)  66% 660k  ⏳ 7d 90% left (→ 5/24 09:00)  ⌛ 1h12m
+```
+
+- 컨텍스트 사용률에 따라 색 (녹→황→적). bar 제거됨.
+- 7일 quota 는 reset 시각이 Unix epoch (number) 라 `date -r` 로 변환.
+- 첫 API 응답 이후부터 quota 표시. API key 환경에선 표시 안 될 수 있음.
+
+---
+
+## 5. 기술 패턴 / 주의점
+
+### 5.1 web → server-side embed
+
+`web/dist/` 가 `rust_embed::RustEmbed#[folder = "../../web/dist/"]` 로 binary 에 build 시점 embedded.
+
+**release / install 순서 필수**:
+```bash
+cd web && pnpm build && cd ..
+cargo install --path crates/secall --force
+/bin/cp -f ~/.cargo/bin/secall ~/.local/bin/secall
+# 사용자가 secall serve 띄웠다면 재시작 + 브라우저 hard reload (Cmd+Shift+R)
+```
+
+### 5.2 markdown rendering (P81 신설 패턴)
+
+vault session md 는 Obsidian 호환 형식 (`> [!type]- title` callout, `[[wikilink]]`). secall web 의 `MarkdownView` 가 다음 plugin 으로 처리:
+
+- `remark-frontmatter` — YAML `---` block strip
+- `remark-gfm` — table / checkbox / strikethrough
+- `remarkObsidianCallouts` (자체) — callout → `<details>`
+- `remark-wiki-link` — `[[Page]]` → `/wiki/Page_Name`
+- `rehype-raw` — raw HTML (`<details>`, `<script>` 차단은 sanitize 가)
+- `rehype-sanitize` — XSS 차단 + className `callout-*` / `hljs-*` / `language-*` 허용
+- `rehype-highlight` — github-dark CSS
+
+### 5.3 vault::config tests 의 race
+
+`vault::config::tests` 의 `ENV_MUTEX` 가 SECALL_CONFIG_PATH env 를 직렬화. `vault::tests::test_config_load_or_default` 도 같은 mutex 잡도록 P58 에서 fix. P68 의 `#[cfg(test)]` 가드까지 추가됐으나 **integration test 에서는 여전히 위험** (core-backlog hot 항목).
+
+### 5.4 CI workflow (P80 적용 후)
+
+```yaml
+- taiki-e/install-action@v2: cargo-audit + cargo-nextest (binary, ~5s)
+- cargo clippy --workspace --all-targets  # --all-features 제거
+- cargo nextest run --workspace --no-fail-fast  # parallel runner
+- cargo test --doc --workspace  # nextest 가 doctest 미지원
+- cargo audit (continue-on-error)
+```
+
+windows lld 는 별도 PR 후보.
+
+---
+
+## 6. 다음 세션 cold-start 체크리스트
+
+1. ☐ `git status` — main 깨끗한지
+2. ☐ `git log --oneline -3` — 최근 머지 확인 (`065f129` 가 P81 머지일 것)
+3. ☐ `cat ~/Library/Application\ Support/secall/config.toml` — `[vault].path` 가 `/Users/d9ng/Documents/Obsidian Vault/seCall` 인지
+4. ☐ `secall --version` — `0.5.0` 인지. 아니면 cargo install + cp 수순.
+5. ☐ `curl -s localhost:8090/api/status | jq` — server 동작 확인 (선택)
+6. ☐ MEMORY.md 의 11건 메모리 읽기 (특히 `feedback_local_ci_gate.md`, `project_vault_path.md`)
+7. ☐ `docs/reference/{core,web}-backlog.md` 의 hot/debt 우선순위 확인
+8. ☐ 본 문서의 §3 미해결 항목 확인 후 다음 작업 결정
+
+---
+
+## 7. 사용자 작업 스타일 (관찰 기반)
+
+- 작업 단위가 도메인 별 분리된 PR 선호 (single-path). 한 PR 에 여러 도메인 묶지 말 것.
+- 서브에이전트 / worktree 활용 적극 수용. 병렬 가능하면 적극 사용.
+- Gemini 리뷰는 항상 확인 후 fix. HIGH security 는 즉시, MEDIUM 은 최소 가능한 것 fix + 큰 변경은 backlog.
+- 보고 시 ❌ 이모티콘은 "현재 실패" 로 읽히므로 fix 완료 항목엔 ✅ 또는 "원인:" / "→" 패턴 사용.
+- 진단 시 "추측 금지, 실제 코드/응답으로 확인" 강조. dump / Playwright / unit test 등 정확한 검증 도구 활용.
+- Plan 보여주고 OK 받기 — 단 한 묶음 작업은 사용자 결정 받은 후 일사천리.
+
+---
+
+## 8. 외부 도구 / MCP
+
+- **context-mode** v1.0.139 (2026-05-19 upgrade). `ctx_search` / `ctx_batch_execute` / `ctx_execute` 등. Bash output 큰 출력 시 자동 라우팅.
+- **tunaLlama** plugin (`/Users/d9ng/privateProject/tunaLlama/plugin`). 로컬/클라우드 LLM 위임. `python3` hook fix 후 정상.
+- **Playwright** ad-hoc (`/tmp/secall-pw/`) — 진단 시 web UI DOM/screenshot 직접 확인용. MCP 미설치, npx 로 실행.
+- **Claude Code IDE / settings**: `~/.claude/settings.json` 의 hooks + statusLine + enabledPlugins.
+
+---
+
+## 9. 알려진 위험 / 함정
+
+| # | 위험 | 회피 |
+|---|---|---|
+| 1 | `cargo install` 후 binary path mismatch (~/.local vs ~/.cargo) | `/bin/cp -f` 동기화 |
+| 2 | `cargo install` 만 돌리면 dist 미반영 | `pnpm build` 선행 |
+| 3 | `cargo test --lib -p secall-core vault::` flaky 재현이 production config 손상 | P68 가드 + 사용자 vault path 메모리 박제 |
+| 4 | clippy rustdoc lint (`doc_lazy_continuation`) — fmt/check 가 못 잡음 | push 전 clippy 풀 게이트 |
+| 5 | macOS 의 `python` 명령 부재 | python3 명시 |
+| 6 | gh pr create 시 `--head` 미지정 → 현재 branch 로 PR (다른 의도된 PR 과 헷갈림) | `--head` 명시 |
+| 7 | gh pr merge --delete-branch 가 local main checkout 실패 (다른 worktree 가 잡고 있으면) — 머지 자체는 OK | 무시 가능, cosmetic |
+| 8 | 서브에이전트 worktree 의 deps 가 main 의 deps 와 다를 수 있음 (rebase 후 pnpm install) | 메인에서 검증 |
+
+---
+
+## 10. 한 줄 요약
+
+> v0.5.0 + 10 PR 누적 머지 + 사용자 환경 보정 완료. main 깨끗. 다음 작업은 backlog 청소 + 미해결 (dist rerun-if-changed / integration test guard / Windows lld) 중 우선순위 선택.
+
+다음 세션이 이 문서 한 번만 읽으면 즉시 작업 가능.

--- a/docs/reference/handoff_2026-05-19.md
+++ b/docs/reference/handoff_2026-05-19.md
@@ -1,13 +1,13 @@
 ---
 type: reference
-status: draft
+status: done
 updated_at: 2026-05-19
 canonical: true
 ---
 
 # seCall 세션 핸드오프 — 2026-05-19
 
-> 작성 배경: v0.5.0 release 직후 누적된 9건의 PR (#72~#81) 머지 + Gemini 리뷰 반영 + 사용자 환경 (statusline / python hook) 보정까지 한 세션에서 끝난 시점. 컨텍스트 90% 도달로 새 세션으로 이관. cold-start 세션이 같은 흐름으로 이어갈 수 있도록 모든 결정/사고/규칙을 한 곳에 정리한다.
+> 작성 배경: v0.5.0 release 직후 누적된 10건의 PR (#72~#81) 머지 + Gemini 리뷰 반영 + 사용자 환경 (statusline / python hook) 보정까지 한 세션에서 끝난 시점. 컨텍스트 90% 도달로 새 세션으로 이관. cold-start 세션이 같은 흐름으로 이어갈 수 있도록 모든 결정/사고/규칙을 한 곳에 정리한다.
 
 ---
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,12 +1,45 @@
 # Reference
 
-Reference document index.
+seCall 의 현재 기준 사실(SSOT) 문서 인덱스. 모든 항목은 "지금 옳다고 합의된 상태" 이며, plans/prompts 와 달리 같은 파일을 갱신하는 것을 원칙으로 한다.
 
-## Documents
+> 문서 규약(파일명, frontmatter, 인덱스 갱신 등)은 [docConventions.md](docConventions.md) 참고.
 
-- [roadmap.md](roadmap.md) — seCall 전체 로드맵 (Phase 1~4, 아키텍처, 기술 스택)
-- [adr-blocking-io-in-async.md](adr-blocking-io-in-async.md) — ADR: async 내 blocking I/O는 spawn_blocking으로 래핑 (CLI 특성상 정당)
-- [idea-two-tier-llm-pipeline.md](idea-two-tier-llm-pipeline.md) — 아이디어: 2계층 LLM 파이프라인 (저비용 초안 → 고품질 검수)
+## 추천 읽기 순서
+
+새 세션에서 컨텍스트를 파악할 때 다음 순서로 읽으면 충분하다.
+
+1. 프로젝트 루트 [`CLAUDE.md`](../../CLAUDE.md) — 프로젝트 전체 규약과 현재 상태 요약
+2. [handoff_2026-05-19.md](handoff_2026-05-19.md) — 최신 세션 핸드오프 (현재 작업 맥락)
+3. [core-backlog.md](core-backlog.md) / [web-backlog.md](web-backlog.md) — 현 우선순위와 백로그
+4. 작업 영역별 reference (LLM 설정이면 `llm-config.md`, Wiki 작업이면 `wiki-setup.md` 등)
+5. (필요 시) 관련 [plans](../plans/index.md) / [prompts](../prompts/index.md)
+
+## 문서 목록
+
+### 프로젝트 기준
+
+- [roadmap.md](roadmap.md) — seCall 전체 로드맵 (Phase 1~4, 아키텍처, 기술 스택) · 상태: done
+- [docConventions.md](docConventions.md) — 문서 규약 (파일명/frontmatter/index/아카이브) · 상태: done
+- [core-backlog.md](core-backlog.md) — 코어(Rust CLI) 백로그 및 현 우선순위 · 상태: in_progress
+- [web-backlog.md](web-backlog.md) — Web/REST/Obsidian 플러그인 백로그 · 상태: in_progress
+
+### 세션 핸드오프 (시간순 스냅샷, 최신만 우선 참고)
+
+- [handoff_2026-05-19.md](handoff_2026-05-19.md) — 최신 세션 핸드오프 · 상태: done
+- [handoff_2026-05-12.md](handoff_2026-05-12.md) — 이전 세션 핸드오프 · 상태: archived (직전 스냅샷, 보존)
+
+### 운영·설정 가이드
+
+- [llm-config.md](llm-config.md) — LLM 백엔드 설정 (Ollama/Gemini/Anthropic, env/config.toml 우선순위) · 상태: done
+- [wiki-setup.md](wiki-setup.md) — Wiki 파이프라인 초기 설정 · 상태: done
+- [github-vault-sync.md](github-vault-sync.md) — Obsidian Vault ↔ GitHub 동기화 절차 · 상태: done
+- [daily-host-suffix-handoff.md](daily-host-suffix-handoff.md) — 데일리 노트 host suffix 처리 핸드오프 · 상태: done
+- [sync-monitor-2026-05-15.md](sync-monitor-2026-05-15.md) — Sync 모니터링 운영 기록 · 상태: partial
+
+### 설계·아이디어
+
+- [adr-blocking-io-in-async.md](adr-blocking-io-in-async.md) — ADR: async 내 blocking I/O 는 `spawn_blocking` 으로 래핑 (CLI 특성상 정당) · 상태: done
+- [idea-two-tier-llm-pipeline.md](idea-two-tier-llm-pipeline.md) — 아이디어: 2계층 LLM 파이프라인 (저비용 초안 → 고품질 검수) · 상태: draft, canonical: false
 
 ## CLI Reference
 

--- a/docs/reference/web-backlog.md
+++ b/docs/reference/web-backlog.md
@@ -1,7 +1,7 @@
 ---
 type: reference
 status: in_progress
-updated_at: 2026-05-16
+updated_at: 2026-05-19
 ---
 
 # secall-web 백로그 / 알려진 이슈
@@ -25,20 +25,7 @@ updated_at: 2026-05-16
 
 ## hot
 
-### Graph snapshot 대용량 응답 → "멈춤 화면"
-- **위치**: `crates/secall-core/src/mcp/server.rs:do_graph_snapshot` + `web/src/lib/api.ts:183` (`graphSnapshot(sessionLimit=80)`) + `web/src/routes/GraphRoute.tsx` (ObsidianGraph)
-- **현상**: server 응답에 **edge 개수 제한이 없음**. `session_limit=80` 만 있고 그 안의 모든 관계 (`by_agent` / `belongs_to` / `discusses_topic` / `same_project` / `same_day`) 가 직렬화됨. 2026-05-16 시점 응답 약 **1246 edges / ~600KB**. web 측은 D3 force-simulation + SVG 로 모든 노드/엣지를 DOM 렌더링 (virtualization 없음). 사용자 보고 "그래프 거의 멈춤화면" 과 직접 연결됨.
-- **권장 fix**:
-  - server: `/api/graph/snapshot` 에 `edge_limit` 파라미터 (또는 relation 별 cap) 추가
-  - client: edge 수 임계값 (예: 300+) 이면 자동 filter / cluster / canvas-mode 전환
-
-### LLM config 모델 자유 입력 (드롭다운 부재)
-- **위치**: `web/src/routes/SettingsRoute.tsx` 7곳 — `review_model:275` / `ollama_model:366` / `anthropic_model:371` / `cloud_model:376` / `log.model:122` / `log.cloud_model:127` / `embedding.openai_model:137`
-- **현상**: 모델 필드가 모두 `<Input type="text">` 자유 입력. 검증은 `validateModelName()` (정규식 `/^[a-zA-Z0-9._:-]+$/`) 만. backend 별 (ollama/ollama_cloud/lmstudio/anthropic/openai/gemini) 추천 모델 hardcode 미존재. 반면 `semantic_backend` 는 정상적으로 `<select>` 드롭다운 사용. 타이포 위험 + 사용자가 가용 모델 모를 때 시행착오.
-- **권장 fix**:
-  - 옵션 a: `web/src/lib/api.ts` 에 backend 별 모델 목록 상수 + `<datalist>` 패턴 (드롭다운 + 자유 입력 fallback)
-  - 옵션 b: server 측 `/api/config/models?backend=...` endpoint 신설 (SSOT)
-  - graph / wiki / log / embedding 4 섹션 모두 동일 패턴 적용
+_현재 항목 없음._
 
 ## debt
 
@@ -51,11 +38,6 @@ updated_at: 2026-05-16
   - `crates/secall-core/build.rs` 에 `cargo:rerun-if-changed=../../web/dist/index.html` 추가해 dist 변경 시 cargo rebuild 트리거
   - 또는 `cargo xtask build` 류 wrapper 가 pnpm build + cargo build 묶어 실행
   - 또는 release 절차에 "pnpm build 후 cargo install" 체크리스트 박제
-
-### Markdown 폴딩/언폴딩 미구현
-- **위치**: `web/src/components/MarkdownView.tsx`
-- **현상**: `react-markdown` + `remarkGfm` 만 로드. `<details>`/`<summary>` 컴포넌트 override 없음. heading 클릭으로 섹션 접기 없음. 비교: `NoteEditor.tsx:57` / `SessionHeader.tsx:61` 은 `<details>` 직접 사용해 동작. 사용자 보고 "폴딩 제대로 안 됨" 과 일치.
-- **권장 fix**: `components` 객체에 `h1/h2/h3` override (click handler + collapsed state) 또는 `remark-collapse` 류 플러그인. 동시에 `details` override 로 click 동작 명시화.
 
 ### `jfetch<unknown>` 타입 미해결 6 endpoints
 - **위치**: `web/src/lib/api.ts` — `daily:162` / `graphSearch:176` / `wikiSearch:179` / `graphSnapshot:183` / `wikiList:188` / `cancelJob:238`
@@ -84,11 +66,6 @@ updated_at: 2026-05-16
 - **위치**: `web/src/routes/SessionDetailRoute.tsx:42` `grid grid-cols-1 lg:grid-cols-[...]` (md breakpoint 없음)
 - **현상**: tailwind breakpoint 가 `lg` (1024px) 만. 태블릿 (768~1023px) 구간은 1열 collapse 또는 미정의 layout.
 - **권장 fix**: `md:` breakpoint 추가 (`md:grid-cols-[minmax(0,var(--read-w))_300px]`) 또는 mobile-first 패턴 점진 도입.
-
-### Markdown link 컴포넌트 미커스텀
-- **위치**: `web/src/components/MarkdownView.tsx`
-- **현상**: `[text](url)` 이 그냥 `<a href=...>` 로. vault 내부 path / `[[wikilink]]` obsidian syntax 미지원. 외부 URL 만 동작.
-- **권장 fix**: `components: { a: CustomLink }` 추가 (vault path detection + react-router navigation) + 필요 시 `remark-wiki-link` 플러그인.
 
 ### server-side version 과 web build 시점 version 불일치
 - **시나리오**: server 만 `cargo install --force` 로 새 버전 깔고 `secall serve` 띄우면 — server 의 `/api/status` 는 새 버전, web bundle (dist) 은 옛 빌드 시점에 박힌 자산 (CSS/JS layout). 표시되는 version 은 server 가 SSOT 이므로 일치하지만, 실제 화면 동작은 옛 dist 기준.


### PR DESCRIPTION
## Summary
- `docs/reference/docConventions.md` 신설 — tunaflow 의 versioning + navigation 두 정책을 secall 컨텍스트로 압축. 8개 디렉토리 역할, 파일명, frontmatter, index, 버전관리, 아카이브, 4단계 체크리스트 포함. CLAUDE.md §3 의 expanded 버전.
- `docs/reference/index.md` 보강 — 누락된 10개 파일 모두 등록 + 상태 라벨 + 5단계 추천 읽기 순서. 기존 CLI Reference 표 보존.
- `docs/reference/web-backlog.md` 청소 — PR #79 (P66 f/u) + #75 (P66) + #78 (P65) 머지로 해소된 4건 제거 (hot 2→0, debt 5→3, watch 4→3).
- `docs/reference/handoff_2026-05-19.md` 신설 — v0.5.0 + 10 PR (#72~#81) 머지 + 사용자 환경 보정 완료 시점 cold-start 인수인계 문서.

## Why
- 컨텍스트가 새로 시작한 세션이 한 문서만 읽고 작업 재개 가능하도록 정리.
- backlog 가 stale 항목으로 가득해 다음 우선순위 판단 정확도 하락 — 청소 필요.

## Test plan
- [x] 문서 변경만 (코드/테스트 영향 없음)
- [x] markdown 렌더링 sanity check (frontmatter 형식, 링크 경로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)