### PR TITLE
feat(lint): P84 — `lint --fix-wiki-invocations` for legacy wiki self-ingest cleanup (#82 follow-up)

### DIFF
--- a/crates/secall-core/src/ingest/lint.rs
+++ b/crates/secall-core/src/ingest/lint.rs
@@ -61,6 +61,7 @@ pub fn run_lint(db: &Database, config: &Config) -> Result<LintReport> {
     check_missing_embeddings(db, &mut findings)?;
     check_fts_integrity(db, &mut findings)?;
     check_orphan_vectors(db, &mut findings)?;
+    check_wiki_invocations(db, config, &mut findings)?;
     check_wiki_frontmatter(config, &mut findings)?;
     check_wiki_source_links(db, config, &mut findings)?;
     check_orphan_sessions(db, config, &mut findings)?;
@@ -390,6 +391,54 @@ fn check_orphan_sessions(
     Ok(())
 }
 
+// ─── L011: wiki invocation suspects (P84 / issue #82) ───────────────────────
+
+/// codex/claude wiki 백엔드는 `cwd = vault_path` 으로 subprocess 를 spawn 한다.
+/// P83 이전에 ingest 된 데이터에는 `WIKI_INVOCATION_MARKER` 가 없으므로 marker
+/// 검사로는 잡히지 않는다. 대신 cwd 가 정확히 vault path 와 일치하는 codex/claude
+/// 세션을 사후 정리 후보로 식별한다.
+///
+/// 사용자가 vault 디렉토리에서 직접 일반 작업한 세션은 false positive 가능성
+/// 있으나, vault 는 secall 의 wiki 저장소라 일반 작업이 거의 없다. 또 archive
+/// 는 reversible (`secall unarchive`) 이므로 보수적 정리에 적합.
+fn check_wiki_invocations(
+    db: &Database,
+    config: &Config,
+    findings: &mut Vec<LintFinding>,
+) -> Result<()> {
+    let vault_str = config.vault.path.to_string_lossy().to_string();
+
+    let conn = db.conn();
+    let mut stmt = conn.prepare(
+        "SELECT id, cwd, agent FROM sessions \
+         WHERE is_archived = 0 \
+           AND cwd IS NOT NULL \
+           AND agent IN ('codex', 'claude-code')",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+        ))
+    })?;
+    for row in rows {
+        let (id, cwd, agent) = row?;
+        if cwd == vault_str {
+            findings.push(LintFinding {
+                code: "L011".to_string(),
+                severity: Severity::Info,
+                message: format!(
+                    "{agent} session at vault path (likely wiki self-invocation): cwd={cwd}"
+                ),
+                session_id: Some(id),
+                path: None,
+            });
+        }
+    }
+    Ok(())
+}
+
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 /// vault 마크다운 파일에서 frontmatter의 session_id 필드를 추출
@@ -712,5 +761,123 @@ mod tests {
         let l010 = report.findings.iter().find(|f| f.code == "L010");
         assert!(l010.is_some(), "expected L010 finding for orphan session");
         assert!(matches!(l010.unwrap().severity, Severity::Info));
+    }
+
+    // ─── L011: wiki invocation suspects (P84 / issue #82) ───────────────────
+
+    #[test]
+    fn test_lint_l011_detects_codex_session_at_vault() {
+        let db = Database::open_memory().unwrap();
+        let (config, _tmp) = make_config_tmp();
+        let vault_str = config.vault.path.to_string_lossy().to_string();
+        db.conn()
+            .execute(
+                "INSERT INTO sessions(id, agent, start_time, ingested_at, cwd) \
+                 VALUES('wiki-codex-1','codex','2026-01-01','2026-01-01', ?1)",
+                rusqlite::params![vault_str],
+            )
+            .unwrap();
+        let report = run_lint(&db, &config).unwrap();
+        let l011: Vec<_> = report
+            .findings
+            .iter()
+            .filter(|f| f.code == "L011")
+            .collect();
+        assert_eq!(l011.len(), 1, "L011 should detect codex session at vault");
+        assert_eq!(l011[0].session_id.as_deref(), Some("wiki-codex-1"));
+        assert!(matches!(l011[0].severity, Severity::Info));
+    }
+
+    #[test]
+    fn test_lint_l011_detects_claude_session_at_vault() {
+        let db = Database::open_memory().unwrap();
+        let (config, _tmp) = make_config_tmp();
+        let vault_str = config.vault.path.to_string_lossy().to_string();
+        db.conn()
+            .execute(
+                "INSERT INTO sessions(id, agent, start_time, ingested_at, cwd) \
+                 VALUES('wiki-claude-1','claude-code','2026-01-01','2026-01-01', ?1)",
+                rusqlite::params![vault_str],
+            )
+            .unwrap();
+        let report = run_lint(&db, &config).unwrap();
+        let l011: Vec<_> = report
+            .findings
+            .iter()
+            .filter(|f| f.code == "L011")
+            .collect();
+        assert_eq!(
+            l011.len(),
+            1,
+            "L011 should detect claude-code session at vault"
+        );
+    }
+
+    #[test]
+    fn test_lint_l011_ignores_archived() {
+        let db = Database::open_memory().unwrap();
+        let (config, _tmp) = make_config_tmp();
+        let vault_str = config.vault.path.to_string_lossy().to_string();
+        db.conn()
+            .execute(
+                "INSERT INTO sessions(id, agent, start_time, ingested_at, cwd, is_archived) \
+                 VALUES('already-archived','codex','2026-01-01','2026-01-01', ?1, 1)",
+                rusqlite::params![vault_str],
+            )
+            .unwrap();
+        let report = run_lint(&db, &config).unwrap();
+        let l011: Vec<_> = report
+            .findings
+            .iter()
+            .filter(|f| f.code == "L011")
+            .collect();
+        assert!(l011.is_empty(), "L011 must skip already-archived sessions");
+    }
+
+    #[test]
+    fn test_lint_l011_ignores_cwd_outside_vault() {
+        let db = Database::open_memory().unwrap();
+        let (config, _tmp) = make_config_tmp();
+        db.conn()
+            .execute_batch(
+                "INSERT INTO sessions(id, agent, start_time, ingested_at, cwd) \
+                 VALUES('user-codex','codex','2026-01-01','2026-01-01','/Users/me/projects/foo')",
+            )
+            .unwrap();
+        let report = run_lint(&db, &config).unwrap();
+        let l011: Vec<_> = report
+            .findings
+            .iter()
+            .filter(|f| f.code == "L011")
+            .collect();
+        assert!(
+            l011.is_empty(),
+            "L011 must not flag normal codex session outside vault"
+        );
+    }
+
+    #[test]
+    fn test_lint_l011_ignores_non_codex_claude_agents() {
+        let db = Database::open_memory().unwrap();
+        let (config, _tmp) = make_config_tmp();
+        let vault_str = config.vault.path.to_string_lossy().to_string();
+        // gemini-cli session at vault path — not a wiki backend, must be ignored
+        db.conn()
+            .execute(
+                "INSERT INTO sessions(id, agent, start_time, ingested_at, cwd) \
+                 VALUES('gemini-at-vault','gemini-cli','2026-01-01','2026-01-01', ?1)",
+                rusqlite::params![vault_str],
+            )
+            .unwrap();
+        let report = run_lint(&db, &config).unwrap();
+        let l011: Vec<_> = report
+            .findings
+            .iter()
+            .filter(|f| f.code == "L011")
+            .collect();
+        assert!(
+            l011.is_empty(),
+            "L011 must only flag codex/claude-code sessions"
+        );
     }
 }

