### PR TITLE
fix(core): P82 — Config::save() integration test 가드 확장

### DIFF
--- a/crates/secall-core/src/vault/config.rs
+++ b/crates/secall-core/src/vault/config.rs
@@ -437,23 +437,21 @@ impl Config {
 
         let path = Self::config_path();
 
-        // P68: test 환경에서 SECALL_CONFIG_PATH 미설정 시 production config 를
-        // 덮어쓰는 사고 방지. 2026-05-16 cargo test 가 사용자 환경의
-        // `[vault].path` 를 `save_preserves_top_level_comments` 의 hardcoded
-        // 값 `/tmp/changed` 로 덮어쓴 사고 (P58 race fix 머지 전) 회복 후
-        // 도입. 단위 테스트 (#[cfg(test)] 적용 범위) 한정 — integration tests
-        // 의 경우는 core-backlog 후속 항목 (runtime guard 또는 helper 분리).
-        #[cfg(test)]
-        {
-            if std::env::var("SECALL_CONFIG_PATH").is_err() {
-                anyhow::bail!(
-                    "Config::save() called without SECALL_CONFIG_PATH in test \
-                     context — refusing to write production config at {:?}. \
-                     테스트는 SECALL_CONFIG_PATH 를 tempdir 로 set 한 후 \
-                     save() 를 호출해야 합니다.",
-                    path
-                );
-            }
+        // P68 + P82: test 환경에서 SECALL_CONFIG_PATH 미설정 시 production
+        // config 를 덮어쓰는 사고 방지. P68 은 unit test 만 (#[cfg(test)]),
+        // P82 에서 runtime env (`SECALL_TEST_MODE=1`) 로 integration test 까지
+        // 확장. integration test 는 `tests/common::ensure_test_mode()` 호출로
+        // SECALL_TEST_MODE 를 set 한다.
+        let in_test = cfg!(test) || std::env::var("SECALL_TEST_MODE").is_ok();
+        if in_test && std::env::var("SECALL_CONFIG_PATH").is_err() {
+            anyhow::bail!(
+                "Config::save() called without SECALL_CONFIG_PATH in test \
+                 context (cfg!(test) 또는 SECALL_TEST_MODE 감지) — refusing \
+                 to write production config at {:?}. 테스트는 \
+                 SECALL_CONFIG_PATH 를 tempdir 로 set 한 후 save() 를 \
+                 호출해야 합니다.",
+                path
+            );
         }
 
         if let Some(parent) = path.parent() {

--- a/crates/secall-core/tests/common/mod.rs
+++ b/crates/secall-core/tests/common/mod.rs
@@ -55,6 +55,10 @@ pub struct TestEnv {
 /// `JobExecutor::with_adapters` 가 sync API 이지만, REST 라우터의 일부 핸들러
 /// (status 등) 는 async tokio 컨텍스트를 요구하므로 본 함수도 async 로 둔다.
 pub async fn make_test_env() -> TestEnv {
+    // P82 follow-up (Gemini 리뷰): 공통 진입점에서 자동 호출하여 명시 호출
+    // 누락 위험 차단.
+    ensure_test_mode();
+
     let dir = tempfile::tempdir().expect("tempdir");
     let db_path = dir.path().join("test.db");
     let db = Database::open(&db_path).expect("open db (v8 migration)");

--- a/crates/secall-core/tests/common/mod.rs
+++ b/crates/secall-core/tests/common/mod.rs
@@ -180,6 +180,23 @@ pub fn make_fake_adapters(delay_ms: u64) -> CommandAdapters {
     }
 }
 
+/// P82: integration test 진입 시 `SECALL_TEST_MODE=1` 을 set 한다.
+///
+/// `Config::save()` 의 runtime 가드 (`cfg!(test) || SECALL_TEST_MODE`) 가
+/// integration test 컨텍스트에서도 trigger 되어, `SECALL_CONFIG_PATH` 미설정
+/// 시 production config (`~/Library/Application Support/secall/config.toml`)
+/// 를 덮어쓰는 사고를 차단한다. 2026-05-16 사고 재발 방지.
+///
+/// `Once` 로 1회 set 후 process 종료까지 유지된다 (test 격리 단위가 process
+/// 이므로 누수 안전).
+pub fn ensure_test_mode() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        std::env::set_var("SECALL_TEST_MODE", "1");
+    });
+}
+
 /// P32~P37 호환 minimal session row. 다른 통합 테스트의 `make_session` 패턴
 /// (`tests/rest_listing.rs`) 을 따른다.
 ///

--- a/crates/secall-core/tests/config_save_guard.rs
+++ b/crates/secall-core/tests/config_save_guard.rs
@@ -1,0 +1,67 @@
+//! P82: integration test 환경에서 `Config::save()` 의 runtime 가드가
+//! production config 를 덮어쓰지 못하게 차단하는지 검증.
+//!
+//! - cfg!(test) 는 integration test crate 입장에서 false (lib 컴파일 시점은 false).
+//! - 대신 `common::ensure_test_mode()` 가 `SECALL_TEST_MODE=1` 을 set 하므로
+//!   save() 의 runtime 가드 (`cfg!(test) || SECALL_TEST_MODE`) 가 trigger.
+
+mod common;
+
+use std::sync::Mutex;
+
+use secall_core::vault::Config;
+
+/// env 조작 직렬화. integration test binary 의 모든 thread 가 공유.
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+#[test]
+fn save_refuses_in_integration_test_without_secall_config_path() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+
+    common::ensure_test_mode();
+    // 다른 test 의 잔여 set 이 있을 수 있어 명시적 unset.
+    std::env::remove_var("SECALL_CONFIG_PATH");
+
+    let config = Config::default();
+    let result = config.save();
+
+    assert!(
+        result.is_err(),
+        "save() must refuse without SECALL_CONFIG_PATH in integration test \
+         context (SECALL_TEST_MODE set, cfg!(test) false)"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("SECALL_CONFIG_PATH"),
+        "error must mention SECALL_CONFIG_PATH, got: {msg}"
+    );
+    assert!(
+        msg.contains("SECALL_TEST_MODE") || msg.contains("test"),
+        "error should hint at test context detection, got: {msg}"
+    );
+}
+
+#[test]
+fn save_succeeds_when_secall_config_path_is_tempdir() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+
+    common::ensure_test_mode();
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let config_path = tempdir.path().join("config.toml");
+    std::env::set_var("SECALL_CONFIG_PATH", &config_path);
+
+    let config = Config::default();
+    let result = config.save();
+
+    std::env::remove_var("SECALL_CONFIG_PATH");
+
+    assert!(
+        result.is_ok(),
+        "save() must succeed with SECALL_CONFIG_PATH set to tempdir, got: {:?}",
+        result.err()
+    );
+    assert!(
+        config_path.exists(),
+        "config.toml should be written to tempdir"
+    );
+}

