### PR TITLE
feat(search): P89 — vector snippet enrich + 관찰 세션 랭킹 강등 (#100)

### DIFF
--- a/crates/secall-core/src/search/bm25.rs
+++ b/crates/secall-core/src/search/bm25.rs
@@ -56,6 +56,8 @@ pub struct SessionMeta {
     pub session_type: String,
     /// P45 — vault SSOT archive 상태. vector passes_filters 에서 사용.
     pub is_archived: bool,
+    /// P89 (#100) — 세션 turn 수. 짧은 관찰/요약 세션 랭킹 강등에 사용.
+    pub turn_count: i64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -192,7 +194,7 @@ fn normalize_scores(results: &mut [SearchResult]) {
     }
 }
 
-fn extract_snippet(content: &str, query: &str, max_chars: usize) -> String {
+pub(crate) fn extract_snippet(content: &str, query: &str, max_chars: usize) -> String {
     let chars: Vec<char> = content.chars().collect();
     let total = chars.len();
 

--- a/crates/secall-core/src/search/hybrid.rs
+++ b/crates/secall-core/src/search/hybrid.rs
@@ -9,6 +9,11 @@ use crate::store::db::Database;
 
 const RRF_K: f64 = 60.0;
 
+/// P89 (#100): 이 turn 수 미만 세션은 관찰/요약성 노이즈로 보고 랭킹 강등.
+const OBSERVER_TURN_THRESHOLD: i64 = 3;
+/// P89 (#100): 관찰성 세션 RRF score 에 곱하는 penalty (제외 아닌 soft 강등).
+const OBSERVER_PENALTY: f64 = 0.5;
+
 pub fn reciprocal_rank_fusion(
     bm25_results: &[SearchResult],
     vector_results: &[SearchResult],
@@ -44,6 +49,12 @@ pub fn reciprocal_rank_fusion(
         .into_iter()
         .map(|(key, mut r)| {
             r.score = score_map[&key];
+            // P89 (#100): classify 가 못 잡은 짧은 관찰/요약 세션 (turn_count <
+            // OBSERVER_TURN_THRESHOLD) 을 soft 강등. automated 완전 제외 (recall.rs)
+            // 와 별개 레이어 — 제외가 아닌 하위 랭킹으로 노이즈만 완화.
+            if r.metadata.turn_count < OBSERVER_TURN_THRESHOLD {
+                r.score *= OBSERVER_PENALTY;
+            }
             r
         })
         .collect();
@@ -323,6 +334,15 @@ mod tests {
     use crate::search::bm25::SessionMeta;
 
     fn make_result(session_id: &str, turn: u32, score: f64) -> SearchResult {
+        make_result_with_turns(session_id, turn, score, 10)
+    }
+
+    fn make_result_with_turns(
+        session_id: &str,
+        turn: u32,
+        score: f64,
+        turn_count: i64,
+    ) -> SearchResult {
         SearchResult {
             session_id: session_id.to_string(),
             turn_index: turn,
@@ -338,6 +358,7 @@ mod tests {
                 vault_path: None,
                 session_type: "interactive".to_string(),
                 is_archived: false,
+                turn_count,
             },
         }
     }
@@ -359,6 +380,24 @@ mod tests {
         // B appears in both lists → should score highest
         assert!(!combined.is_empty());
         assert_eq!(combined[0].session_id, "B");
+    }
+
+    #[test]
+    fn test_rrf_observer_penalty_demotes_short_sessions() {
+        // P89 (#100): turn_count < OBSERVER_TURN_THRESHOLD 인 짧은 관찰 세션은
+        // 동일 rank 라도 penalty 로 하위로 강등되어야 한다.
+        // 두 결과를 각각 단독 리스트에 같은 1위로 넣어 RRF rank 를 동일하게 만든 뒤,
+        // turn_count 만 다르게 해 penalty 효과를 본다.
+        let normal = vec![make_result_with_turns("normal", 0, 1.0, 10)];
+        let observer = vec![make_result_with_turns("observer", 0, 1.0, 1)];
+        let combined = reciprocal_rank_fusion(&normal, &observer, RRF_K);
+
+        assert_eq!(combined.len(), 2);
+        // 둘 다 rank 0 (각 리스트 1위) 이지만 observer 는 penalty → normal 이 상위.
+        assert_eq!(combined[0].session_id, "normal");
+        assert_eq!(combined[1].session_id, "observer");
+        // observer score 가 normal 의 OBSERVER_PENALTY 배 (정규화 전 기준).
+        assert!(combined[1].score < combined[0].score);
     }
 
     #[test]

--- a/crates/secall-core/src/search/vector.rs
+++ b/crates/secall-core/src/search/vector.rs
@@ -290,13 +290,21 @@ impl VectorIndexer {
                             Ok((session_id, turn_index, _chunk_seq)) => {
                                 if let Ok(meta) = db.get_session_meta(&session_id) {
                                     if passes_filters(&meta, filters) {
+                                        // P89 (#100): vector 결과 snippet 채우기 —
+                                        // turn content 앞부분 (검증성 확보).
+                                        let snippet = db
+                                            .get_turn(&session_id, turn_index)
+                                            .map(|t| {
+                                                super::bm25::extract_snippet(&t.content, "", 200)
+                                            })
+                                            .unwrap_or_default();
                                         results.push(SearchResult {
                                             session_id,
                                             turn_index,
                                             score: 1.0 - *distance as f64,
                                             bm25_score: None,
                                             vector_score: Some(1.0 - *distance as f64),
-                                            snippet: String::new(),
+                                            snippet,
                                             metadata: meta,
                                         });
                                     }
@@ -332,13 +340,18 @@ impl VectorIndexer {
                 if !passes_filters(&meta, filters) {
                     return None;
                 }
+                // P89 (#100): vector 결과 snippet 채우기 (turn content 앞부분).
+                let snippet = db
+                    .get_turn(&row.session_id, row.turn_index)
+                    .map(|t| super::bm25::extract_snippet(&t.content, "", 200))
+                    .unwrap_or_default();
                 Some(SearchResult {
                     session_id: row.session_id,
                     turn_index: row.turn_index,
                     score: 1.0 - row.distance as f64,
                     bm25_score: None,
                     vector_score: Some(1.0 - row.distance as f64),
-                    snippet: String::new(),
+                    snippet,
                     metadata: meta,
                 })
             })
@@ -731,6 +744,7 @@ mod tests {
             vault_path: None,
             session_type: "interactive".to_string(),
             is_archived,
+            turn_count: 10,
         }
     }
 

--- a/crates/secall-core/src/search/vector.rs
+++ b/crates/secall-core/src/search/vector.rs
@@ -290,21 +290,15 @@ impl VectorIndexer {
                             Ok((session_id, turn_index, _chunk_seq)) => {
                                 if let Ok(meta) = db.get_session_meta(&session_id) {
                                     if passes_filters(&meta, filters) {
-                                        // P89 (#100): vector 결과 snippet 채우기 —
-                                        // turn content 앞부분 (검증성 확보).
-                                        let snippet = db
-                                            .get_turn(&session_id, turn_index)
-                                            .map(|t| {
-                                                super::bm25::extract_snippet(&t.content, "", 200)
-                                            })
-                                            .unwrap_or_default();
+                                        // P89 (#100): snippet 은 루프 후 batch 로 채움
+                                        // (Gemini PR #101: N+1 회피).
                                         results.push(SearchResult {
                                             session_id,
                                             turn_index,
                                             score: 1.0 - *distance as f64,
                                             bm25_score: None,
                                             vector_score: Some(1.0 - *distance as f64),
-                                            snippet,
+                                            snippet: String::new(),
                                             metadata: meta,
                                         });
                                     }
@@ -325,6 +319,7 @@ impl VectorIndexer {
                         );
                         // fall through to BLOB scan
                     } else {
+                        fill_snippets(db, &mut results);
                         return Ok(results);
                     }
                 }
@@ -333,30 +328,48 @@ impl VectorIndexer {
 
         // BLOB 선형 스캔 fallback
         let rows = db.search_vectors(embedding, limit, candidate_session_ids)?;
-        let results = rows
+        let mut results: Vec<SearchResult> = rows
             .into_iter()
             .filter_map(|row| {
                 let meta = db.get_session_meta(&row.session_id).ok()?;
                 if !passes_filters(&meta, filters) {
                     return None;
                 }
-                // P89 (#100): vector 결과 snippet 채우기 (turn content 앞부분).
-                let snippet = db
-                    .get_turn(&row.session_id, row.turn_index)
-                    .map(|t| super::bm25::extract_snippet(&t.content, "", 200))
-                    .unwrap_or_default();
+                // P89 (#100): snippet 은 batch 로 채움 (Gemini PR #101: N+1 회피).
                 Some(SearchResult {
                     session_id: row.session_id,
                     turn_index: row.turn_index,
                     score: 1.0 - row.distance as f64,
                     bm25_score: None,
                     vector_score: Some(1.0 - row.distance as f64),
-                    snippet,
+                    snippet: String::new(),
                     metadata: meta,
                 })
             })
             .collect();
+        fill_snippets(db, &mut results);
         Ok(results)
+    }
+}
+
+/// P89 (#100, Gemini PR #101): vector 결과들의 snippet 을 단일 batch 쿼리로 채운다.
+/// turn content 앞부분 (200자) 을 snippet 으로 사용. 누락/실패는 빈 문자열 유지.
+fn fill_snippets(db: &Database, results: &mut [SearchResult]) {
+    if results.is_empty() {
+        return;
+    }
+    let keys: Vec<(String, u32)> = results
+        .iter()
+        .map(|r| (r.session_id.clone(), r.turn_index))
+        .collect();
+    let contents = match db.get_turn_contents(&keys) {
+        Ok(m) => m,
+        Err(_) => return, // 조회 실패 시 snippet 빈 채로 graceful
+    };
+    for r in results.iter_mut() {
+        if let Some(content) = contents.get(&(r.session_id.clone(), r.turn_index)) {
+            r.snippet = super::bm25::extract_snippet(content, "", 200);
+        }
     }
 }
 

--- a/crates/secall-core/src/store/db.rs
+++ b/crates/secall-core/src/store/db.rs
@@ -1472,4 +1472,49 @@ mod tests {
         let ids = db.list_sessions_for_graph_rebuild(filter).unwrap();
         assert_eq!(ids, vec!["d-10", "d-5"]);
     }
+
+    // P89 (#100, Gemini PR #101): get_turn_contents 배치 조회
+    #[test]
+    fn test_get_turn_contents_empty_returns_empty() {
+        let db = Database::open_memory().unwrap();
+        let map = db.get_turn_contents(&[]).unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_get_turn_contents_batch_and_missing() {
+        let db = Database::open_memory().unwrap();
+        db.conn()
+            .execute_batch(
+                "INSERT INTO sessions(id, agent, start_time, ingested_at) VALUES('s1','claude-code','2026-01-01','2026-01-01');
+                 INSERT INTO sessions(id, agent, start_time, ingested_at) VALUES('s2','claude-code','2026-01-01','2026-01-01');
+                 INSERT INTO turns(session_id, turn_index, role, content) VALUES('s1',0,'user','alpha');
+                 INSERT INTO turns(session_id, turn_index, role, content) VALUES('s1',1,'assistant','beta');
+                 INSERT INTO turns(session_id, turn_index, role, content) VALUES('s2',0,'user','gamma');",
+            )
+            .unwrap();
+
+        let keys = vec![
+            ("s1".to_string(), 0u32),
+            ("s1".to_string(), 1u32),
+            ("s2".to_string(), 0u32),
+            ("s2".to_string(), 99u32), // missing → 맵에서 제외
+        ];
+        let map = db.get_turn_contents(&keys).unwrap();
+
+        assert_eq!(map.len(), 3, "missing key must be excluded");
+        assert_eq!(
+            map.get(&("s1".to_string(), 0)).map(String::as_str),
+            Some("alpha")
+        );
+        assert_eq!(
+            map.get(&("s1".to_string(), 1)).map(String::as_str),
+            Some("beta")
+        );
+        assert_eq!(
+            map.get(&("s2".to_string(), 0)).map(String::as_str),
+            Some("gamma")
+        );
+        assert!(map.get(&("s2".to_string(), 99)).is_none());
+    }
 }

--- a/crates/secall-core/src/store/db.rs
+++ b/crates/secall-core/src/store/db.rs
@@ -1515,6 +1515,6 @@ mod tests {
             map.get(&("s2".to_string(), 0)).map(String::as_str),
             Some("gamma")
         );
-        assert!(map.get(&("s2".to_string(), 99)).is_none());
+        assert!(!map.contains_key(&("s2".to_string(), 99)));
     }
 }

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -1569,11 +1569,21 @@ mod tests {
     fn test_insert_session_from_vault_reindex_syncs_turn_count() {
         let db = Database::open_memory().unwrap();
 
+        let read_turn_count = |id: &str| -> i64 {
+            db.conn()
+                .query_row(
+                    "SELECT turn_count FROM sessions WHERE id = ?1",
+                    [id],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        };
+
         let mut fm = make_fm("sess-tc", None);
         fm.turns = Some(2);
         db.insert_session_from_vault(&fm, "body", "raw/.sessions/tc.md")
             .unwrap();
-        assert_eq!(db.get_session_meta("sess-tc").unwrap().turn_count, 2);
+        assert_eq!(read_turn_count("sess-tc"), 2);
 
         // 재인덱싱: turns 2 → 8
         let mut fm2 = make_fm("sess-tc", None);
@@ -1581,7 +1591,7 @@ mod tests {
         db.insert_session_from_vault(&fm2, "body", "raw/.sessions/tc.md")
             .unwrap();
         assert_eq!(
-            db.get_session_meta("sess-tc").unwrap().turn_count,
+            read_turn_count("sess-tc"),
             8,
             "reindex 시 turn_count 가 frontmatter 값으로 동기화돼야 함"
         );

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -216,6 +216,50 @@ impl Database {
             })
     }
 
+    /// P89 (#100, Gemini PR #101): `(session_id, turn_index)` 다건의 content 를
+    /// 단일 쿼리로 가져온다. vector 검색 결과 snippet 채우기의 N+1 회피용.
+    ///
+    /// 누락된 키 (turn 없음) 는 맵에 포함되지 않는다. 입력이 비면 빈 맵 반환.
+    pub fn get_turn_contents(
+        &self,
+        keys: &[(String, u32)],
+    ) -> Result<std::collections::HashMap<(String, u32), String>> {
+        use std::collections::HashMap;
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        // row-value IN: WHERE (session_id, turn_index) IN (VALUES (?,?), (?,?), ...)
+        let placeholders = vec!["(?,?)"; keys.len()].join(", ");
+        let sql = format!(
+            "SELECT session_id, turn_index, content FROM turns \
+             WHERE (session_id, turn_index) IN (VALUES {placeholders})"
+        );
+
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::with_capacity(keys.len() * 2);
+        for (sid, idx) in keys {
+            params.push(Box::new(sid.clone()));
+            params.push(Box::new(*idx as i64));
+        }
+        let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+
+        let conn = self.conn();
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(param_refs.as_slice(), |row| {
+            let sid: String = row.get(0)?;
+            let idx: i64 = row.get(1)?;
+            let content: String = row.get(2)?;
+            Ok(((sid, idx as u32), content))
+        })?;
+
+        let mut map = HashMap::with_capacity(keys.len());
+        for r in rows {
+            let (key, content) = r?;
+            map.insert(key, content);
+        }
+        Ok(map)
+    }
+
     pub fn count_sessions(&self) -> Result<i64> {
         let count = self
             .conn()

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -469,10 +469,18 @@ impl Database {
             ],
         )?;
 
-        // P45 — 기존 row 가 있던 경우에도 vault frontmatter 의 archive 상태로 DB 동기화
+        // P45 — 기존 row 가 있던 경우에도 vault frontmatter 의 archive 상태로 DB 동기화.
+        // P89 (#100, Gemini PR #101): INSERT OR IGNORE 라 재인덱싱 시 turn_count 가
+        // 옛 값으로 남아 RRF 강등 판단이 stale 해진다. archive 와 함께 turn_count 도
+        // frontmatter 값으로 동기화.
         self.conn().execute(
-            "UPDATE sessions SET is_archived = ?1, archived_at = ?2 WHERE id = ?3",
-            rusqlite::params![archived_int, archived_at, fm.session_id],
+            "UPDATE sessions SET is_archived = ?1, archived_at = ?2, turn_count = ?3 WHERE id = ?4",
+            rusqlite::params![
+                archived_int,
+                archived_at,
+                fm.turns.unwrap_or(0),
+                fm.session_id
+            ],
         )?;
 
         // FTS 인덱싱 — 본문 전체를 하나의 청크로

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -1562,4 +1562,28 @@ mod tests {
             .unwrap();
         assert_eq!(is_archived_after, 1);
     }
+
+    // P89 (#100, Gemini PR #101): 재인덱싱 시 turn_count 가 frontmatter 값으로
+    // 동기화되는지 (INSERT OR IGNORE 로 stale 하게 남지 않는지).
+    #[test]
+    fn test_insert_session_from_vault_reindex_syncs_turn_count() {
+        let db = Database::open_memory().unwrap();
+
+        let mut fm = make_fm("sess-tc", None);
+        fm.turns = Some(2);
+        db.insert_session_from_vault(&fm, "body", "raw/.sessions/tc.md")
+            .unwrap();
+        assert_eq!(db.get_session_meta("sess-tc").unwrap().turn_count, 2);
+
+        // 재인덱싱: turns 2 → 8
+        let mut fm2 = make_fm("sess-tc", None);
+        fm2.turns = Some(8);
+        db.insert_session_from_vault(&fm2, "body", "raw/.sessions/tc.md")
+            .unwrap();
+        assert_eq!(
+            db.get_session_meta("sess-tc").unwrap().turn_count,
+            8,
+            "reindex 시 turn_count 가 frontmatter 값으로 동기화돼야 함"
+        );
+    }
 }

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -164,7 +164,7 @@ impl SessionRepo for Database {
     fn get_session_meta(&self, session_id: &str) -> crate::error::Result<SessionMeta> {
         self.conn()
             .query_row(
-                "SELECT agent, model, project, start_time, vault_path, session_type, is_archived FROM sessions WHERE id = ?1",
+                "SELECT agent, model, project, start_time, vault_path, session_type, is_archived, turn_count FROM sessions WHERE id = ?1",
                 [session_id],
                 |row| {
                     let start_time: String = row.get(3)?;
@@ -177,6 +177,7 @@ impl SessionRepo for Database {
                         vault_path: row.get(4)?,
                         session_type: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
                         is_archived: row.get::<_, i64>(6).unwrap_or(0) != 0,
+                        turn_count: row.get::<_, i64>(7).unwrap_or(0),
                     })
                 },
             )

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -1571,11 +1571,9 @@ mod tests {
 
         let read_turn_count = |id: &str| -> i64 {
             db.conn()
-                .query_row(
-                    "SELECT turn_count FROM sessions WHERE id = ?1",
-                    [id],
-                    |r| r.get(0),
-                )
+                .query_row("SELECT turn_count FROM sessions WHERE id = ?1", [id], |r| {
+                    r.get(0)
+                })
                 .unwrap()
         };
 

--- a/docs/plans/p89-search-quality.md
+++ b/docs/plans/p89-search-quality.md
@@ -1,0 +1,70 @@
+---
+type: plan
+status: in_progress
+updated_at: 2026-06-01
+canonical: true
+---
+
+# P89 — 검색 품질: vector snippet enrich + 관찰 세션 랭킹 강등 (issue #100)
+
+## 배경
+
+Issue #100 (hang-in, codex 검색 품질 스모크 테스트). 전체 임베딩 완료 후 검색 품질 점검에서 두 개선점 확인:
+1. `--vec` (vector-only) 결과의 `snippet` 이 비어 검증성 낮음
+2. observer/관찰성 세션이 일반 검색 결과 상위에 섞이는 노이즈
+
+## 원인 (코드 확인)
+
+- **snippet 빈 값**: `vector.rs:299` (ANN 경로) + `341` (BLOB 스캔) 의 `SearchResult.snippet = String::new()`. BM25 (`bm25.rs:147`) 는 FTS content 로 `extract_snippet` 을 채우지만 vector 경로엔 그 단계가 없음. vector 검색은 `(session_id, turn_index)` 까지 알면서도 turn content 를 안 가져옴.
+- **관찰 노이즈**: `recall.rs:55-58` 기본 `exclude_session_types = ["automated"]` 로 automated 만 제외. classify (`commands/classify.rs`, config rule 기반) 가 못 잡은 관찰성 세션은 `interactive` 로 남아 검색에 섞임.
+
+## 목표
+
+- A: vector 결과에 turn content 기반 snippet 채워 검증성 확보.
+- B2: automated 제외는 유지 + classify 가 못 잡은 관찰성 세션(짧은 turn 수)을 랭킹에서 soft 강등 (제외 아님).
+
+## 구현
+
+### A. vector snippet enrich
+
+- `bm25.rs:195` `fn extract_snippet` → `pub(crate) fn extract_snippet` (search 모듈 공유). 빈 query 시 `find("")` 가 `Some(0)` → 앞부분 추출이라 안전.
+- `vector.rs`:
+  - `search_with_embedding` 시그니처에 `query: Option<&str>` 추가.
+  - ANN/BLOB 두 경로에서 `db.get_turn(&session_id, turn_index)` 로 turn content 가져와 `extract_snippet(content, query.unwrap_or(""), 200)` 으로 snippet 채움. get_turn 실패 시 빈 문자열 유지 (graceful).
+  - `search` (async, line 240) 가 `Some(query)` 전달.
+- `hybrid.rs:225` `vi.search_with_embedding(...)` 호출에 query 전달 (보유 시 Some, 없으면 None).
+
+### B2. 관찰 세션 랭킹 강등
+
+- `hybrid.rs` 의 `reciprocal_rank_fusion` 결과 정렬/정규화 **전**에, 각 result 의 `metadata.turn_count` 가 임계값 미만(예: `< 3`) 이면 RRF score 에 penalty (`*= 0.5`) 적용.
+  - 근거: 관찰/요약 세션은 turn 수가 매우 적음. automated 로 분류 안 된 짧은 노이즈 세션을 하위로.
+  - 임계값/penalty 는 상수로 (`OBSERVER_TURN_THRESHOLD = 3`, `OBSERVER_PENALTY = 0.5`).
+- automated 완전 제외(`recall.rs`)는 그대로 유지 — 이건 별개 레이어.
+
+## 변경 파일
+
+- `crates/secall-core/src/search/bm25.rs` — `extract_snippet` pub(crate)
+- `crates/secall-core/src/search/vector.rs` — search_with_embedding query param + snippet 채움 (2 경로)
+- `crates/secall-core/src/search/hybrid.rs` — search_with_embedding 호출 갱신 + RRF turn_count penalty
+- `docs/plans/p89-search-quality.md` (신규) + `docs/plans/index.md`
+
+## 검증
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test -p secall-core --lib search::
+```
+
+- 신규 unit test: RRF penalty (turn_count < 3 인 result 가 강등되는지), extract_snippet 빈 query 동작.
+- ⚠️ context-mode hook 이 Read 출력을 오염시키는 환경 → 검증은 cargo (Bash) 결과로.
+
+## 리스크
+
+- snippet 채우려 result 마다 `get_turn` 쿼리 1회 추가 → N+1. limit 작아(기본 10) 영향 미미. 필요 시 batch 조회 후속.
+- turn_count 강등이 짧지만 중요한 세션을 누를 수 있음 → penalty 0.5 로 완만하게 (제외 아님).
+
+## 후속 (별도)
+
+- hybrid 결과에 BM25/vector hit 근거 표시 (#100 제안 4).
+- 품질 회귀 테스트용 고정 쿼리 세트 (#100 제안 5).


### PR DESCRIPTION
## Summary
Issue #100 (검색 품질 스모크 테스트) 의 두 항목 fix.

### A. vector snippet enrich
- `bm25::extract_snippet` → `pub(crate)`
- `vector.rs` ANN/BLOB 두 경로가 `db.get_turn` 으로 turn content 가져와 snippet 채움 (이전 `String::new()`). `--vec` 결과 `snippet: ""` 검증성 문제 해소.

### B2. 관찰/요약 세션 랭킹 강등
- `bm25::SessionMeta` 에 `turn_count` 추가
- `reciprocal_rank_fusion` 이 turn_count < 3 세션 RRF score *0.5 (제외 아닌 soft 강등). recall 의 automated 완전 제외와 별개 레이어.

## Test plan
- [x] cargo fmt --check / clippy --workspace --all-targets -D warnings clean
- [x] cargo test --workspace all green (신규 test_rrf_observer_penalty 포함)

## Out of scope (별도)
- hybrid hit 근거 표시 (#100 제안 4), 품질 회귀 고정 쿼리 세트 (제안 5)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)