### PR TITLE
refactor(ingest): P90 — WIKI_INVOCATION_MARKER 소유권 ingest 로 이전

### DIFF
--- a/crates/secall-core/src/ingest/mod.rs
+++ b/crates/secall-core/src/ingest/mod.rs
@@ -19,6 +19,17 @@ pub use types::{Action, AgentKind, Role, Session, TokenUsage, Turn};
 const SECALL_SUMMARY_PROMPT_PREFIX: &str =
     "Analyze the following conversation and produce a JSON array of topic-based summaries";
 
+/// P83/P90 (#82, refactoring report [낮음]): codex/claude wiki 호출이 만든
+/// subprocess 세션을 ingest 가 self-ingest 노이즈로 식별하기 위한 prompt prefix
+/// marker. `is_noise_session` 이 첫 user turn 에서 이 marker 를 검출하면 해당
+/// 세션을 skip 한다.
+///
+/// 소유권은 노이즈 판정 주체인 `ingest` 에 둔다 — wiki 백엔드 (`wiki::{codex,
+/// claude}::generate`) 가 prompt 앞에 이 상수를 prepend 하므로, 하위 레이어
+/// (ingest) 의 식별 규칙을 상위 레이어 (wiki) 가 참조하는 올바른 의존 방향이다.
+/// (이전엔 `wiki::WIKI_INVOCATION_MARKER` 로 정의되어 ingest → wiki 역참조였음.)
+pub const WIKI_INVOCATION_MARKER: &str = "<!-- secall:wiki-update -->";
+
 pub trait SessionParser: Send + Sync {
     /// Check if this parser can handle the given path
     fn can_parse(&self, path: &Path) -> bool;
@@ -43,7 +54,7 @@ pub trait SessionParser: Send + Sync {
 /// ingest 가 발생해 vault 가 거의 동일한 짧은 세션으로 오염됐다. 차단 패턴:
 ///   1. cwd 가 OS 임시 디렉토리 (`/private/var/folders`, `/var/folders`, `/tmp`)
 ///   2. 첫 user turn 본문이 secall 의 알려진 summary 프롬프트 prefix 로 시작
-///   3. (P83) 첫 user turn 본문이 `wiki::WIKI_INVOCATION_MARKER` 를 포함
+///   3. (P83) 첫 user turn 본문이 `WIKI_INVOCATION_MARKER` 를 포함
 ///      — `secall wiki update` 가 codex/claude 백엔드 subprocess 호출 시 prompt
 ///      앞에 prefix 로 추가하는 marker. Issue #82 fix.
 ///
@@ -66,7 +77,7 @@ pub fn is_noise_session(session: &Session) -> Option<&'static str> {
         // P83 marker 는 `contains` — codex/claude 가 system prompt 를 앞에 prepend
         // 하는 경우에도 robust. 변수는 일관성 위해 `content_trimmed` 재사용
         // (trim 결과 marker 자체는 변하지 않음).
-        if content_trimmed.contains(crate::wiki::WIKI_INVOCATION_MARKER) {
+        if content_trimmed.contains(WIKI_INVOCATION_MARKER) {
             return Some("secall wiki invocation");
         }
     }
@@ -166,7 +177,7 @@ mod tests {
     fn is_noise_wiki_invocation_marker_at_start() {
         let prompt = format!(
             "{}\n\nUpdate the wiki for the following sessions...",
-            crate::wiki::WIKI_INVOCATION_MARKER
+            WIKI_INVOCATION_MARKER
         );
         let s = dummy_session(Some("/Users/me/projects/seCall"), Some(&prompt));
         assert_eq!(is_noise_session(&s), Some("secall wiki invocation"));
@@ -176,10 +187,7 @@ mod tests {
     fn is_noise_wiki_invocation_marker_in_middle() {
         // marker 가 어디에 있든 검출되어야 함 (codex/claude 의 system prompt 가
         // 앞에 붙는 경우에도 robust).
-        let prompt = format!(
-            "Some preamble...\n{}\nMore content",
-            crate::wiki::WIKI_INVOCATION_MARKER
-        );
+        let prompt = format!("Some preamble...\n{}\nMore content", WIKI_INVOCATION_MARKER);
         let s = dummy_session(Some("/Users/me/projects/seCall"), Some(&prompt));
         assert_eq!(is_noise_session(&s), Some("secall wiki invocation"));
     }

--- a/crates/secall-core/src/wiki/mod.rs
+++ b/crates/secall-core/src/wiki/mod.rs
@@ -22,12 +22,11 @@ pub use reviewers::{
     ClaudeReviewer, CodexReviewer, HaikuReviewer, LmStudioReviewer, OllamaReviewer,
 };
 
-/// P83: codex/claude wiki 호출이 만든 subprocess 세션을 ingest 가 식별하기 위한
-/// prompt prefix marker. `wiki::{codex,claude}::generate()` 가 prompt 앞에
-/// 이 marker 를 prepend 하고, `ingest::is_noise_session` 이 첫 user turn 에서
-/// 검출하면 self-ingest 루프 차단을 위해 해당 세션을 skip 한다.
-/// Issue #82 fix.
-pub const WIKI_INVOCATION_MARKER: &str = "<!-- secall:wiki-update -->";
+/// P83/P90: wiki self-ingest marker. 소유권은 노이즈 판정 주체인 `ingest` 로
+/// 이전됨 (`ingest::WIKI_INVOCATION_MARKER`). 기존 `wiki::WIKI_INVOCATION_MARKER`
+/// 참조 호환을 위해 re-export 한다. `wiki::{codex,claude}::generate()` 가 prompt
+/// 앞에 prepend, `ingest::is_noise_session` 이 검출. Issue #82.
+pub use crate::ingest::WIKI_INVOCATION_MARKER;
 
 /// wiki 생성 프롬프트를 LLM에 전달하고 결과를 반환하는 추상 인터페이스
 #[async_trait::async_trait]


### PR DESCRIPTION
## Summary
Gemini 리팩토링 보고서의 **[낮음]** 항목 (유일하게 저비용·저위험으로 동의한 항목) 처리. 하위 레이어 `ingest` 가 상위 레이어 `wiki` 의 상수를 참조하던 역방향 의존(논리적 순환)을 해소.

## 변경
- `WIKI_INVOCATION_MARKER` 정의를 `wiki::mod.rs` → `ingest::mod.rs` 로 이전. 노이즈 판정 주체(ingest)가 marker 의 owner.
- `wiki::mod.rs` 는 `pub use crate::ingest::WIKI_INVOCATION_MARKER` re-export → 기존 `wiki::WIKI_INVOCATION_MARKER` 참조처 (`wiki/codex.rs`, `wiki/claude.rs`) 변경 없이 호환.
- `ingest/mod.rs` 의 self-참조 + test 2곳을 로컬 상수로 정리.

## 효과
`ingest/` 디렉토리에 `crate::wiki` 참조 **0건** (역참조 완전 제거). 의존 방향: wiki(상위) → ingest(하위) 단방향으로 정리. **동작 변경 없음** (상수 값 동일, re-export 로 모든 호출처 유지).

## Test plan
- [x] `cargo fmt --all -- --check` = 0
- [x] `cargo clippy --workspace --all-targets -- -D warnings` = 0
- [x] `cargo test --workspace --no-fail-fast` = 0 (ingest 115 + 전체 green)

## Note
나머지 보고서 제안 3건(LLM 클라이언트 공통화 / CLI→core service 이전 / SeCallMcpServer 분리)은 비용·위험 대비 현 시점 가치가 낮아 보류 (백로그). 이 PR 은 보고서 + 검토자 모두 "리스크 전무, 국소적"으로 동의한 항목만 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)