### PR TITLE
feat(wiki,config): P85 — `[wiki].generation_timeout_secs` config option (#87)

### DIFF
--- a/crates/secall-core/src/vault/config.rs
+++ b/crates/secall-core/src/vault/config.rs
@@ -153,10 +153,20 @@ pub struct WikiConfig {
     /// --review 시 사용할 모델: "sonnet" | "opus" (기본: sonnet)
     #[serde(default)]
     pub review_model: Option<String>,
+    /// P85 (issue #87): wiki generation backend timeout in seconds.
+    /// claude/codex/ollama/lmstudio backend 의 generate() 가 사용한다.
+    /// 기본값 1800 (30분) — P59 에서 5분 → 30분 상향한 hardcoded 값과 동일.
+    /// 수만 세션 vault 또는 느린 모델 사용 시 사용자가 더 큰 값으로 override 가능.
+    #[serde(default = "default_wiki_generation_timeout_secs")]
+    pub generation_timeout_secs: u64,
 }
 
 fn default_wiki_backend() -> String {
     "claude".to_string()
+}
+
+fn default_wiki_generation_timeout_secs() -> u64 {
+    1800
 }
 
 impl Default for WikiConfig {
@@ -166,6 +176,7 @@ impl Default for WikiConfig {
             backends: std::collections::HashMap::new(),
             review_backend: None,
             review_model: None,
+            generation_timeout_secs: default_wiki_generation_timeout_secs(),
         }
     }
 }

--- a/crates/secall-core/src/vault/config.rs
+++ b/crates/secall-core/src/vault/config.rs
@@ -165,8 +165,12 @@ fn default_wiki_backend() -> String {
     "claude".to_string()
 }
 
+/// Gemini PR #90 리뷰: compile-time const 로 정의하여 명확성/유지보수성 향상.
+/// serde default 속성용 함수도 같은 const 를 반환한다 (단일 source of truth).
+const DEFAULT_WIKI_GENERATION_TIMEOUT_SECS: u64 = 1800;
+
 fn default_wiki_generation_timeout_secs() -> u64 {
-    1800
+    DEFAULT_WIKI_GENERATION_TIMEOUT_SECS
 }
 
 impl Default for WikiConfig {
@@ -176,7 +180,7 @@ impl Default for WikiConfig {
             backends: std::collections::HashMap::new(),
             review_backend: None,
             review_model: None,
-            generation_timeout_secs: default_wiki_generation_timeout_secs(),
+            generation_timeout_secs: DEFAULT_WIKI_GENERATION_TIMEOUT_SECS,
         }
     }
 }

--- a/crates/secall-core/src/wiki/claude.rs
+++ b/crates/secall-core/src/wiki/claude.rs
@@ -9,6 +9,8 @@ use super::WikiBackend;
 pub struct ClaudeBackend {
     pub model: String,
     pub vault_path: PathBuf,
+    /// P85 (issue #87): config.wiki.generation_timeout_secs.
+    pub timeout_secs: u64,
 }
 
 #[async_trait]
@@ -93,10 +95,17 @@ impl WikiBackend for ClaudeBackend {
             Ok::<_, anyhow::Error>((status, buf))
         };
 