--- a/crates/secall-core/src/ingest/lint.rs
+++ b/crates/secall-core/src/ingest/lint.rs
@@ -408,14 +408,16 @@ fn check_wiki_invocations(
 ) -> Result<()> {
     let vault_str = config.vault.path.to_string_lossy().to_string();
 
+    // Gemini PR #86 리뷰: cwd 비교를 SQL 에서 직접 — DB level 필터링으로
+    // 불필요한 row 전송/순회 회피.
     let conn = db.conn();
     let mut stmt = conn.prepare(
         "SELECT id, cwd, agent FROM sessions \
          WHERE is_archived = 0 \
-           AND cwd IS NOT NULL \
+           AND cwd = ?1 \
            AND agent IN ('codex', 'claude-code')",
     )?;
-    let rows = stmt.query_map([], |r| {
+    let rows = stmt.query_map([&vault_str], |r| {
         Ok((
             r.get::<_, String>(0)?,
             r.get::<_, String>(1)?,
@@ -424,17 +426,15 @@ fn check_wiki_invocations(
     })?;
     for row in rows {
         let (id, cwd, agent) = row?;
-        if cwd == vault_str {
-            findings.push(LintFinding {
-                code: "L011".to_string(),
-                severity: Severity::Info,
-                message: format!(
-                    "{agent} session at vault path (likely wiki self-invocation): cwd={cwd}"
-                ),
-                session_id: Some(id),
-                path: None,
-            });
-        }
+        findings.push(LintFinding {
+            code: "L011".to_string(),
+            severity: Severity::Info,
+            message: format!(
+                "{agent} session at vault path (likely wiki self-invocation): cwd={cwd}"
+            ),
+            session_id: Some(id),
+            path: None,
+        });
     }
     Ok(())
 }

--- a/crates/secall/src/commands/lint.rs
+++ b/crates/secall/src/commands/lint.rs
@@ -5,7 +5,13 @@ use secall_core::{
     vault::Config,
 };
 
-pub fn run(json: bool, errors_only: bool, fix: bool, fix_orphan_vault: bool) -> Result<()> {
+pub fn run(
+    json: bool,
+    errors_only: bool,
+    fix: bool,
+    fix_orphan_vault: bool,
+    fix_wiki_invocations: bool,
+) -> Result<()> {
     let config = Config::load_or_default();
     let db_path = get_default_db_path();
     let db = Database::open(&db_path)?;
@@ -19,6 +25,9 @@ pub fn run(json: bool, errors_only: bool, fix: bool, fix_orphan_vault: bool) -> 
         }
         if fix_orphan_vault {
             run_fix_orphan_vault(&config, &report)?;
+        }
+        if fix_wiki_invocations {
+            run_fix_wiki_invocations(&db, &config, &report)?;
         }
         return Ok(());
     }
@@ -74,6 +83,13 @@ pub fn run(json: bool, errors_only: bool, fix: bool, fix_orphan_vault: bool) -> 
         run_fix_orphan_vault(&config, &report)?;
     }
 
+    // P84 (issue #82) --fix-wiki-invocations: L011 (codex/claude wiki invocation
+    // 의심 세션 — cwd 가 vault path) 을 archived 로 마킹. P83 머지 전 ingest 된
+    // legacy 데이터의 self-ingest 잔재 정리.
+    if fix_wiki_invocations {
+        run_fix_wiki_invocations(&db, &config, &report)?;
+    }
+
     // Exit with code 1 if there are errors (after fix, re-count).
     // Gemini PR #63: fix_orphan_vault 만 사용 시 L002(Warn) 처리라
     // errors 카운트에 영향 없음 → 불필요한 rerun 회피.
@@ -88,6 +104,55 @@ pub fn run(json: bool, errors_only: bool, fix: bool, fix_orphan_vault: bool) -> 
         std::process::exit(1);
     }
 
+    Ok(())
+}
+
+/// P84 (issue #82): L011 finding 의 wiki invocation 의심 세션을 archive 로 마킹.
+///
+/// archive (DB `is_archived = 1`) 만 — vault md 파일은 그대로 둠. 사용자가 의도치
+/// 않게 archive 된 경우 `secall unarchive <id>` 또는 web UI 로 복원 가능.
+fn run_fix_wiki_invocations(
+    db: &Database,
+    config: &Config,
+    report: &secall_core::ingest::lint::LintReport,
+) -> Result<()> {
+    let suspects: Vec<&str> = report
+        .findings
+        .iter()
+        .filter(|f| f.code == "L011" && f.session_id.is_some())
+        .filter_map(|f| f.session_id.as_deref())
+        .collect();
+
+    if suspects.is_empty() {
+        eprintln!("[fix-wiki-invocations] No wiki invocation suspects.");
+        return Ok(());
+    }
+
+    let vault = secall_core::vault::Vault::new(config.vault.path.clone());
+    let tz = config.timezone();
+
+    eprintln!(
+        "[fix-wiki-invocations] Archiving {} wiki invocation session(s)...",
+        suspects.len()
+    );
+    let mut archived = 0usize;
+    let mut failed = 0usize;
+    for session_id in &suspects {
+        match db.archive_session(session_id, &vault, tz) {
+            Ok(()) => {
+                eprintln!("  archived {}", &session_id[..session_id.len().min(8)]);
+                archived += 1;
+            }
+            Err(e) => {
+                eprintln!(
+                    "  failed to archive {}: {e}",
+                    &session_id[..session_id.len().min(8)]
+                );
+                failed += 1;
+            }
+        }
+    }
+    eprintln!("[fix-wiki-invocations] Done. {archived} archived, {failed} failed.");
     Ok(())
 }
 

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -169,6 +169,12 @@ enum Commands {
         /// Auto-fix orphan vault files (L002) — move vault md to archive if not in DB
         #[arg(long)]
         fix_orphan_vault: bool,
+
+        /// P84 (issue #82): Auto-archive wiki invocation sessions (L011) — codex/claude
+        /// sessions whose cwd matches the vault path are wiki self-invocations, archived
+        /// to prevent self-ingest loops in legacy data (pre-P83 ingest).
+        #[arg(long)]
+        fix_wiki_invocations: bool,
     },
 
     /// Start MCP server
@@ -552,8 +558,15 @@ async fn main() -> anyhow::Result<()> {
             errors_only,
             fix,
             fix_orphan_vault,
+            fix_wiki_invocations,
         } => {
-            commands::lint::run(json, errors_only, fix, fix_orphan_vault)?;
+            commands::lint::run(
+                json,
+                errors_only,
+                fix,
+                fix_orphan_vault,
+                fix_wiki_invocations,
+            )?;
         }
         Commands::Mcp { http } => {
             commands::mcp::run(http).await?;

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -142,3 +142,11 @@ Plan document index. Register new plans here.
 - [전체 계획서](p83-wiki-self-ingest-loop.md) — in_progress, 2026-05-19
 - 단일 Task: `wiki/{codex,claude}.rs` 의 generate() 가 prompt 앞에 `WIKI_INVOCATION_MARKER` prefix → `is_noise_session()` 이 marker 검출 시 skip → wiki 호출이 생성한 codex/claude 세션의 self-ingest 루프 차단.
 - 관련: issue #82 (dicebattle).
+
+---
+
+### seCall P84 — `lint --fix-wiki-invocations` (P83 fast-follow)
+
+- [전체 계획서](p84-lint-fix-wiki-invocations.md) — in_progress, 2026-05-19
+- 단일 Task: `check_wiki_invocations()` (L011 신규) — cwd 가 vault path 인 codex/claude 세션 검출 + `secall lint --fix-wiki-invocations` 옵션으로 일괄 archive. P83 marker 가 없는 legacy 데이터 사후 정리.
+- 관련: issue #82 fast-follow.

--- a/docs/plans/p84-lint-fix-wiki-invocations.md
+++ b/docs/plans/p84-lint-fix-wiki-invocations.md
@@ -1,0 +1,83 @@
+---
+type: plan
+status: in_progress
+updated_at: 2026-05-19
+canonical: true
+---
+
+# P84 — `secall lint --fix-wiki-invocations` (P83 fast-follow)
+
+## 배경
+
+P83 (#85) 머지로 신규 codex/claude wiki invocation 세션은 `is_noise_session()` 의 marker 검사로 차단되지만, **머지 전에 이미 ingest 된** 세션에는 marker 가 없어 자동 정리가 안 된다. dicebattle (issue #82) 등 사용자가 수동으로 `secall archive` 또는 `~/.codex/sessions/` 파일 삭제로 정리해야 하는 부담.
+
+P83 PR 의 "Out of scope" 에서 fast-follow PR 로 분리 명시.
+
+## 목표
+
+- 사용자가 `secall lint --fix-wiki-invocations` 한 번 실행해 legacy wiki invocation 세션을 일괄 archive.
+- archive 는 reversible (`secall unarchive`) 이라 false positive 시에도 복구 가능.
+
+## 비목표
+
+- 새 ingest 동작 변경 없음 (P83 marker 검사가 이미 처리).
+- 자동 sync --force 등 사용자 모르게 동작 안 함 — 명시적 명령으로만.
+
+## 검출 룰 (L011 신규)
+
+```
+SELECT id, cwd, agent FROM sessions
+WHERE is_archived = 0
+  AND cwd IS NOT NULL
+  AND agent IN ('codex', 'claude-code')
+```
+→ `cwd == config.vault.path` 인 경우 L011 finding (Severity: Info).
+
+근거: `wiki/codex.rs` + `wiki/claude.rs` 가 subprocess 를 `cwd = vault_path` 으로 spawn. 따라서 wiki 호출이 만든 세션의 cwd 는 정확히 vault path. 사용자가 vault 디렉토리 자체에서 일반 작업할 확률은 매우 낮음 (vault 는 wiki 저장소).
+
+## 사용 흐름
+
+```bash
+# 1. 검사 (자동 fix 없이)
+secall lint
+# → L011 [INFO] codex session at vault path (likely wiki self-invocation): cwd=/Users/me/Documents/Obsidian Vault/seCall
+# → L011 [INFO] claude-code session at vault path ...
+
+# 2. 자동 archive
+secall lint --fix-wiki-invocations
+# → [fix-wiki-invocations] Archiving 12 wiki invocation session(s)...
+# →   archived a1b2c3d4
+# →   ...
+# → [fix-wiki-invocations] Done. 12 archived, 0 failed.
+
+# 3. (의도와 다르면 개별 복원)
+secall unarchive <session-id>
+```
+
+## 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `crates/secall-core/src/ingest/lint.rs` | `check_wiki_invocations()` 함수 추가, `run_lint` 에 호출, 신규 unit test 5건 |
+| `crates/secall/src/commands/lint.rs` | `run_fix_wiki_invocations()` 함수 추가, `run()` 시그니처에 `fix_wiki_invocations: bool` |
+| `crates/secall/src/main.rs` | clap arg `--fix-wiki-invocations` + 호출 사이트 갱신 |
+| `docs/plans/index.md` | P84 등록 |
+
+## 검증
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test -p secall-core --lib ingest::lint::tests
+cargo test --workspace --no-fail-fast
+```
+
+## 리스크
+
+- **False positive**: 사용자가 vault 디렉토리에서 codex/claude 일반 작업한 경우 archive 됨. 대응: `secall unarchive` 로 복구. 게다가 vault 는 일반적으로 wiki 저장소라 직접 작업 빈도 낮음.
+- **agent 이름 정확성**: SQL 의 `IN ('codex', 'claude-code')` 가 `AgentKind::as_str()` 값과 일치해야 함. 신규 test 가 검증.
+
+## 후속
+
+- core-backlog 에 fast-follow 완료 표기 (PR 머지 후).
+- 이슈 #82 에 P84 머지 안내 comment 추가 — 사용자가 명령 실행해 정리할 수 있도록 가이드.


### PR DESCRIPTION
## Summary
P83 (#85) fast-follow. 머지 전에 이미 ingest 된 wiki invocation 세션을 사용자가 한 번 실행해 일괄 archive 할 수 있는 lint 옵션 추가.

- `ingest/lint.rs`: `check_wiki_invocations()` 함수 추가 — L011 신규. cwd 가 `[vault].path` 와 일치하는 codex/claude 세션을 Info 레벨로 finding.
- `commands/lint.rs`: `--fix-wiki-invocations` flag 처리하는 `run_fix_wiki_invocations()` — `SessionRepo::archive_session` 호출.
- `main.rs`: clap arg + call site 갱신.
- 신규 unit test 5건.

## Why
P83 marker 는 신규 ingest 만 보호. 기존 세션은 marker 가 없어 자동 정리 안 됨. dicebattle (issue #82) 등 사용자가 수동으로 `secall archive` 또는 파일 삭제로 정리해야 하는 부담 해소.

## Usage
\`\`\`bash
# 1. 검사 (자동 fix 없이)
secall lint
# → L011 [INFO] codex session at vault path (likely wiki self-invocation): cwd=/Users/me/Documents/Obsidian Vault/seCall

# 2. 자동 archive
secall lint --fix-wiki-invocations
# → [fix-wiki-invocations] Archiving 12 wiki invocation session(s)...

# 3. 의도와 다르면 개별 복원 (reversible)
secall unarchive <session-id>
\`\`\`

## Detection rule (L011)
\`\`\`sql
SELECT id, cwd, agent FROM sessions
WHERE is_archived = 0
  AND cwd IS NOT NULL
  AND agent IN ('codex', 'claude-code')
\`\`\`
→ \`cwd == config.vault.path\` 인 경우 L011 finding.

근거: \`wiki/{codex,claude}.rs\` 가 subprocess 를 \`cwd = vault_path\` 으로 spawn. wiki 호출이 만든 세션의 cwd 는 정확히 vault path.

## Risks
- **False positive**: 사용자가 vault 디렉토리에서 codex/claude 일반 작업한 경우 archive 됨. 대응: \`secall unarchive\` 로 복구. 게다가 vault 는 일반적으로 wiki 저장소라 직접 작업 빈도 낮음.

## Test plan
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p secall-core --lib ingest::lint\` 18 passed (신규 L011 5건 포함)
- [x] \`cargo test --workspace --no-fail-fast\` all green (lib 426 + integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)