### PR TITLE
fix(wiki): P86 — ollama/lmstudio 백엔드 + wiki update fail-fast (#88)

### DIFF
--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -190,6 +190,27 @@ async fn run_update_with_sink(
         .unwrap_or_else(|| config.wiki.default_backend.clone());
     let resolved_model = resolve_backend_model(&config, &backend_name, model);
 
+    // P86 (issue #88): ollama / lmstudio 백엔드는 wiki update 의 prompt 가
+    // 가정하는 MCP 도구 호출 (`secall recall/get/status` + `wiki/` 파일 쓰기) 을
+    // 수행할 능력이 없다. batch / incremental / --since 모든 모드에서 모델이
+    // "임무 이해" 응답만 출력하고 종료 → 사용자가 silent wait (timeout 까지)
+    // 후 빈손으로 깨닫는 사고. 명시적 fail-fast + 가이드.
+    if matches!(backend_name.as_str(), "ollama" | "lmstudio") {
+        anyhow::bail!(
+            "wiki backend `{backend_name}` 는 wiki update 와 호환되지 않습니다.\n\
+             도구 호출 (`secall recall`/`get`/`status` + `wiki/` 파일 쓰기) 능력이 없어\n\
+             prompt 가 가정하는 작업을 수행할 수 없습니다.\n\
+             \n\
+             해결책 (편한 것 사용):\n\
+               • `--backend claude`  (Claude Code CLI + MCP 통합)\n\
+               • `--backend codex`   (Codex CLI)\n\
+               • `--backend haiku`   (Anthropic API, 세션 데이터를 prompt 에 inline,\n\
+                                      `ANTHROPIC_API_KEY` 필요)\n\
+             \n\
+             참고: issue #88, docs/plans/p86-ollama-batch-fail-fast.md"
+        );
+    }
+
     // 2. Load prompt — haiku 백엔드는 세션 데이터를 직접 주입
     let prompt = if backend_name == "haiku" {
         build_haiku_prompt(&config, &wiki_dir, session, since)?

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -150,3 +150,11 @@ Plan document index. Register new plans here.
 - [전체 계획서](p84-lint-fix-wiki-invocations.md) — in_progress, 2026-05-19
 - 단일 Task: `check_wiki_invocations()` (L011 신규) — cwd 가 vault path 인 codex/claude 세션 검출 + `secall lint --fix-wiki-invocations` 옵션으로 일괄 archive. P83 marker 가 없는 legacy 데이터 사후 정리.
 - 관련: issue #82 fast-follow.
+
+---
+
+### seCall P86 — Wiki update + ollama/lmstudio 백엔드 fail-fast (issue #88)
+
+- [전체 계획서](p86-ollama-batch-fail-fast.md) — in_progress, 2026-05-19
+- 단일 Task: `commands/wiki.rs` 의 backend 선택 직후 ollama/lmstudio 차단 + 가이드 메시지. silent 30분 wait 사고 차단.
+- 관련: issue #88 (cakel).

--- a/docs/plans/p86-ollama-batch-fail-fast.md
+++ b/docs/plans/p86-ollama-batch-fail-fast.md
@@ -1,0 +1,84 @@
+---
+type: plan
+status: in_progress
+updated_at: 2026-05-19
+canonical: true
+---
+
+# P86 — Wiki update + ollama/lmstudio 백엔드 fail-fast
+
+## 배경
+
+Issue #88 (cakel, 2026-05-19) 보고:
+
+> ollama (gemma4:26b) 에서 wiki update 시, 준비만하고 실제 업데이트가 안됨
+> ... 알겠습니다. 저는 지금부터 seCall 위키 관리 에이전트로서 임무를 수행합니다.
+> ... 작업을 시작할 준비가 되었습니다.
+
+진단 결과:
+- `docs/prompts/wiki-update.md` (batch) + `wiki-incremental.md` (incremental) 둘 다 **MCP 도구 호출** (`secall recall`, `secall get`, `secall status`) + **`wiki/` 디렉토리 파일 쓰기** 를 가정.
+- Claude Code CLI = MCP 통합 / Codex CLI = 도구 호출 가능 / Haiku = 세션 데이터를 prompt 에 직접 inline (도구 불필요)
+- **ollama / lmstudio = HTTP API 단순 text generation, 도구 호출 능력 없음**
+- → ollama/lmstudio 백엔드는 prompt 받아서 "임무 이해, 시작 준비됨" 답하고 종료. 실제 작업 수행 안 됨
+
+기존 코드는 silent 하게 1800s timeout 까지 또는 모델이 stop token 보낼 때까지 wait → 사용자가 빈손으로 깨닫는 사고.
+
+## 목표
+
+- ollama/lmstudio 백엔드 + `wiki update` 모든 모드 조합 사용 시 **즉시 명시적 에러** + 사용 가능한 백엔드 가이드.
+- 사용자가 30분 silent wait 후 빈손으로 깨닫는 일 차단.
+
+## 비목표
+
+- ollama/lmstudio 의 wiki update 지원 자체 추가는 별도 PR. 향후 haiku 같은 데이터-inline batch 방식으로 확장 가능 (큰 작업).
+- 백엔드의 다른 사용 (graph, log 등) 동작 변경 없음.
+
+## 구현
+
+### `crates/secall/src/commands/wiki.rs`
+
+backend selection (line 188~191) 다음, prompt build 직전에 가드:
+
+```rust
+if matches!(backend_name.as_str(), "ollama" | "lmstudio") {
+    anyhow::bail!(
+        "wiki backend `{backend_name}` 는 wiki update 와 호환되지 않습니다.\n\
+         도구 호출 (`secall recall`/`get`/`status` + `wiki/` 파일 쓰기) 능력이 없어\n\
+         prompt 가 가정하는 작업을 수행할 수 없습니다.\n\
+         \n\
+         해결책:\n\
+           • `--backend claude` ...\n\
+           • `--backend codex` ...\n\
+           • `--backend haiku` ...\n\
+         \n\
+         참고: issue #88, docs/plans/p86-ollama-batch-fail-fast.md"
+    );
+}
+```
+
+## 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `crates/secall/src/commands/wiki.rs` | backend gate + 에러 메시지 |
+| `docs/plans/p86-ollama-batch-fail-fast.md` (신규) | 본 plan |
+| `docs/plans/index.md` | P86 등록 |
+
+## 검증
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --no-fail-fast
+# 수동 검증: secall wiki update --backend ollama → 즉시 명시적 에러 출력
+```
+
+테스트 추가 옵션:
+- `commands::wiki` 가 binary crate 라 unit test 작성이 까다로움.
+- integration test 는 SQL/vault 등 fixture 가 많아 비용 큼.
+- 본 PR 은 가드 메시지가 정확한 contract — 코드 변경 작아 manual smoke 로 충분.
+
+## 리스크
+
+- false positive 없음 — ollama/lmstudio 가 wiki update 에 동작했던 적 없음.
+- 향후 ollama 데이터-inline 지원 추가 시 이 가드 수정 필요. plan 에 명시.


### PR DESCRIPTION
## Summary
Issue #88 (cakel): ollama 백엔드로 wiki update 실행 시 모델이 "임무 이해, 시작 준비됨" 응답만 출력하고 종료. 실제 wiki 생성 안 됨.

원인: `docs/prompts/wiki-update.md` + `wiki-incremental.md` 둘 다 **MCP 도구 호출** (`secall recall`/`get`/`status` + `wiki/` 파일 쓰기) 을 가정. ollama/lmstudio 는 HTTP API 단순 text generation 으로 도구 호출 능력 없음 — 모든 모드 (batch / incremental / --since) 에서 실패.

Fix: `commands/wiki.rs` 의 backend 선택 직후 ollama/lmstudio 차단 + 명시적 에러 + 사용 가능한 백엔드 가이드.

## 백엔드 호환성 매트릭스

| Backend | 도구 호출 능력 | wiki update 동작 |
|---|---|---|
| claude (CLI) | ✅ MCP 통합 | ✅ |
| codex (CLI) | ✅ 도구 | ✅ |
| haiku (API) | — (세션 데이터를 prompt 에 inline) | ✅ |
| **ollama** | ❌ 단순 text generation | ❌ (silent fail) |
| **lmstudio** | ❌ 동일 | ❌ (silent fail) |

## Error message
```
wiki backend `ollama` 는 wiki update 와 호환되지 않습니다.
도구 호출 (`secall recall`/`get`/`status` + `wiki/` 파일 쓰기) 능력이 없어
prompt 가 가정하는 작업을 수행할 수 없습니다.

해결책 (편한 것 사용):
  • `--backend claude`  (Claude Code CLI + MCP 통합)
  • `--backend codex`   (Codex CLI)
  • `--backend haiku`   (Anthropic API, 세션 데이터를 prompt 에 inline,
                         `ANTHROPIC_API_KEY` 필요)

참고: issue #88, docs/plans/p86-ollama-batch-fail-fast.md
```

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --no-fail-fast` all green
- [ ] Manual smoke: `secall wiki update --backend ollama` → 즉시 명시적 에러 출력 (다음 release 빌드 후 확인)

## Out of scope
ollama/lmstudio 의 wiki update 지원 자체 추가는 별도 PR. 향후 haiku 같은 데이터-inline batch 방식으로 확장 가능 (큰 작업).

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)