-        let (status, buffer) =
-            tokio::time::timeout(std::time::Duration::from_secs(1800), stream_and_wait)
-                .await
-                .map_err(|_| anyhow::anyhow!("claude wiki generation timed out after 1800s"))??;
+        let (status, buffer) = tokio::time::timeout(
+            std::time::Duration::from_secs(self.timeout_secs),
+            stream_and_wait,
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "claude wiki generation timed out after {}s",
+                self.timeout_secs
+            )
+        })??;
 
         if !status.success() {
             anyhow::bail!("claude exited with code {:?}", status.code());

--- a/crates/secall-core/src/wiki/codex.rs
+++ b/crates/secall-core/src/wiki/codex.rs
@@ -9,6 +9,8 @@ use super::WikiBackend;
 pub struct CodexBackend {
     pub model: String,
     pub vault_path: PathBuf,
+    /// P85 (issue #87): config.wiki.generation_timeout_secs.
+    pub timeout_secs: u64,
 }
 
 #[async_trait]
@@ -54,9 +56,17 @@ impl WikiBackend for CodexBackend {
 
         // P52/P59: codex CLI hang 회피. 1800s 한도 (정상 wiki 생성도 10~20분
         // 걸리는 경우가 있어 P59 에서 5분 → 30분 상향). kill_on_drop=true.
-        let status = tokio::time::timeout(std::time::Duration::from_secs(1800), child.wait())
-            .await
-            .map_err(|_| anyhow::anyhow!("codex wiki generation timed out after 1800s"))??;
+        let status = tokio::time::timeout(
+            std::time::Duration::from_secs(self.timeout_secs),
+            child.wait(),
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "codex wiki generation timed out after {}s",
+                self.timeout_secs
+            )
+        })??;
         if !status.success() {
             anyhow::bail!("codex exited with code {:?}", status.code());
         }

--- a/crates/secall-core/src/wiki/lmstudio.rs
+++ b/crates/secall-core/src/wiki/lmstudio.rs
@@ -7,6 +7,8 @@ pub struct LmStudioBackend {
     pub api_url: String,
     pub model: String,
     pub max_tokens: u32,
+    /// P85 (issue #87): config.wiki.generation_timeout_secs.
+    pub timeout_secs: u64,
 }
 
 #[async_trait]
@@ -20,7 +22,7 @@ impl WikiBackend for LmStudioBackend {
         // 한도 (P59 에서 5분 → 30분 상향).
         // P60: stream=true (OpenAI-compatible SSE) 로 전환. delta.content 누적.
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(1800))
+            .timeout(std::time::Duration::from_secs(self.timeout_secs))
             .build()?;
         let resp = client
             .post(format!("{}/v1/chat/completions", self.api_url))
@@ -143,6 +145,7 @@ mod tests {
             api_url: server.url(),
             model: "qwen3-coder-32b".to_string(),
             max_tokens: 4096,
+            timeout_secs: 60,
         };
 
         let result = backend.generate("test prompt").await;
@@ -169,6 +172,7 @@ mod tests {
             api_url: server.url(),
             model: "qwen3-coder-32b".to_string(),
             max_tokens: 4096,
+            timeout_secs: 60,
         };
 
         let result = backend.generate("test prompt").await;
@@ -199,6 +203,7 @@ mod tests {
             api_url: server.url(),
             model: "qwen3-coder-32b".to_string(),
             max_tokens: 4096,
+            timeout_secs: 60,
         };
 
         let result = backend.generate("test prompt").await.unwrap();

--- a/crates/secall-core/src/wiki/ollama.rs
+++ b/crates/secall-core/src/wiki/ollama.rs
@@ -8,6 +8,8 @@ pub struct OllamaBackend {
     pub model: String,
     pub max_tokens: u32,
     pub api_key: Option<String>,
+    /// P85 (issue #87): config.wiki.generation_timeout_secs.
+    pub timeout_secs: u64,
 }
 
 #[async_trait]
@@ -23,7 +25,7 @@ impl WikiBackend for OllamaBackend {
         // claude.rs 의 line-stream 과 동일 톤으로 stderr 에 `[ollama] ...` echo
         // 하여 사용자가 진행 상황을 본다.
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(1800))
+            .timeout(std::time::Duration::from_secs(self.timeout_secs))
             .build()?;
         let mut req =
             client
@@ -168,6 +170,7 @@ mod tests {
             model: "gemma4:31b-cloud".to_string(),
             max_tokens: 4096,
             api_key: Some("cloud-key".to_string()),
+            timeout_secs: 60,
         };
 
         let result = backend.generate("test prompt").await;
