### PR TITLE
fix: cargo install --git 빌드 실패 해결 (web/dist 없을 때)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 > NOTE: v0.3.x ~ v0.4.x 의 상세 변경 이력은 `README.md` 의 "버전 히스토리" 표 참고. CHANGELOG.md 는 v0.2.x 시점에서 README 로 SSOT 이전됨.
 
+## Unreleased
+
+### 🐛 Fixes
+
+- **`cargo install --git` 빌드 실패 해결** (web-ui default): `web-ui` 기능이 release 빌드 시점에 `web/dist/` (gitignore 된 `pnpm build` 산출물) 를 `rust-embed` 로 요구하는데, `cargo install --git ...` 사용자는 `pnpm build` 를 거치지 않아 `RustEmbed` derive 가 `folder ... does not exist` 로 항상 컴파일 실패하던 문제. `crates/secall-core/build.rs` 추가 — dist 가 없으면 안내용 placeholder `index.html` 을 생성해 컴파일을 살리고(웹 UI 자리에 빌드 안내 페이지 표시, CLI·MCP·REST API 는 정상), dist 가 있으면 그대로 사용한다. 더불어 `web/dist/index.html` 에 `cargo:rerun-if-changed` 를 걸어 dist 갱신 후 옛 번들이 embed 되던 staleness 회귀도 함께 해소. Node 불필요. (웹 UI 가 필요 없으면 종전처럼 `--no-default-features` 로 설치 가능)
+
+---
+
 ## v0.6.2 (2026-06-01)
 
 검색 품질 개선 + 내부 의존 방향 정리.

--- a/crates/secall-core/build.rs
+++ b/crates/secall-core/build.rs
@@ -22,7 +22,7 @@ fn main() {
         return;
     }
 
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
     // embed.rs 의 `#[folder = "../../web/dist/"]` 와 동일한 위치.
     let dist_dir = Path::new(&manifest_dir).join("../../web/dist");
     let index_html = dist_dir.join("index.html");

