### PR TITLE
fix(wiki,ingest): P83 — wiki 호출이 만든 codex/claude 세션 self-ingest 루프 차단 (#82)

### DIFF
--- a/crates/secall-core/src/ingest/mod.rs
+++ b/crates/secall-core/src/ingest/mod.rs
@@ -36,13 +36,16 @@ pub trait SessionParser: Send + Sync {
     }
 }
 
-/// P49: 노이즈 세션을 감지한다.
+/// P49 + P83: 노이즈 세션을 감지한다.
 ///
-/// secall 자체가 Claude Code 를 invoke 해 요약을 생성하는 흐름이 `~/.claude/projects/`
-/// 에 또 jsonl 로 남으면서 자기참조 ingest 가 발생해 vault 가 거의 동일한 짧은 세션으로
-/// 오염됐다. 두 가지 패턴을 차단한다:
+/// secall 자체가 Claude Code 또는 codex 를 invoke 해 요약/위키를 생성하는 흐름이
+/// `~/.claude/projects/` 또는 `~/.codex/sessions/` 에 또 jsonl 로 남으면서 자기참조
+/// ingest 가 발생해 vault 가 거의 동일한 짧은 세션으로 오염됐다. 차단 패턴:
 ///   1. cwd 가 OS 임시 디렉토리 (`/private/var/folders`, `/var/folders`, `/tmp`)
 ///   2. 첫 user turn 본문이 secall 의 알려진 summary 프롬프트 prefix 로 시작
+///   3. (P83) 첫 user turn 본문이 `wiki::WIKI_INVOCATION_MARKER` 를 포함
+///      — `secall wiki update` 가 codex/claude 백엔드 subprocess 호출 시 prompt
+///      앞에 prefix 로 추가하는 marker. Issue #82 fix.
 ///
 /// 매치 시 사유 문자열을 반환, 정상 세션은 `None`.
 pub fn is_noise_session(session: &Session) -> Option<&'static str> {