@@ -196,6 +199,7 @@ mod tests {
             model: "local-model".to_string(),
             max_tokens: 4096,
             api_key: None,
+            timeout_secs: 60,
         };
 
         let result = backend.generate("test prompt").await;
@@ -222,6 +226,7 @@ mod tests {
             model: "gemma4:31b-cloud".to_string(),
             max_tokens: 4096,
             api_key: Some("bad-key".to_string()),
+            timeout_secs: 60,
         };
 
         let result = backend.generate("test prompt").await;
@@ -253,6 +258,7 @@ mod tests {
             model: "local-model".to_string(),
             max_tokens: 4096,
             api_key: None,
+            timeout_secs: 60,
         };
 
         let result = backend.generate("test prompt").await.unwrap();

--- a/crates/secall-core/tests/sync_termination.rs
+++ b/crates/secall-core/tests/sync_termination.rs
@@ -49,6 +49,7 @@ async fn test_claude_backend_fails_fast_when_not_found() {
     let backend = ClaudeBackend {
         model: "sonnet".to_string(),
         vault_path: std::env::temp_dir(),
+        timeout_secs: 10,
     };
 
     let result = tokio::time::timeout(Duration::from_secs(5), backend.generate("test")).await;
@@ -76,6 +77,7 @@ async fn test_codex_backend_fails_fast_when_not_found() {
     let backend = CodexBackend {
         model: "gpt-5.4".to_string(),
         vault_path: std::env::temp_dir(),
+        timeout_secs: 10,
     };
 
     let result = tokio::time::timeout(Duration::from_secs(5), backend.generate("test")).await;

--- a/crates/secall/src/commands/log.rs
+++ b/crates/secall/src/commands/log.rs
@@ -276,6 +276,7 @@ pub async fn generate_log_body(
             let backend = ClaudeBackend {
                 model,
                 vault_path: config.vault.path.clone(),
+                timeout_secs: config.wiki.generation_timeout_secs,
             };
             backend
                 .generate(&build_backend_prompt(system_prompt, user_prompt))
@@ -289,6 +290,7 @@ pub async fn generate_log_body(
             let backend = CodexBackend {
                 model,
                 vault_path: config.vault.path.clone(),
+                timeout_secs: config.wiki.generation_timeout_secs,
             };
             backend
                 .generate(&build_backend_prompt(system_prompt, user_prompt))
@@ -310,6 +312,7 @@ pub async fn generate_log_body(
                 model: resolved_model.unwrap_or_else(|| LOG_OLLAMA_DEFAULT.to_string()),
                 max_tokens: resolve_log_max_tokens(config),
                 api_key: None,
+                timeout_secs: config.wiki.generation_timeout_secs,
             };
             backend
                 .generate(&build_backend_prompt(system_prompt, user_prompt))
@@ -337,6 +340,7 @@ pub async fn generate_log_body(
                 model,
                 max_tokens: resolve_log_max_tokens(config),
                 api_key: Some(api_key),
+                timeout_secs: config.wiki.generation_timeout_secs,
             };
             backend
                 .generate(&build_backend_prompt(system_prompt, user_prompt))
@@ -352,6 +356,7 @@ pub async fn generate_log_body(
                     GRAPH_LMSTUDIO_DEFAULT.to_string()
                 }),
                 max_tokens: resolve_log_max_tokens(config),
+                timeout_secs: config.wiki.generation_timeout_secs,
             };
             backend
                 .generate(&build_backend_prompt(system_prompt, user_prompt))

--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -651,6 +651,7 @@ fn build_wiki_backend(
                 model: cfg.model.unwrap_or_else(|| "llama3".to_string()),
                 max_tokens: cfg.max_tokens,
                 api_key: None,
+                timeout_secs: config.wiki.generation_timeout_secs,
             }))
         }
         // P55 Gemini #64: build_reviewer 와 일관되게 ollama_cloud 도 지원.