--- a/crates/secall-core/tests/rest_config.rs
+++ b/crates/secall-core/tests/rest_config.rs
@@ -43,6 +43,7 @@ fn make_router(dir: &tempfile::TempDir, allow_config_edit: bool) -> axum::Router
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_config_masks_secret_and_reports_env_indicators() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -72,6 +73,7 @@ cloud_api_key = "secret-key"
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_patch_config_updates_section_when_enabled() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -104,6 +106,7 @@ path = "/tmp/test-vault"
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_patch_config_returns_403_when_disabled() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -140,6 +143,7 @@ path = "/tmp/test-vault"
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_patch_config_unknown_section_returns_404() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -176,6 +180,7 @@ path = "/tmp/test-vault"
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_patch_graph_section_ignores_cloud_api_key() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -215,6 +220,7 @@ cloud_api_key = "original-secret"
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_patch_log_section_ignores_cloud_api_key() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -254,6 +260,7 @@ cloud_api_key = "original-log-secret"
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_patch_preserves_other_sections_in_toml() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -316,6 +323,7 @@ backend = "ort"
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_patch_invalid_json_body_returns_400() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -352,6 +360,7 @@ path = "/tmp/test-vault"
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_patch_embedding_section_ignores_cloud_api_key() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -391,6 +400,7 @@ cloud_api_key = "original-embed-secret"
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_config_masks_embedding_cloud_api_key() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -419,6 +429,7 @@ cloud_api_key = "secret-embed-key"
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_patch_embedding_section_updates_non_secret_fields() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -475,6 +486,7 @@ backend = "ollama"
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_config_returns_pool_size_field() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(
@@ -504,6 +516,7 @@ pool_size = 4
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_config_env_indicators_includes_ollama_cloud_api_key() {
     let _guard = ENV_MUTEX.lock().await;
+    common::ensure_test_mode();
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = dir.path().join("config").join("config.toml");
     write_config(

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -126,3 +126,11 @@ Plan document index. Register new plans here.
 | [02](secall-p17-cli-git-branch-task-02.md) | secall config 서브커맨드 | B | 01 | draft |
 | [03](secall-p17-cli-git-branch-task-03.md) | 대화형 온보딩 (secall init 개선) | C | 01,02 | draft |
 | [04](secall-p17-cli-git-branch-task-04.md) | status 설정 요약 표시 | D | 02 | draft |
+
+---
+
+### seCall P82 — Config::save() integration test 가드 확장
+
+- [전체 계획서](p82-config-save-guard.md) — in_progress, 2026-05-19
+- 단일 Task: `Config::save()` 의 `#[cfg(test)]` 가드를 runtime env (`SECALL_TEST_MODE`) 로 확장해 integration test 까지 보호.
+- 관련: `docs/reference/core-backlog.md` hot 1건 해소 대상.

--- a/docs/plans/p82-config-save-guard.md
+++ b/docs/plans/p82-config-save-guard.md
@@ -1,0 +1,87 @@
+---
+type: plan
+status: in_progress
+updated_at: 2026-05-19
+canonical: true
+---
+
+# P82 — `Config::save()` integration test 가드 확장
+
+## 배경
+
+2026-05-16 사고: `cargo test --lib -p secall-core vault::` flaky test 재현 시도 (P58 race fix 머지 전) 중 production `~/Library/Application Support/secall/config.toml` 의 `[vault].path` 가 unit test `save_preserves_top_level_comments` 의 hardcoded 값 (`/tmp/changed`) 으로 덮어쓰여, 사용자 web UI 가 wiki 빈 화면 / graph 멈춤. 복구 후 P68 (`#[cfg(test)]` 가드) 도입.
+
+**한계**: `#[cfg(test)]` 는 컴파일 시점 — `secall-core` 가 lib 으로 컴파일될 때 (integration test 입장의 외부 dependency) false. 따라서 `crates/secall-core/tests/*.rs` 에서 `secall_core::vault::Config::save()` 직·간접 호출 시 가드 무력. core-backlog hot 1건으로 박제됨.
+
+## 목표
+
+- `Config::save()` 가 unit test + integration test 두 컨텍스트 모두에서 `SECALL_CONFIG_PATH` 미설정 시 production config 를 덮어쓰지 못하도록 보호.
+- 사용자 직접 사고 (2026-05-16) 의 재발 차단.
+
+## 비목표
+
+- production `secall` CLI 동작 변경 없음 (env 미설정 시 정상 save).
+- `commands/config.rs`, `commands/init.rs` 의 save 호출 사이트 수정 없음.
+- core-backlog 의 다른 항목 (dist rerun-if-changed, /api/status 분리 등) 은 별도 P 번호.
+
+## 옵션 비교 (요약)
+
+| 옵션 | 장점 | 단점 | 선택 |
+|---|---|---|---|
+| **A. Runtime env guard** (`SECALL_TEST_MODE=1`) | integration test 까지 보호. 변경 최소. unit test 가드 패턴 그대로 재활용 | 명시적 env set 필요 (자동 검출 불가능) | ✅ |
+| B. `save_to_path(&path)` helper 분리 | API 명시 | 호출 사이트 다수 수정. 가드 자체 문제는 미해결 | ❌ |
+| C. `serial_test` crate | race 직렬화 | 가드와 직교 (이미 ENV_MUTEX 존재). 사고 직접 방지 아님 | ❌ |
+
+## 구현 절차
+
+### 1. `crates/secall-core/src/vault/config.rs` 의 `Config::save()` 가드 통합
+
+- 기존 `#[cfg(test)]` 블록을 `cfg!(test) || SECALL_TEST_MODE` runtime check 로 확장.
+- error message 에 `SECALL_TEST_MODE` 도 언급.
+
+### 2. `crates/secall-core/tests/common/mod.rs` 에 `ensure_test_mode()` 추가
+
+- `std::sync::Once` 로 1회 set. 모듈 사용처가 호출.
+- env unset 은 안 함 (test 종료 시까지 살아 있도록).
+
+### 3. `Config::save()` 가 (직·간접) 호출될 수 있는 integration tests 의 setup 에 `common::ensure_test_mode()` 호출 추가
+
+- `rest_config.rs` — 모든 test fn 의 ENV_MUTEX 잡은 직후
+- `vault_auto_commit.rs` — Config 사용 여부 grep 검증
+- 그 외 `secall_core::vault::Config` import 한 test 파일 검증
+
+### 4. 신규 unit test `save_refuses_in_runtime_test_context_without_env`
+
+- ENV_MUTEX 잡기 → `SECALL_TEST_MODE=1` 보장 → `SECALL_CONFIG_PATH` remove → `Config::default().save()` → err 검증 → env 복원.
+
+### 5. `docs/reference/core-backlog.md` 의 hot 1건 해소 표기
+
+- 해당 entry 에 "해소: PR #N (P82)" 표시 또는 hot → done 이동.
+
+## 변경 파일
+
+| 파일 | 변경 종류 |
+|---|---|
+| `crates/secall-core/src/vault/config.rs` | save() 가드 통합 + 신규 unit test 1건 |
+| `crates/secall-core/tests/common/mod.rs` | `ensure_test_mode()` 추가 |
+| `crates/secall-core/tests/rest_config.rs` | setup 에 `common::ensure_test_mode()` 호출 (각 test fn 또는 모듈 상단 1회) |
+| `crates/secall-core/tests/vault_auto_commit.rs` | Config 사용 시 동일 |
+| `docs/reference/core-backlog.md` | hot 항목 해소 표기 |
+| `docs/plans/index.md` | P82 plan 등록 |
+
+## 검증
+
+```bash
+cargo test -p secall-core vault::config::tests
+cargo nextest run -p secall-core --test rest_config --test vault_auto_commit
+cargo nextest run --workspace --no-fail-fast
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+## 리스크
+
+- integration test 누락 시 새 가드에 걸려 fail → 변경 후 워크스페이스 nextest 로 회귀 검증 필수.
+- `SECALL_TEST_MODE` env 가 CI/dev shell 에 leak 시 production CLI 사용 시 의도치 않은 가드 trigger.
+  - CI: test 만 실행하므로 OK
+  - 개발자 shell: 명시적 unset 필요 — handoff 문서에 명시.

--- a/docs/plans/p82-config-save-guard.md
+++ b/docs/plans/p82-config-save-guard.md
@@ -62,12 +62,14 @@ canonical: true
 
 | 파일 | 변경 종류 |
 |---|---|
-| `crates/secall-core/src/vault/config.rs` | save() 가드 통합 + 신규 unit test 1건 |
-| `crates/secall-core/tests/common/mod.rs` | `ensure_test_mode()` 추가 |
-| `crates/secall-core/tests/rest_config.rs` | setup 에 `common::ensure_test_mode()` 호출 (각 test fn 또는 모듈 상단 1회) |
-| `crates/secall-core/tests/vault_auto_commit.rs` | Config 사용 시 동일 |
+| `crates/secall-core/src/vault/config.rs` | save() 가드 통합 |
+| `crates/secall-core/tests/common/mod.rs` | `ensure_test_mode()` 추가 + `make_test_env()` 내부에서 자동 호출 (Gemini 리뷰 반영) |
+| `crates/secall-core/tests/config_save_guard.rs` (신규) | runtime 가드 동작 검증 2건 |
+| `crates/secall-core/tests/rest_config.rs` | 각 test fn 에 `common::ensure_test_mode()` 호출 (Gemini 리뷰 반영 — 미래 누락 방지 안전 마진) |
 | `docs/reference/core-backlog.md` | hot 항목 해소 표기 |
 | `docs/plans/index.md` | P82 plan 등록 |
+
+> **참고**: 초안 plan 에는 `vault_auto_commit.rs` 도 변경 대상이었으나, 해당 파일은 `secall_core::vault::Config` 를 사용하지 않고 (`VaultGit` 만 사용) `mod common;` 도 import 하지 않음. 가드 trigger 경로가 없어 변경 제외.
 
 ## 검증
 

--- a/docs/reference/core-backlog.md
+++ b/docs/reference/core-backlog.md
@@ -1,7 +1,7 @@
 ---
 type: reference
 status: in_progress
-updated_at: 2026-05-16
+updated_at: 2026-05-19
 ---
 
 # secall-core 백로그 / 알려진 이슈
@@ -13,16 +13,9 @@ updated_at: 2026-05-16
 
 ## hot
 
-### cargo test 가 production config.toml 을 덮어쓰는 회귀
-- **위치**: `crates/secall-core/src/vault/config.rs#tests` (`save_*` 류 테스트)
-- **현상**: `save_preserves_top_level_comments`, `save_removes_optional_keys_when_cleared` 등이 `Config::save()` 를 호출. `SECALL_CONFIG_PATH` env 를 tempdir 로 set 한 상태에서 호출하지만, 다른 테스트와 race / 또는 panic 으로 인한 unwind 시 `SECALL_CONFIG_PATH` 가 unset 된 채 save 가 실행되면 **production config (`~/Library/Application Support/secall/config.toml`) 를 덮어씀**.
-- **재현 (2026-05-16)**: P58 race fix 머지 전 vault::config flaky test 재현 시도 (5회 반복) 도중 한 시점에 production config.toml 의 `[vault].path` 가 `/tmp/changed` (`save_preserves_top_level_comments` 의 hardcoded 값) 로 변경됨. 사용자가 web UI 에서 wiki 빈 화면 / graph 멈춤으로 인지.
-- **위험도**: HIGH — 사용자의 실 환경을 깨뜨리는 부수효과. 단 P58 race fix 머지 후엔 race 자체는 차단.
-- **남은 위험**: panic / 강제 종료 시 `SECALL_CONFIG_PATH` unset → save 가 production 으로 흘러갈 가능성. 테스트가 `Config::save()` 를 호출하는 한 구조적 위험 잔존.
-- **후속 액션 후보**:
-  1. `Config::save()` 가 `SECALL_CONFIG_PATH` 이 set 되어 있지 않으면 **production path 대신 명시 에러 또는 noop** 으로 동작하는 `#[cfg(test)]` 가드 추가
-  2. 또는 test 만의 `Config::save_to_path(&path)` 헬퍼 신설해 save() 호출 자체 회피
-  3. 또는 `serial_test` crate 도입해 env mutation 테스트 전체를 process-level serial 화 (현 ENV_MUTEX 는 panic 복구 불가)
+(현재 없음)
+
+> 직전 해소: cargo test 가 production config.toml 을 덮어쓰는 회귀 — **P82 (PR 작성 중)** 에서 `Config::save()` 의 `#[cfg(test)]` 가드를 runtime env (`SECALL_TEST_MODE`) 로 확장해 integration test 까지 보호. 신규 `tests/config_save_guard.rs` 가 가드 동작 검증. 참조: [docs/plans/p82-config-save-guard.md](../plans/p82-config-save-guard.md).
 
 ## debt
 


### PR DESCRIPTION
## Summary
- `Config::save()` 의 `#[cfg(test)]` 가드를 runtime env (`SECALL_TEST_MODE`) 로 확장 — integration test 까지 보호.
- `tests/common/mod.rs` 에 `ensure_test_mode()` helper 추가 (`Once` 로 1회 set).
- 신규 `tests/config_save_guard.rs` (2건) 가 가드 동작을 검증: SECALL_CONFIG_PATH 미설정 시 bail, tempdir set 시 정상 save.
- core-backlog hot 1건 해소, plans/index.md 에 P82 등록.

## Why
2026-05-16 회귀: `cargo test --lib -p secall-core vault::` flaky test 재현 시도 (P58 race fix 머지 전) 도중 production `~/Library/Application Support/secall/config.toml` 의 `[vault].path` 가 unit test `save_preserves_top_level_comments` 의 hardcoded `/tmp/changed` 로 덮어쓰여, 사용자 web UI 가 wiki 빈 화면 / graph 멈춤. P68 (`#[cfg(test)]` 가드) 가 unit test 만 보호 — integration test 가 `secall_core::vault::Config::save()` 를 직·간접 호출 시 가드 무력. core-backlog hot 으로 추적되던 미해결 위험.

옵션 비교는 `docs/plans/p82-config-save-guard.md` 참조 (Runtime env guard ✅ vs helper 분리 ❌ vs serial_test ❌).

## Test plan
- [x] `cargo test -p secall-core --lib vault::config` — 17 passed
- [x] `cargo test -p secall-core --test config_save_guard` — 2 passed
- [x] `cargo test --workspace --no-fail-fast` — all green
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

## Note
`SECALL_TEST_MODE` env 가 dev shell 에 leak 시 production CLI 사용 시 가드 trigger. 명시적 unset 필요 — handoff 문서에 명시 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)