### PR TITLE
chore: v0.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 > NOTE: v0.3.x ~ v0.4.x 의 상세 변경 이력은 `README.md` 의 "버전 히스토리" 표 참고. CHANGELOG.md 는 v0.2.x 시점에서 README 로 SSOT 이전됨.
 
-## Unreleased
+## v0.6.3 (2026-06-18)
+
+설치 경험 개선 — `cargo install --git` 빌드 실패 복구 + 원라인 설치 스크립트.
+
+### ✨ Features
+
+- **원라인 설치 스크립트** (#106, Closes #105, 외부 기여 @hohoShin): `curl -fsSL .../install.sh | sh` (macOS) / `irm .../install.ps1 | iex` (Windows) 한 줄로 release 바이너리를 받아 PATH 에 배치. `install.sh` 는 `uname` 기반 target 감지 + GitHub API latest 조회 (`SECALL_VERSION` 고정 가능) + shadowing 경고, `install.ps1` 은 `secall.exe`+`onnxruntime.dll` 동반 복사 + User PATH 등록 시 REG_EXPAND_SZ 타입 보존 + running-process 가드. Linux 는 prebuilt 자산이 없어 소스 빌드 안내. README(.md/.en/.ja/.zh) 설치 섹션에 권장 경로로 추가.
 
 ### 🐛 Fixes
 
-- **`cargo install --git` 빌드 실패 해결** (web-ui default): `web-ui` 기능이 release 빌드 시점에 `web/dist/` (gitignore 된 `pnpm build` 산출물) 를 `rust-embed` 로 요구하는데, `cargo install --git ...` 사용자는 `pnpm build` 를 거치지 않아 `RustEmbed` derive 가 `folder ... does not exist` 로 항상 컴파일 실패하던 문제. `crates/secall-core/build.rs` 추가 — dist 가 없으면 안내용 placeholder `index.html` 을 생성해 컴파일을 살리고(웹 UI 자리에 빌드 안내 페이지 표시, CLI·MCP·REST API 는 정상), dist 가 있으면 그대로 사용한다. 더불어 `web/dist/index.html` 에 `cargo:rerun-if-changed` 를 걸어 dist 갱신 후 옛 번들이 embed 되던 staleness 회귀도 함께 해소. Node 불필요. (웹 UI 가 필요 없으면 종전처럼 `--no-default-features` 로 설치 가능)
+- **`cargo install --git` 빌드 실패 해결** (#104, 외부 기여 @cakel): `web-ui` 기능이 release 빌드 시점에 `web/dist/` (gitignore 된 `pnpm build` 산출물) 를 `rust-embed` 로 요구하는데, `cargo install --git ...` 사용자는 `pnpm build` 를 거치지 않아 `RustEmbed` derive 가 `folder ... does not exist` 로 항상 컴파일 실패하던 문제. `crates/secall-core/build.rs` 추가 — dist 가 없으면 안내용 placeholder `index.html` 을 생성해 컴파일을 살리고(웹 UI 자리에 빌드 안내 페이지 표시, CLI·MCP·REST API 는 정상), dist 가 있으면 그대로 사용한다. 더불어 `web/dist/index.html` 에 `cargo:rerun-if-changed` 를 걸어 dist 갱신 후 옛 번들이 embed 되던 staleness 회귀도 함께 해소. Node 불필요. (웹 UI 가 필요 없으면 종전처럼 `--no-default-features` 로 설치 가능)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,7 +3288,7 @@ checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "secall"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "secall-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ codegen-units = 1
 strip = true
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 rust-version = "1.75"
 license = "AGPL-3.0"


### PR DESCRIPTION
## Summary
설치 경험 개선 release.

- `Cargo.toml` 0.6.2 → 0.6.3 + CHANGELOG v0.6.3

## Includes
- **#104 (@cakel)** — `cargo install --git` 빌드 실패 fix (build.rs placeholder). 깨져 있던 default 설치 경로 복구.
- **#106 (@hohoShin, Closes #105)** — 원라인 설치 스크립트 (install.sh / install.ps1 + README).

## Note
CHANGELOG 에 #106 설치 스크립트 Features 항목을 함께 정리 (squash 머지 시 누락됐던 분 복구).

## Post-merge
1. `git tag v0.6.3` + push
2. `gh release create v0.6.3`
3. #104 / #106 / #105 에 처리 내역 + 감사 댓글

🤖 Generated with [Claude Code](https://claude.com/claude-code)