### PR TITLE
fix(ci): clippy/fmt 위반 수정 — PR #95 test 코드 (main 복구)

### DIFF
--- a/crates/secall-core/src/search/embedding.rs
+++ b/crates/secall-core/src/search/embedding.rs
@@ -159,7 +159,8 @@ impl OrtEmbedder {
 
         // Build first session and probe dimensions
         #[allow(unused_mut)]
-        let mut builder = ort::session::Session::builder().map_err(|e| anyhow!("ort builder: {e}"))?;
+        let mut builder =
+            ort::session::Session::builder().map_err(|e| anyhow!("ort builder: {e}"))?;
         #[cfg(all(feature = "coreml", target_os = "macos", target_arch = "aarch64"))]
         {
             use ort::execution_providers::CoreMLExecutionProvider;
@@ -181,7 +182,8 @@ impl OrtEmbedder {
         // Build remaining sessions
         for _ in 1..pool_size {
             #[allow(unused_mut)]
-            let mut builder = ort::session::Session::builder().map_err(|e| anyhow!("ort builder: {e}"))?;
+            let mut builder =
+                ort::session::Session::builder().map_err(|e| anyhow!("ort builder: {e}"))?;
             #[cfg(all(feature = "coreml", target_os = "macos", target_arch = "aarch64"))]
             {
                 use ort::execution_providers::CoreMLExecutionProvider;
@@ -1008,7 +1010,7 @@ mod tests {
         ];
 
         let embeddings = rt
-            .block_on(embedder.embed_batch(&texts.iter().map(|s| *s).collect::<Vec<_>>()))
+            .block_on(embedder.embed_batch(&texts))
             .expect("embed_batch");
 
         assert_eq!(embeddings.len(), 4);
@@ -1024,9 +1026,8 @@ mod tests {
         // Semantic sanity: context-question pairs should be more similar to each
         // other than to unrelated pairs (bge-m3 is a cross-lingual retrieval model)
         let sim_philosophy = cosine(&embeddings[0], &embeddings[1]); // context ↔ its question
-        let sim_noah = cosine(&embeddings[2], &embeddings[3]);       // context ↔ its question
-        let sim_cross = cosine(&embeddings[0], &embeddings[3]);      // philosophy ↔ noah question
-
+        let sim_noah = cosine(&embeddings[2], &embeddings[3]); // context ↔ its question
+        let sim_cross = cosine(&embeddings[0], &embeddings[3]); // philosophy ↔ noah question
 
         assert!(
             sim_philosophy > sim_cross,


### PR DESCRIPTION
## Summary
PR #95 (#94 fix) 가 fork PR 이라 GitHub 이 maintainer approval 전까지 workflow 를 보류 → CI 미실행으로 clippy/fmt 위반이 main 에 머지됨. **main CI 가 failure 상태** ([run 26605390207](https://github.com/hang-in/seCall/actions/runs/26605390207)).

## Fix
- `crates/secall-core/src/search/embedding.rs` test 코드:
  - `texts.iter().map(|s| *s).collect::<Vec<_>>()` → `&texts` (배열→슬라이스 coerce). `clippy::map_clone` + `clippy::iter_cloned_collect` 해소.
  - 동 test 의 fmt 위반 (이중 빈 줄) 정리.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

긴급 main 복구용 hotfix 입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)