### PR TITLE
feat(install): 원라인 설치 스크립트 (install.sh + install.ps1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+install.sh text eol=lf
+install.ps1 text eol=crlf

--- a/README.en.md
+++ b/README.en.md
@@ -220,9 +220,21 @@ secall lint
 
 ### Step 1. Install
 
-**GitHub Releases (recommended)** — single binary with embedded web UI:
+**One-line install (recommended)** — downloads the release binary and places it on PATH:
 
-Download the binary for your OS from the [Releases page](https://github.com/hang-in/seCall/releases).
+```bash
+# macOS
+curl -fsSL https://raw.githubusercontent.com/hang-in/seCall/main/install.sh | sh
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/hang-in/seCall/main/install.ps1 | iex
+```
+
+> Linux prebuilt binaries are not published yet — use the Cargo build below.
+
+**Manual download** — grab the binary for your OS from the [Releases page](https://github.com/hang-in/seCall/releases):
 - macOS: `secall-aarch64-apple-darwin.tar.gz` / `secall-x86_64-apple-darwin.tar.gz`
 - Windows: `secall-x86_64-pc-windows-msvc.zip` (secall.exe + onnxruntime.dll)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -219,9 +219,21 @@ secall lint
 
 ### Step 1. インストール
 
-**GitHub Releases (推奨)** — Web UI同梱の単一バイナリ:
+**ワンライナーインストール (推奨)** — releaseバイナリを自動取得してPATHに配置:
 
-[Releasesページ](https://github.com/hang-in/seCall/releases) からOSに合ったファイルをダウンロード。
+```bash
+# macOS
+curl -fsSL https://raw.githubusercontent.com/hang-in/seCall/main/install.sh | sh
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/hang-in/seCall/main/install.ps1 | iex
+```
+
+> Linuxのprebuiltバイナリはまだありません — 下記のCargoビルドを利用してください。
+
+**手動ダウンロード** — [Releasesページ](https://github.com/hang-in/seCall/releases) からOSに合ったファイルをダウンロード:
 - macOS: `secall-aarch64-apple-darwin.tar.gz` / `secall-x86_64-apple-darwin.tar.gz`
 - Windows: `secall-x86_64-pc-windows-msvc.zip` (secall.exe + onnxruntime.dll)
 

--- a/README.md
+++ b/README.md
@@ -219,9 +219,21 @@ secall lint
 
 ### Step 1. 설치
 
-**GitHub Releases (권장)** — 웹 UI 포함된 단일 바이너리:
+**원라인 설치 (권장)** — release 바이너리를 자동으로 받아 PATH에 배치:
 
-[Releases 페이지](https://github.com/hang-in/seCall/releases)에서 OS에 맞는 파일 다운로드.
+```bash
+# macOS
+curl -fsSL https://raw.githubusercontent.com/hang-in/seCall/main/install.sh | sh
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/hang-in/seCall/main/install.ps1 | iex
+```
+
+> Linux는 아직 prebuilt 바이너리가 없습니다 — 아래 Cargo 빌드를 사용하세요.
+
+**수동 다운로드** — [Releases 페이지](https://github.com/hang-in/seCall/releases)에서 OS에 맞는 파일 다운로드:
 - macOS: `secall-aarch64-apple-darwin.tar.gz` / `secall-x86_64-apple-darwin.tar.gz`
 - Windows: `secall-x86_64-pc-windows-msvc.zip` (secall.exe + onnxruntime.dll)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -219,9 +219,21 @@ secall lint
 
 ### Step 1. 安装
 
-**GitHub Releases (推荐)** — 含 Web UI 的单一二进制:
+**一行安装 (推荐)** — 自动下载 release 二进制并放入 PATH:
 
-从 [Releases 页面](https://github.com/hang-in/seCall/releases) 下载对应 OS 的文件。
+```bash
+# macOS
+curl -fsSL https://raw.githubusercontent.com/hang-in/seCall/main/install.sh | sh
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/hang-in/seCall/main/install.ps1 | iex
+```
+
+> Linux 暂无 prebuilt 二进制 — 请使用下面的 Cargo 构建。
+
+**手动下载** — 从 [Releases 页面](https://github.com/hang-in/seCall/releases) 下载对应 OS 的文件:
 - macOS: `secall-aarch64-apple-darwin.tar.gz` / `secall-x86_64-apple-darwin.tar.gz`
 - Windows: `secall-x86_64-pc-windows-msvc.zip`（secall.exe + onnxruntime.dll）
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,84 @@
+# seCall installer for Windows — downloads the latest release and places it on PATH.
+#
+#   irm https://raw.githubusercontent.com/hang-in/seCall/main/install.ps1 | iex
+#
+# Environment overrides:
+#   $env:SECALL_VERSION   Pin a release tag (e.g. v0.6.2). Default: latest release.
+#   $env:SECALL_INSTALL   Install directory. Default: %LOCALAPPDATA%\secall\bin
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'hang-in/seCall'
+$Target = 'x86_64-pc-windows-msvc'
+$InstallDir = if ($env:SECALL_INSTALL) { $env:SECALL_INSTALL } else { Join-Path $env:LOCALAPPDATA 'secall\bin' }
+
+function Info($msg) { Write-Host "  $msg" }
+
+# Resolve version (env override or latest release tag).
+if ($env:SECALL_VERSION) {
+    $Version = $env:SECALL_VERSION
+} else {
+    Info 'Resolving latest release...'
+    $latest = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+    $Version = $latest.tag_name
+    if (-not $Version) { throw 'could not determine latest release tag' }
+}
+
+$Asset = "secall-$Target.zip"
+$Url = "https://github.com/$Repo/releases/download/$Version/$Asset"
+
+Info "Installing seCall $Version ($Target)"
+Info "From: $Url"
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("secall-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+try {
+    $zip = Join-Path $tmp $Asset
+    Invoke-WebRequest -Uri $Url -OutFile $zip
+    Expand-Archive -Path $zip -DestinationPath $tmp -Force
+
+    $exe = Join-Path $tmp 'secall.exe'
+    if (-not (Test-Path $exe)) { throw "binary 'secall.exe' not found in $Asset" }
+
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    # Copy both secall.exe and onnxruntime.dll — the DLL must sit beside the binary.
+    Copy-Item -Path (Join-Path $tmp 'secall.exe') -Destination $InstallDir -Force
+    $dll = Join-Path $tmp 'onnxruntime.dll'
+    if (Test-Path $dll) {
+        Copy-Item -Path $dll -Destination $InstallDir -Force
+    }
+} finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}
+
+Info "Installed to: $InstallDir\secall.exe"
+
+# Add install dir to the user PATH if missing.
+# Write via the registry preserving the original value kind: if the user PATH is
+# REG_EXPAND_SZ, plain SetEnvironmentVariable would rewrite it as REG_SZ and freeze
+# %VAR% entries (e.g. %USERPROFILE%\bin) into literal paths. Reading with
+# DoNotExpandEnvironmentNames keeps those tokens intact.
+$key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+if (-not $key) { $key = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment') }
+try {
+    $rawPath = ''
+    $kind = [Microsoft.Win32.RegistryValueKind]::ExpandString  # Windows default for user PATH
+    if ($key.GetValueNames() -contains 'Path') {
+        $rawPath = [string]$key.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        $kind = $key.GetValueKind('Path')
+    }
+
+    $entries = @($rawPath -split ';' | Where-Object { $_ -ne '' })
+    $already = $entries | Where-Object { $_.TrimEnd('\') -ieq $InstallDir.TrimEnd('\') }
+    if (-not $already) {
+        $newPath = if ($rawPath) { "$rawPath;$InstallDir" } else { $InstallDir }
+        $key.SetValue('Path', $newPath, $kind)
+        Info "Added $InstallDir to your user PATH (restart your terminal to pick it up)."
+    }
+} finally {
+    $key.Close()
+}
+
+Write-Host ''
+Info 'Done. Next steps:'
+Info '  secall init      # interactive setup'
+Info '  secall --help'

--- a/install.ps1
+++ b/install.ps1
@@ -29,11 +29,24 @@ $Url = "https://github.com/$Repo/releases/download/$Version/$Asset"
 Info "Installing seCall $Version ($Target)"
 Info "From: $Url"
 
+# Detect an existing install (used later to warn about shadowing copies).
+$prev = Get-Command secall -CommandType Application -ErrorAction SilentlyContinue
+if ($prev) {
+    $prevVer = try { (& $prev.Source --version) 2>$null } catch { $null }
+    Info "Existing install: $($prev.Source) $prevVer"
+}
+
+# A running secall.exe is file-locked and cannot be overwritten — fail fast with a clear message.
+$running = Get-Process -Name secall -ErrorAction SilentlyContinue
+if ($running) {
+    throw "secall is running (PID $($running.Id -join ', ')). Stop it (e.g. 'secall serve' / MCP server) and re-run."
+}
+
 $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("secall-" + [System.Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $tmp -Force | Out-Null
 try {
     $zip = Join-Path $tmp $Asset
-    Invoke-WebRequest -Uri $Url -OutFile $zip
+    Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $zip
     Expand-Archive -Path $zip -DestinationPath $tmp -Force
 
     $exe = Join-Path $tmp 'secall.exe'
@@ -75,7 +88,16 @@ try {
         Info "Added $InstallDir to your user PATH (restart your terminal to pick it up)."
     }
 } finally {
-    $key.Close()
+    if ($key) { $key.Close() }
+}
+
+# Warn if a different secall on PATH would shadow the one just installed.
+$targetBin = Join-Path $InstallDir 'secall.exe'
+if ($prev -and ($prev.Source -ne $targetBin)) {
+    Write-Host ''
+    Info "WARNING: another 'secall' exists at $($prev.Source)"
+    Info "         Depending on PATH order it may shadow the version just installed."
+    Info "         Remove the old copy if you want this one to take effect."
 }
 
 Write-Host ''

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# seCall installer — downloads the latest release binary and places it on PATH.
+#
+#   curl -fsSL https://raw.githubusercontent.com/hang-in/seCall/main/install.sh | sh
+#
+# Environment overrides:
+#   SECALL_VERSION   Pin a release tag (e.g. v0.6.2). Default: latest release.
+#   SECALL_INSTALL   Install directory. Default: $HOME/.local/bin
+set -eu
+
+REPO="hang-in/seCall"
+INSTALL_DIR="${SECALL_INSTALL:-$HOME/.local/bin}"
+
+err() {
+	printf 'error: %s\n' "$1" >&2
+	exit 1
+}
+
+info() {
+	printf '  %s\n' "$1"
+}
+
+# Pick a downloader: curl or wget.
+if command -v curl >/dev/null 2>&1; then
+	dl() { curl -fsSL "$1"; }
+	dl_to() { curl -fsSL "$1" -o "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+	dl() { wget -qO- "$1"; }
+	dl_to() { wget -qO "$2" "$1"; }
+else
+	err "curl or wget is required"
+fi
+
+# Detect target triple from uname.
+os="$(uname -s)"
+arch="$(uname -m)"
+
+case "$os" in
+Darwin)
+	case "$arch" in
+	arm64 | aarch64) target="aarch64-apple-darwin" ;;
+	x86_64) target="x86_64-apple-darwin" ;;
+	*) err "unsupported macOS architecture: $arch" ;;
+	esac
+	;;
+Linux)
+	err "Linux prebuilt binaries are not published yet (see seCall#105).
+    Build from source instead:
+      git clone https://github.com/$REPO.git && cd seCall
+      cargo install --path crates/secall --no-default-features"
+	;;
+*)
+	err "unsupported OS: $os (use install.ps1 on Windows)"
+	;;
+esac
+
+# Resolve version (env override or latest release tag).
+if [ "${SECALL_VERSION:-}" != "" ]; then
+	version="$SECALL_VERSION"
+else
+	info "Resolving latest release..."
+	version="$(dl "https://api.github.com/repos/$REPO/releases/latest" |
+		grep '"tag_name"' | head -1 |
+		sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+	[ "$version" != "" ] || err "could not determine latest release tag"
+fi
+
+asset="secall-$target.tar.gz"
+url="https://github.com/$REPO/releases/download/$version/$asset"
+
+info "Installing seCall $version ($target)"
+info "From: $url"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+dl_to "$url" "$tmp/$asset" || err "download failed: $url"
+tar -xzf "$tmp/$asset" -C "$tmp" || err "extraction failed"
+[ -f "$tmp/secall" ] || err "binary 'secall' not found in $asset"
+
+mkdir -p "$INSTALL_DIR"
+mv "$tmp/secall" "$INSTALL_DIR/secall"
+chmod +x "$INSTALL_DIR/secall"
+
+info "Installed to: $INSTALL_DIR/secall"
+
+# Warn if install dir is not on PATH.
+case ":$PATH:" in
+*":$INSTALL_DIR:"*) ;;
+*)
+	printf '\n'
+	info "NOTE: $INSTALL_DIR is not on your PATH."
+	info "Add it to your shell profile, e.g.:"
+	info "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+	;;
+esac
+
+printf '\n'
+info "Done. Next steps:"
+info "  secall init      # interactive setup"
+info "  secall --help"

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,13 @@ Linux)
 	;;
 esac
 
+# Detect an existing install (used later to warn about shadowing copies).
+prev_bin="$(command -v secall 2>/dev/null || true)"
+if [ "$prev_bin" != "" ]; then
+	prev_ver="$("$prev_bin" --version 2>/dev/null || echo '?')"
+	info "Existing install: $prev_bin ($prev_ver)"
+fi
+
 # Resolve version (env override or latest release tag).
 if [ "${SECALL_VERSION:-}" != "" ]; then
 	version="$SECALL_VERSION"
@@ -72,7 +79,11 @@ info "Installing seCall $version ($target)"
 info "From: $url"
 
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT INT TERM
+cleanup() { rm -rf "$tmp"; }
+trap cleanup EXIT
+# On INT/TERM, exit explicitly so the script stops (the EXIT trap then runs cleanup);
+# a plain cleanup trap on INT/TERM would resume execution on the next line.
+trap 'exit 1' INT TERM
 
 dl_to "$url" "$tmp/$asset" || err "download failed: $url"
 tar -xzf "$tmp/$asset" -C "$tmp" || err "extraction failed"
@@ -94,6 +105,14 @@ case ":$PATH:" in
 	info "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
 	;;
 esac
+
+# Warn if a different secall on PATH would shadow the one just installed.
+if [ "$prev_bin" != "" ] && [ "$prev_bin" != "$INSTALL_DIR/secall" ]; then
+	printf '\n'
+	info "WARNING: another 'secall' exists at $prev_bin"
+	info "         Depending on PATH order it may shadow the version just installed."
+	info "         Remove the old copy if you want this one to take effect."
+fi
 
 printf '\n'
 info "Done. Next steps:"


### PR DESCRIPTION
## 요약

`secall`을 실행 가능 상태로 만드는 경로가 전부 수동(다운로드 → 압축 해제 → PATH 등록)이라 진입 장벽이 높았다. 원라인 설치 스크립트를 추가해 한 줄로 release 바이너리를 받아 PATH에 배치한다.

```bash
# macOS
curl -fsSL https://raw.githubusercontent.com/hang-in/seCall/main/install.sh | sh
```
```powershell
# Windows (PowerShell)
irm https://raw.githubusercontent.com/hang-in/seCall/main/install.ps1 | iex
```

## 변경 내용

- **install.sh** (macOS): `uname` 기반 target 감지(`aarch64`/`x86_64-apple-darwin`), GitHub API로 latest release 자동 조회(`SECALL_VERSION`로 고정 가능), `${SECALL_INSTALL:-~/.local/bin}` 배치 + chmod, PATH 미등록 시 안내. Linux는 prebuilt 자산이 없으므로 소스 빌드 안내 후 종료.
- **install.ps1** (Windows): `x86_64-pc-windows-msvc` zip 다운로드, `secall.exe` + `onnxruntime.dll` 둘 다 `%LOCALAPPDATA%\secall\bin` 배치(DLL 분실 방지), User PATH 등록 시 **레지스트리 값 타입(REG_EXPAND_SZ) 보존** — `%USERPROFILE%` 등 `%VAR%` 항목이 리터럴로 굳는 것을 방지.
- **.gitattributes**: `install.sh`=lf / `install.ps1`=crlf 고정 (CRLF 오염으로 인한 shebang 깨짐 방지).
- **README** (.md/.en/.ja/.zh): 설치 섹션 최상단에 원라인 설치를 권장 경로로 추가, 기존 Releases 다운로드는 "수동 다운로드"로 정리.

## 검증

- `sh -n install.sh` 통과, LF + 실행비트(100755) 확인.
- 세 release 자산 URL(aarch64/x86_64 darwin, windows zip) HTTP 200 확인 — 자산명이 `release.yml` 산출물과 정확히 일치.
- `install.ps1` PowerShell 파서 통과, PATH 읽기 로직을 실제 레지스트리에 대해 read-only dry-run하여 타입 보존·중복 감지 동작 확인.

Closes #105