@@ -56,12 +59,15 @@ pub fn is_noise_session(session: &Session) -> Option<&'static str> {
     }
 
     if let Some(first_user) = session.turns.iter().find(|t| t.role == Role::User) {
-        if first_user
-            .content
-            .trim_start()
-            .starts_with(SECALL_SUMMARY_PROMPT_PREFIX)
-        {
+        let content_trimmed = first_user.content.trim_start();
+        if content_trimmed.starts_with(SECALL_SUMMARY_PROMPT_PREFIX) {
             return Some("secall summary prompt");
+        }
+        // P83 marker 는 `contains` — codex/claude 가 system prompt 를 앞에 prepend
+        // 하는 경우에도 robust. 변수는 일관성 위해 `content_trimmed` 재사용
+        // (trim 결과 marker 자체는 변하지 않음).
+        if content_trimmed.contains(crate::wiki::WIKI_INVOCATION_MARKER) {
+            return Some("secall wiki invocation");
         }
     }
 
@@ -151,6 +157,39 @@ mod tests {
     #[test]
     fn is_not_noise_when_no_cwd_no_user_turn() {
         let s = dummy_session(None, None);
+        assert_eq!(is_noise_session(&s), None);
+    }
+
+    /// P83 (issue #82): codex/claude wiki 호출이 marker prefix 한 prompt 로
+    /// 생성한 세션은 self-ingest 루프 차단을 위해 skip.
+    #[test]
+    fn is_noise_wiki_invocation_marker_at_start() {
+        let prompt = format!(
+            "{}\n\nUpdate the wiki for the following sessions...",
+            crate::wiki::WIKI_INVOCATION_MARKER
+        );
+        let s = dummy_session(Some("/Users/me/projects/seCall"), Some(&prompt));
+        assert_eq!(is_noise_session(&s), Some("secall wiki invocation"));
+    }
+
+    #[test]
+    fn is_noise_wiki_invocation_marker_in_middle() {
+        // marker 가 어디에 있든 검출되어야 함 (codex/claude 의 system prompt 가
+        // 앞에 붙는 경우에도 robust).
+        let prompt = format!(
+            "Some preamble...\n{}\nMore content",
+            crate::wiki::WIKI_INVOCATION_MARKER
+        );
+        let s = dummy_session(Some("/Users/me/projects/seCall"), Some(&prompt));
+        assert_eq!(is_noise_session(&s), Some("secall wiki invocation"));
+    }
+
+    #[test]
+    fn is_not_noise_without_wiki_marker() {
+        let s = dummy_session(
+            Some("/Users/me/projects/seCall"),
+            Some("Just a normal user prompt without any markers"),
+        );
         assert_eq!(is_noise_session(&s), None);
     }
 }

--- a/crates/secall-core/src/wiki/claude.rs
+++ b/crates/secall-core/src/wiki/claude.rs
@@ -45,8 +45,13 @@ impl WikiBackend for ClaudeBackend {
             .current_dir(&self.vault_path)
             .spawn()?;
 
+        // P83 (issue #82): prompt 앞에 secall wiki marker 를 prefix 로 추가해
+        // claude CLI 가 생성한 세션 파일을 ingest 가 self-ingest 루프로 인식해
+        // skip 하도록 한다. 무한 wiki 재생성 차단.
+        let marked_prompt = format!("{}\n\n{}", crate::wiki::WIKI_INVOCATION_MARKER, prompt);
+
         if let Some(mut stdin) = child.stdin.take() {
-            stdin.write_all(prompt.as_bytes()).await?;
+            stdin.write_all(marked_prompt.as_bytes()).await?;
             stdin.shutdown().await?;
         }
 

--- a/crates/secall-core/src/wiki/codex.rs
+++ b/crates/secall-core/src/wiki/codex.rs
@@ -42,8 +42,13 @@ impl WikiBackend for CodexBackend {
             .kill_on_drop(true)
             .spawn()?;
 
+        // P83 (issue #82): prompt 앞에 secall wiki marker 를 prefix 로 추가해
+        // codex CLI 가 생성한 세션 파일을 ingest 가 self-ingest 루프로 인식해
+        // skip 하도록 한다. 무한 wiki 재생성 차단.
+        let marked_prompt = format!("{}\n\n{}", crate::wiki::WIKI_INVOCATION_MARKER, prompt);
+
         if let Some(mut stdin) = child.stdin.take() {
-            stdin.write_all(prompt.as_bytes()).await?;
+            stdin.write_all(marked_prompt.as_bytes()).await?;
             stdin.shutdown().await?;
         }
 

--- a/crates/secall-core/src/wiki/mod.rs
+++ b/crates/secall-core/src/wiki/mod.rs
@@ -22,6 +22,13 @@ pub use reviewers::{
     ClaudeReviewer, CodexReviewer, HaikuReviewer, LmStudioReviewer, OllamaReviewer,
 };
 
+/// P83: codex/claude wiki 호출이 만든 subprocess 세션을 ingest 가 식별하기 위한
+/// prompt prefix marker. `wiki::{codex,claude}::generate()` 가 prompt 앞에
+/// 이 marker 를 prepend 하고, `ingest::is_noise_session` 이 첫 user turn 에서
+/// 검출하면 self-ingest 루프 차단을 위해 해당 세션을 skip 한다.
+/// Issue #82 fix.
+pub const WIKI_INVOCATION_MARKER: &str = "<!-- secall:wiki-update -->";
+
 /// wiki 생성 프롬프트를 LLM에 전달하고 결과를 반환하는 추상 인터페이스
 #[async_trait::async_trait]
 pub trait WikiBackend: Send + Sync {

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -134,3 +134,11 @@ Plan document index. Register new plans here.
 - [전체 계획서](p82-config-save-guard.md) — in_progress, 2026-05-19
 - 단일 Task: `Config::save()` 의 `#[cfg(test)]` 가드를 runtime env (`SECALL_TEST_MODE`) 로 확장해 integration test 까지 보호.
 - 관련: `docs/reference/core-backlog.md` hot 1건 해소 대상.
+
+---
+
+### seCall P83 — Wiki self-ingest 루프 차단 (issue #82)
+
+- [전체 계획서](p83-wiki-self-ingest-loop.md) — in_progress, 2026-05-19
+- 단일 Task: `wiki/{codex,claude}.rs` 의 generate() 가 prompt 앞에 `WIKI_INVOCATION_MARKER` prefix → `is_noise_session()` 이 marker 검출 시 skip → wiki 호출이 생성한 codex/claude 세션의 self-ingest 루프 차단.
+- 관련: issue #82 (dicebattle).

--- a/docs/plans/p83-wiki-self-ingest-loop.md
+++ b/docs/plans/p83-wiki-self-ingest-loop.md
@@ -1,0 +1,136 @@
+---
+type: plan
+status: in_progress
+updated_at: 2026-05-19
+canonical: true
+---
+
+# P83 — Wiki 호출이 만든 codex/claude 세션을 ingest 가 자동 archive
+
+## 배경
+
+Issue #82 (dicebattle / 2026-05-18) 보고:
+
+> codex를 이용해서 세션을 요약시키니, 세션 요약 과정에서 새로운 codex 세션이 생기고, 그걸 다시 새로운 대화세션으로 인식해서 LLM 요약 과정을 다시 위키에 저장하는 상황
+
+진단 결과 codex + claude 두 wiki 백엔드 모두 동일 결함:
+
+1. `wiki update` → `backend.generate(prompt)` 호출
+2. `tokio::process::Command::new("codex"|"claude")` subprocess 실행 (cwd = `vault_path`)
+3. CLI 가 자체 세션 파일 (`~/.codex/sessions/...` 또는 `~/.claude/projects/...`) 생성
+4. `secall sync` 가 그 디렉토리 스캔 (`find_codex_sessions` / `find_claude_sessions`)
+5. wiki 호출로 생긴 세션도 일반 사용자 세션과 동일하게 ingest
+6. 다음 wiki 호출 또는 자동 hook 실행 시 그 세션도 분석 대상에 포함 → 중복 wiki / 무한 루프
+7. `ingest/{codex,claude}.rs` 어디에도 wiki 호출 식별 / skip 룰 없음
+
+다른 백엔드 (haiku, ollama, lmstudio) 는 HTTP API 라 영향 없음.
+
+## 목표
+
+- codex + claude wiki 호출이 생성한 세션을 ingest 시 자동으로 `archived = true` 로 마킹.
+- 기존에 이미 ingest 된 세션도 사후 정리 가능 (lint 또는 sync --force).
+- false positive 최소화 (사용자가 의도해서 만든 일반 세션은 영향 없음).
+
+## 비목표
+
+- 사용자가 vault 디렉토리에서 직접 codex/claude 를 일반 작업으로 사용한 경우까지 archive 하지 않는다 (단, marker prefix 가 robust 한 식별자라 이게 우선 적용).
+- wiki 호출 자체의 동작은 변경 없음 (prompt 에 marker prefix 만 추가).
+
+## Fix 방향 — 기존 `is_noise_session()` 에 marker 룰 추가
+
+조사 결과 `ingest/mod.rs:48` 의 `is_noise_session()` 이 이미 P49 에서 비슷한 self-ingest 패턴 (tmpdir cwd + Claude Code summary prompt) 을 차단하고 있고, `commands/ingest.rs:976` 에서 호출되어 매치 시 **skip 처리** (archive 가 아닌 skip). 즉 parser 시그니처 변경 없이 룰 한 줄 추가만으로 완성.
+
+| 검출 룰 | 적용 |
+|---|---|
+| (기존) cwd tmpdir | `/private/var/folders`, `/var/folders`, `/tmp` |
+| (기존) Claude Code summary prompt | `SECALL_SUMMARY_PROMPT_PREFIX` |
+| **(신규) wiki invocation marker** | 첫 user turn content 에 `WIKI_INVOCATION_MARKER` 포함 |
+
+처리 방식: skip (DB insert 자체 안 함). archive 보다 깔끔.
+
+### cwd vault 룰 미채택 사유
+
+옵션 2 (cwd 가 vault path 면 match) 도 검토했으나:
+- 사용자가 vault 디렉토리에서 직접 codex/claude 작업 시 false positive
+- marker 룰만으로도 robust (wiki 호출 prompt 는 항상 marker prefix)
+- false positive 위험이 추가 안전 마진 대비 큼
+
+별도 후속 PR (lint 신규 옵션 또는 sync --force) 에서 cwd 룰 검토 가능.
+
+## 구현 절차
+
+### 1. `crates/secall-core/src/wiki/mod.rs` — 공통 marker 상수
+
+```rust
+/// P83: wiki 호출 prompt 첫 줄에 prefix 로 추가되는 식별자.
+/// codex/claude CLI 가 만든 세션을 ingest 가 자동 archive 하는 marker.
+pub const WIKI_INVOCATION_MARKER: &str = "<!-- secall:wiki-update -->";
+```
+
+### 2. `crates/secall-core/src/wiki/codex.rs` 와 `wiki/claude.rs` — prompt prefix
+
+각 `generate()` 시작에서:
+```rust
+let marked_prompt = format!("{}\n\n{}", crate::wiki::WIKI_INVOCATION_MARKER, prompt);
+```
+그리고 `marked_prompt` 를 stdin 으로.
+
+### 3. `crates/secall-core/src/ingest/mod.rs` 의 `is_noise_session()` 룰 확장
+
+기존:
+```rust
+if first_user.content.trim_start().starts_with(SECALL_SUMMARY_PROMPT_PREFIX) {
+    return Some("secall summary prompt");
+}
+```
+
+추가:
+```rust
+if first_user.content.contains(crate::wiki::WIKI_INVOCATION_MARKER) {
+    return Some("secall wiki invocation");
+}
+```
+
+`contains` 로 검사 (codex/claude 가 system prompt 를 앞에 prepend 하는 경우에도 robust).
+
+### 4. 사후 정리 (기존 세션)
+
+P83 1차 PR 에서는 **신규 ingest 만 처리** — 무한 루프 차단이 시급. 기존 wiki invocation 세션 정리는 별도 fast-follow PR 또는 사용자 가이드 (issue 응답에 명시) 로 분리.
+
+### 5. 신규 테스트
+
+`ingest/mod.rs::tests` 에 3건 추가:
+- `is_noise_wiki_invocation_marker_at_start` — marker 가 prompt 맨 앞
+- `is_noise_wiki_invocation_marker_in_middle` — marker 가 중간에 있어도 검출
+- `is_not_noise_without_wiki_marker` — marker 없으면 통과
+
+## 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `crates/secall-core/src/wiki/mod.rs` | `WIKI_INVOCATION_MARKER` 상수 추가 |
+| `crates/secall-core/src/wiki/codex.rs` | `generate()` 가 marker prefix |
+| `crates/secall-core/src/wiki/claude.rs` | 동일 |
+| `crates/secall-core/src/ingest/mod.rs` | `is_noise_session()` 에 marker 룰 추가 + 신규 unit test 3건 |
+| `docs/plans/index.md` | P83 등록 |
+
+## 검증
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test -p secall-core --lib ingest::codex
+cargo test -p secall-core --lib ingest::claude
+cargo test -p secall-core --lib wiki
+cargo test --workspace --no-fail-fast
+```
+
+## 리스크
+
+- 사후 정리 (기존 wiki invocation 세션) 는 본 PR 범위 외 — 사용자가 직접 `secall archive` 또는 `secall list --recent` 로 처리 가능 (issue #82 응답에 명시).
+- marker 가 prompt 첫 부분에 노출 — codex/claude 는 marker 를 일반 HTML 주석으로 처리하므로 출력에 영향 없음 (검증 필요).
+
+## 후속 (별도 PR)
+
+- 기존 wiki invocation 세션 일괄 archive lint 옵션 또는 sync --force 자동 처리.
+- core-backlog 에 fast-follow 항목 등록 (필요 시).


### PR DESCRIPTION
## Summary
Issue #82 (dicebattle 보고) 의 wiki self-ingest 루프 차단.

- `wiki::WIKI_INVOCATION_MARKER` (`<!-- secall:wiki-update -->`) 상수 신설.
- `wiki/codex.rs` + `wiki/claude.rs` 의 `generate()` 가 prompt 앞에 marker prefix.
- `ingest::is_noise_session()` 에 marker 검출 룰 추가 — 첫 user turn 의 content 에 marker 포함 시 `"secall wiki invocation"` 사유로 skip.
- 기존 P49 (`SECALL_SUMMARY_PROMPT_PREFIX`) 와 동일 메커니즘이라 parser 시그니처 변경 없음.
- 신규 unit test 3건 (marker at start / in middle / absent).

## Why
`secall wiki update` → `codex exec` subprocess → codex CLI 가 `~/.codex/sessions/...` 에 새 세션 jsonl 생성 → secall sync 가 그 세션을 일반 사용자 세션과 동일하게 ingest → 다음 wiki 실행 시 그 세션도 분석 대상에 포함 → 무한 wiki 재생성 / 중복 항목. claude 백엔드 (`claude -p`) 도 동일.

다른 백엔드 (haiku, ollama, lmstudio) 는 HTTP API 라 영향 없음.

조사 결과 기존 `ingest/mod.rs::is_noise_session()` (P49) 이 이미 `tmpdir cwd` + `SECALL_SUMMARY_PROMPT_PREFIX` 검출로 self-ingest 패턴을 차단 중. wiki marker 룰 한 줄 추가만으로 동일 메커니즘 확장 가능.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p secall-core --lib ingest::` 110 passed (신규 3건 포함)
- [x] `cargo test --workspace --no-fail-fast` all green (lib 421 + integration)

## Out of scope
본 PR 머지 전 이미 ingest 된 wiki invocation 세션은 marker 가 없음. 사용자가 `secall list --recent` + `secall archive <id>` 또는 `~/.codex/sessions/` 직접 삭제로 수동 정리. 자동 일괄 정리는 별도 fast-follow PR 검토.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)