### PR TITLE
feat(wiki): P88 — claude+haiku wiki generation 경고 (#93)

### DIFF
--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -211,6 +211,21 @@ async fn run_update_with_sink(
         );
     }
 
+    // P88 (issue #93): claude 백엔드 + haiku 모델은 wiki generation prompt 의
+    // instruction-following 이 약해 작업을 시작하지 않고 "뭘 원하나요?" 라고
+    // 되묻는 경우가 잦다 (sonnet/opus 는 정상). 차단하진 않되 (haiku 도 도구
+    // 호출 자체는 가능하고 review backend 로는 적합) 빈 결과로 끝나는 혼란을
+    // 줄이기 위해 경고한다.
+    if backend_name == "claude" && resolved_model.trim().eq_ignore_ascii_case("haiku") {
+        eprintln!(
+            "⚠️  wiki generation 에 haiku 모델은 권장되지 않습니다 \
+             (instruction-following 이 약해 작업을 건너뛸 수 있음). \
+             [wiki.backends.claude] model = \"sonnet\" 또는 \"opus\" 를 권장합니다. \
+             haiku 는 review backend (review_backend = \"haiku\") 용도로 적합합니다. \
+             참고: issue #93"
+        );
+    }
+
     // 2. Load prompt — haiku 백엔드는 세션 데이터를 직접 주입
     let prompt = if backend_name == "haiku" {
         build_haiku_prompt(&config, &wiki_dir, session, since)?

--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -216,7 +216,10 @@ async fn run_update_with_sink(
     // 되묻는 경우가 잦다 (sonnet/opus 는 정상). 차단하진 않되 (haiku 도 도구
     // 호출 자체는 가능하고 review backend 로는 적합) 빈 결과로 끝나는 혼란을
     // 줄이기 위해 경고한다.
-    if backend_name == "claude" && resolved_model.trim().eq_ignore_ascii_case("haiku") {
+    // Gemini PR #98: claude.rs 의 model_id 매칭이 정확히 "haiku" 일 때만 haiku 를
+    // 쓰고 "Haiku"/"haiku " 는 sonnet 으로 보내므로, 경고 조건도 정확히 "haiku"
+    // 로 일치시킨다 (느슨한 비교 시 sonnet 실행인데 haiku 경고 뜨는 불일치).
+    if backend_name == "claude" && resolved_model == "haiku" {
         eprintln!(
             "⚠️  wiki generation 에 haiku 모델은 권장되지 않습니다 \
              (instruction-following 이 약해 작업을 건너뛸 수 있음). \

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -174,3 +174,11 @@ Plan document index. Register new plans here.
 - [전체 계획서](p87-windows-cmd-spawn.md) — in_progress, 2026-05-29
 - 단일 Task: `which` crate 로 `resolve_program` 추가 — Windows PATHEXT 적용해 npm `.cmd` 래퍼 (codex/claude) 를 정상 spawn. spawn 5곳 + `command_exists` 통일.
 - 관련: issue #92 (cakel).
+
+---
+
+### seCall P88 — claude+haiku wiki generation 경고 (issue #93)
+
+- [전체 계획서](p88-haiku-wiki-warn.md) — in_progress, 2026-05-29
+- 단일 Task: generation 경로에서 claude+haiku 조합 감지 시 경고 (sonnet/opus 권장). 코드 버그 아닌 모델 capability — 차단 대신 안내.
+- 관련: issue #93 (cakel).

--- a/docs/plans/p88-haiku-wiki-warn.md
+++ b/docs/plans/p88-haiku-wiki-warn.md
@@ -1,0 +1,57 @@
+---
+type: plan
+status: in_progress
+updated_at: 2026-05-29
+canonical: true
+---
+
+# P88 — claude+haiku wiki generation 경고 (issue #93)
+
+## 배경
+
+Issue #93 (cakel, v0.6.0): `[wiki.backends.claude] model = "haiku"` 설정 시 `secall wiki update` 가 작업을 안 하고 "뭘 원하나요?" 라고 되물은 뒤 `✓ Wiki update complete` 로 빈 결과 종료. `model = "sonnet"` 은 정상.
+
+## 원인 (코드 버그 아님 — 모델 capability)
+
+`wiki update` batch/incremental prompt 는 MCP 도구 (`secall recall`/`get`/`status`) 능동 호출 + `wiki/` 파일 생성을 요구하는 복잡한 instruction. claude CLI 자체는 haiku/sonnet 모두 도구 호출 가능하나, **haiku 는 instruction-following 이 약해** 이 prompt 를 받으면 작업을 시작하지 않고 되묻는 경우가 잦다. #88(ollama, 도구 호출 자체 불가)과 달리 haiku 는 가능은 하므로 **완전 차단(fail-fast)은 부적절** — review backend 로는 정상 사용되기 때문.
+
+## 목표
+
+- generation 경로에서 claude+haiku 조합 감지 시 **경고 출력** (sonnet/opus 권장 + haiku 는 review 용 안내).
+- silent 빈 결과로 끝나 사용자가 원인 모르는 혼란 제거.
+
+## 비목표
+
+- haiku 차단 안 함 (review backend 로 적합, generation 도 가능은 함).
+- prompt 강화로 haiku 가 따르게 만드는 작업은 별도 (효과 불확실).
+
+## 구현
+
+`crates/secall/src/commands/wiki.rs` 의 `run_update_with_sink` — P86 fail-fast 블록 다음:
+
+```rust
+if backend_name == "claude" && resolved_model.trim().eq_ignore_ascii_case("haiku") {
+    eprintln!("⚠️  wiki generation 에 haiku 모델은 권장되지 않습니다 ...");
+}
+```
+
+generation 경로(`run_update_with_sink`)에만 위치 → review backend (별도 `build_reviewer`) 는 영향 없음.
+
+## 변경 파일
+
+- `crates/secall/src/commands/wiki.rs` — 경고 추가
+- `docs/plans/p88-haiku-wiki-warn.md` (신규) + `docs/plans/index.md`
+
+## 검증
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo build --workspace
+# 수동: [wiki.backends.claude] model="haiku" 로 secall wiki update → 경고 출력 확인
+```
+
+## 리스크
+
+- eprintln 경고만 추가 — 동작 변경 없음, 회귀 위험 최소.
+- `model = "sonnet "` (trailing space) 같은 입력은 `claude.rs` 가 `_ => sonnet` 으로 처리하므로 경고 대상 아님 (`trim().eq_ignore_ascii_case("haiku")` 가 정확히 haiku 만 매칭).


### PR DESCRIPTION
## Summary
Issue #93 (cakel): `[wiki.backends.claude] model = "haiku"` 설정 시 `secall wiki update` 가 작업을 안 하고 "뭘 원하나요?" 되묻고 빈 결과로 종료. `model = "sonnet"` 은 정상.

## 원인 (코드 버그 아님 — 모델 capability)
wiki batch/incremental prompt 는 MCP 도구 능동 호출 + `wiki/` 파일 생성을 요구하는 복잡한 instruction. claude CLI 는 haiku/sonnet 모두 도구 호출 가능하나, **haiku 는 instruction-following 이 약해** 작업을 시작하지 않고 되묻는 경우가 잦음. #88(ollama, 도구 호출 자체 불가)과 달리 haiku 는 가능은 하므로 완전 차단은 부적절 (review backend 로는 정상).

## Fix
`commands/wiki.rs` 의 generation 경로 (`run_update_with_sink`, P86 fail-fast 다음) 에서 claude+haiku 조합 감지 시 경고 출력:
- sonnet/opus 권장
- haiku 는 review backend 용도로 안내
- silent 빈 결과로 끝나는 혼란 제거 (차단 아님)

generation 경로에만 위치 → review backend (별도 `build_reviewer`) 영향 없음.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] 수동: `[wiki.backends.claude] model="haiku"` 로 `secall wiki update` → 경고 출력 확인 (다음 release 빌드 후)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)