@@ -682,6 +683,7 @@ fn build_wiki_backend(
                 }),
                 max_tokens: cfg.max_tokens,
                 api_key: Some(api_key),
+                timeout_secs: config.wiki.generation_timeout_secs,
             }))
         }
         "lmstudio" => {
@@ -692,15 +694,18 @@ fn build_wiki_backend(
                     .unwrap_or_else(|| "http://localhost:1234".to_string()),
                 model: cfg.model.unwrap_or_else(|| "local-model".to_string()),
                 max_tokens: cfg.max_tokens,
+                timeout_secs: config.wiki.generation_timeout_secs,
             }))
         }
         "codex" => Ok(Box::new(secall_core::wiki::CodexBackend {
             model: resolved_model.to_string(),
             vault_path: config.vault.path.clone(),
+            timeout_secs: config.wiki.generation_timeout_secs,
         })),
         "claude" => Ok(Box::new(secall_core::wiki::ClaudeBackend {
             model: resolved_model.to_string(),
             vault_path: config.vault.path.clone(),
+            timeout_secs: config.wiki.generation_timeout_secs,
         })),
         _ => anyhow::bail!(
             "Unknown backend '{}'. Supported: claude, codex, haiku, ollama, ollama_cloud, lmstudio",

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -153,6 +153,14 @@ Plan document index. Register new plans here.
 
 ---
 
+### seCall P85 — Wiki generation timeout config option (issue #87)
+
+- [전체 계획서](p85-wiki-timeout-config.md) — in_progress, 2026-05-19
+- 단일 Task: `[wiki].generation_timeout_secs` config (default 1800) — claude/codex/ollama/lmstudio backend 의 hardcoded 1800s 를 사용자 override 가능하게 함.
+- 관련: issue #87 (cakel).
+
+---
+
 ### seCall P86 — Wiki update + ollama/lmstudio 백엔드 fail-fast (issue #88)
 
 - [전체 계획서](p86-ollama-batch-fail-fast.md) — in_progress, 2026-05-19

--- a/docs/plans/p85-wiki-timeout-config.md
+++ b/docs/plans/p85-wiki-timeout-config.md
@@ -1,0 +1,75 @@
+---
+type: plan
+status: in_progress
+updated_at: 2026-05-19
+canonical: true
+---
+
+# P85 — Wiki generation timeout config option (issue #87)
+
+## 배경
+
+Issue #87 (cakel, 2026-05-19): `claude wiki generation timed out after 300s`. cakel 환경에서 wiki update 가 timeout. 사용자 요청: option 으로 변경 가능 여부.
+
+진단 결과:
+- 현재 main 의 모든 long-generation wiki backend (claude/codex/ollama/lmstudio) timeout 은 **P59 (#69, 2026-05-15)** 에서 1800s 로 상향됨. 300s 에러는 cakel 이 P59 이전 버전 사용 의심 → release 진행 (별도) 으로 fix 가능.
+- 단 1800s 도 부족한 케이스 (수만 세션 vault 또는 느린 모델) 가 있을 수 있어, **사용자가 config 로 override** 할 수 있는 옵션 추가가 정당함.
+
+## 목표
+
+- `config.toml` 의 `[wiki].generation_timeout_secs` 로 long-generation backend timeout 조정 가능.
+- default 1800 (기존 hardcoded 값 유지) → backward-compat.
+- 사용자 설정: `[wiki] generation_timeout_secs = 3600` 같이 30분 → 1시간 변경 가능.
+
+## 비목표
+
+- haiku (Anthropic API HTTP 120s) + reviewers (60~120s) 의 timeout 은 별도 — 단일 API call timeout 이라 long generation 과 다름.
+- log/graph backend 의 timeout 도 별개 영역. 단 log 가 wiki backend struct 를 reuse 하므로 동일 값 적용 (자연스러움).
+
+## 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `crates/secall-core/src/vault/config.rs` | `WikiConfig` 에 `generation_timeout_secs: u64` (default 1800) 추가 |
+| `crates/secall-core/src/wiki/claude.rs` | `ClaudeBackend` 에 `timeout_secs` 필드 + `generate()` 가 self.timeout_secs 사용 |
+| `crates/secall-core/src/wiki/codex.rs` | 동일 |
+| `crates/secall-core/src/wiki/ollama.rs` | 동일 (test 3건 갱신 포함) |
+| `crates/secall-core/src/wiki/lmstudio.rs` | 동일 (test 3건 갱신 포함) |
+| `crates/secall-core/tests/sync_termination.rs` | ClaudeBackend / CodexBackend literal 갱신 |
+| `crates/secall/src/commands/wiki.rs` | `build_wiki_backend()` 가 `config.wiki.generation_timeout_secs` 전달 (5 instantiation) |
+| `crates/secall/src/commands/log.rs` | log command 가 backend 생성 시 동일 값 전달 (5 instantiation) |
+| `docs/plans/p85-wiki-timeout-config.md` (신규) | 본 plan |
+| `docs/plans/index.md` | P85 등록 |
+
+## 사용 예시
+
+```toml
+# ~/Library/Application Support/secall/config.toml
+[wiki]
+generation_timeout_secs = 3600  # 30분 → 1시간
+```
+
+```
+$ secall wiki update --backend claude
+...
+# (수만 세션 분석 후 1시간 한도 안에서 정상 완료)
+```
+
+## 검증
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test -p secall-core --lib wiki::config
+cargo test --workspace --no-fail-fast
+```
+
+## 리스크
+
+- 사용자가 너무 작은 값 (예: 60s) 설정 시 정상 생성도 timeout. 사용자 책임.
+- log 도 wiki 의 timeout 사용 — log 가 별도 timeout 필요해지면 future 에 `[log].generation_timeout_secs` 추가 가능 (현재는 unify).
+
+## 후속
+
+- issue #87 에 머지 안내 comment.
+- release notes 에 명시 (v0.6.0 changelog 항목).


### PR DESCRIPTION
## Summary
Issue #87 (cakel): wiki update 시 claude/codex/ollama/lmstudio 백엔드의 timeout 값을 사용자가 직접 조정할 수 있는 config 옵션 추가.

배경:
- P59 (#69) 머지로 hardcoded 5분 → 30분 (1800s) 상향됨.
- cakel 보고의 300s 에러는 P59 이전 버전 사용 의심 — release (v0.6.0) 진행으로 fix.
- 단 1800s 도 부족한 케이스 (수만 세션 vault 또는 느린 모델) 가 있어 사용자 override 옵션은 정당한 기능.

## 변경
- `vault/config.rs`: `WikiConfig.generation_timeout_secs: u64` (default 1800).
- `wiki/{claude,codex,ollama,lmstudio}.rs`: 각 Backend struct 에 `timeout_secs` 필드. `generate()` 가 `from_secs(self.timeout_secs)`.
- `commands/wiki.rs::build_wiki_backend`: 5개 instantiation 모두 `timeout_secs: config.wiki.generation_timeout_secs` 전달.
- `commands/log.rs`: log command 의 backend 5 instantiation 도 동일 (log 가 wiki backend struct 를 reuse).
- `tests/sync_termination.rs` + wiki/{ollama,lmstudio} unit test literal 갱신.

## 사용 예시
\`\`\`toml
# config.toml
[wiki]
generation_timeout_secs = 3600  # 30분 → 1시간
\`\`\`

## Out of scope
- haiku (Anthropic API HTTP 120s) + reviewers (60~120s) timeout 은 별도.
- log 가 별도 timeout 필요해지면 future 에 `[log]` 섹션에 추가 가능 (현재는 wiki 와 unify).

## Test plan
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace --no-fail-fast\` all green (lib 426 + integration)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)