--- a/crates/secall-core/build.rs
+++ b/crates/secall-core/build.rs
@@ -1,0 +1,83 @@
+//! 빌드 스크립트 — `web-ui` 기능의 정적 자산 임베드를 견고하게 만든다.
+//!
+//! `src/web/embed.rs` 의 `#[derive(RustEmbed)] #[folder = "../../web/dist/"]` 는
+//! release 빌드 시점에 `web/dist/` 폴더가 **반드시 존재**해야 컴파일된다.
+//! `web/dist/` 는 `pnpm build` 산출물이라 `.gitignore` 대상이고 git 에 포함되지
+//! 않으므로, 외부 사용자가 `cargo install --git ...` 로 받으면 폴더가 없어
+//! `RustEmbed` derive 가 컴파일 에러를 낸다.
+//!
+//! 이 스크립트는 두 가지를 보장한다:
+//!   1. `web/dist/index.html` 변경 시 cargo 가 rebuild 하도록 추적한다.
+//!      (dist 갱신 후 `cargo install` 만 돌리면 옛 번들이 embed 되던 회귀 방지)
+//!   2. `web/dist/` 가 없으면 안내용 placeholder 를 만들어 컴파일이 깨지지 않게
+//!      한다. CLI · MCP · REST API 는 그대로 동작하고, 웹 UI 자리에는 빌드 방법을
+//!      안내하는 페이지가 표시된다.
+
+use std::path::Path;
+
+fn main() {
+    // `web-ui` 기능이 꺼져 있으면 embed 자체가 컴파일되지 않으므로 할 일이 없다.
+    // cargo 는 활성 기능마다 `CARGO_FEATURE_<NAME>` (대문자, `-`→`_`) 을 설정한다.
+    if std::env::var_os("CARGO_FEATURE_WEB_UI").is_none() {
+        return;
+    }
+
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    // embed.rs 의 `#[folder = "../../web/dist/"]` 와 동일한 위치.
+    let dist_dir = Path::new(&manifest_dir).join("../../web/dist");
+    let index_html = dist_dir.join("index.html");
+
+    // dist 가 바뀌면 (특히 index.html) cargo 가 재컴파일하도록 추적한다.
+    println!("cargo:rerun-if-changed={}", index_html.display());
+
+    if index_html.exists() {
+        // 정상 경로: CI / `just build` / `pnpm build` 로 만들어진 실제 번들이 있다.
+        return;
+    }
+
+    // dist 가 없다 — placeholder 를 만들어 컴파일을 살린다.
+    if let Err(e) = std::fs::create_dir_all(&dist_dir) {
+        // 디렉터리조차 못 만들면 RustEmbed 가 명확히 에러를 내도록 그냥 둔다.
+        println!("cargo:warning=secall: web/dist 생성 실패 ({e}). 웹 UI 없이 빌드하려면 --no-default-features 를 사용하세요.");
+        return;
+    }
+
+    if let Err(e) = std::fs::write(&index_html, PLACEHOLDER_INDEX_HTML) {
+        println!("cargo:warning=secall: placeholder index.html 작성 실패 ({e}).");
+        return;
+    }
+
+    println!(
+        "cargo:warning=secall: web/dist 가 없어 placeholder 웹 UI 로 빌드합니다. \
+         실제 웹 UI 를 쓰려면 `cd web && pnpm install && pnpm build` 후 다시 빌드하거나, \
+         웹 UI 가 필요 없으면 `--no-default-features` 로 설치하세요."
+    );
+}
+
+/// dist 가 없을 때 임베드되는 안내 페이지.
+const PLACEHOLDER_INDEX_HTML: &str = r#"<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>seCall — web UI not built</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 42rem; margin: 4rem auto; padding: 0 1.5rem; line-height: 1.6; color: #1a1a1a; }
+  code { background: #f0f0f0; padding: .15em .4em; border-radius: 4px; }
+  pre { background: #f6f8fa; padding: 1rem; border-radius: 8px; overflow-x: auto; }
+  h1 { font-size: 1.4rem; }
+  .muted { color: #666; }
+</style>
+</head>
+<body>
+  <h1>seCall web UI is not built</h1>
+  <p>This binary was compiled without a pre-built <code>web/dist/</code> bundle, so the web UI is a placeholder. The REST API, MCP server, and CLI all work normally.</p>
+  <p>To get the full web UI, build the frontend and reinstall:</p>
+  <pre>cd web
+pnpm install
+pnpm build
+# then rebuild/reinstall secall</pre>
+  <p class="muted">If you don't need the web UI, install with <code>--no-default-features</code> to skip it entirely.</p>
+</body>
+</html>
+"#;


### PR DESCRIPTION
# fix: `cargo install --git` 빌드 실패 해결 (web/dist 없을 때)

## 배경 / 문제

`cargo install --git https://github.com/hang-in/seCall --tag v0.6.2 --locked` 가 다음 에러로 항상 실패합니다:

```
error: #[derive(RustEmbed)] folder '.../crates/secall-core/../../web/dist/' does not exist.
  --> crates/secall-core/src/web/embed.rs:12:1
```

원인:
- `web-ui` 가 **default feature** 이고, `src/web/embed.rs` 의 `#[derive(RustEmbed)] #[folder = "../../web/dist/"]` 가 **release 빌드 시점에** `web/dist/` 폴더를 요구합니다.
- `web/dist/` 는 `pnpm build` 산출물이라 `.gitignore` 대상 → git 체크아웃에 존재하지 않습니다.
- CI/release 워크플로는 항상 `pnpm build` 로 dist 를 먼저 만들지만, `cargo install --git` 으로 받는 외부 사용자는 그 과정을 거치지 않으므로 **무조건 컴파일 실패**합니다.
- 이 회귀는 `docs/reference/web-backlog.md` 에 이미 알려진 이슈로 기록돼 있습니다.

> 임시 우회책: `--no-default-features` 로 설치하면 web-ui 가 빠져 정상 빌드됩니다. 다만 default 설치가 깨져 있는 상태 자체가 문제입니다.

### 플랫폼 무관 (Windows · macOS · Linux 공통)

이 실패는 **OS 와 무관**합니다. 실패 지점이 OS 별 분기 코드가 아니라 `RustEmbed` derive 의 **컴파일 타임 폴더 존재 검사**이고, `embed` 모듈은 모든 플랫폼에서 동일하게 `#[cfg(not(debug_assertions))]`(release 전용) 입니다. 따라서 `cargo install --git ... --tag v0.6.2` (default features) 는 Windows · macOS · Linux 모두에서 동일하게 컴파일 실패합니다.

Releases 의 macOS/Windows 바이너리가 정상인 이유는 플랫폼 차이가 아니라 **빌드 경로 차이** 입니다 — `release.yml` 은 `pnpm build` 로 `web/dist/` 를 먼저 채운 뒤(`web-dist` 아티팩트 download → `cargo build`) 컴파일하므로 폴더가 존재합니다. `cargo install --git` 은 그 단계를 거치지 않는, 어떤 CI 도 커버하지 않는 경로입니다. (참고로 Releases 에 Linux 타깃 바이너리가 없어, Linux 사용자는 이 깨진 `cargo install` 경로로 떠밀려 먼저 드러난 것뿐입니다. release 매트릭스에 Linux 추가는 별개 이슈.)

## 변경 내용

`crates/secall-core/build.rs` (신규) 를 추가합니다. `embed.rs` 등 다른 코드는 변경하지 않습니다.

동작:
1. `web-ui` 기능이 꺼져 있으면(`CARGO_FEATURE_WEB_UI` 미설정) 아무 동작도 하지 않음.
2. `web/dist/index.html` 에 `cargo:rerun-if-changed` 를 걸어, **dist 갱신 후 옛 번들이 embed 되던 staleness 회귀**(web-backlog.md 기록) 도 함께 해소.
3. `web/dist/` 가 이미 있으면 early-return — 실제 번들을 그대로 사용(덮어쓰지 않음, 회귀 없음).
4. `web/dist/` 가 없으면 안내용 placeholder `index.html` 을 생성해 **컴파일이 깨지지 않게** 함. 웹 UI 자리에는 "pnpm build 하거나 `--no-default-features` 로 설치하라"는 안내 페이지가 표시됨. **Node 불필요.**

## 검증 (실제 v0.6.2 클론, release 빌드)

| 경로 | 이전 | 변경 후 |
|---|---|---|
| `cargo build --release -p secall` (web-ui ON), dist 없음 | ❌ 컴파일 실패 | ✅ placeholder 생성 후 성공 |
| `cargo build --release -p secall --no-default-features` | ✅ | ✅ |
| dist 존재 시 | — | ✅ early-return, 덮어쓰지 않음 |

## 트레이드오프 / 대안

- **대안 A (채택):** build.rs 그레이스풀 처리 — Node 없이 default 설치가 항상 성공. dist 미빌드 시 웹 UI 만 placeholder.
- 대안 B: prebuilt `web/dist` 를 repo 에 커밋 → 빌드 산출물을 git 에 보관해야 함.
- 대안 C: 문서/에러만 개선 → default 설치 깨짐은 그대로.

build.rs 가 소스 트리(`web/dist/`)에 placeholder 를 쓰지만, 해당 경로는 `.gitignore` 대상이고 dist 가 없을 때만 1회 생성하므로 커밋/개발 흐름에 영향이 없습니다.

## 영향 범위

- 동작 변경 없음(웹 UI 가 정상 빌드된 환경은 종전과 동일).
- `--no-default-features` 경로 영향 없음.
- 새 의존성 없음(표준 라이브러리만 사용).
