### PR TITLE
feat: delete sessions from the web UI session list

### DIFF
--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -9,7 +9,7 @@ use axum::{
         sse::{Event, KeepAlive, Sse},
         IntoResponse,
     },
-    routing::{get, patch, post},
+    routing::{delete, get, patch, post},
     Router,
 };
 use futures_util::stream::Stream;
@@ -149,6 +149,7 @@ pub fn rest_router(server: SeCallMcpServer, executor: Arc<JobExecutor>) -> Route
         .route("/api/sessions/{id}/tags", patch(api_set_tags))
         .route("/api/sessions/{id}/favorite", patch(api_set_favorite))
         .route("/api/sessions/{id}/notes", patch(api_set_notes))
+        .route("/api/sessions/{id}", delete(api_delete_session))
         // P33 Task 03 — Job 시스템
         .route("/api/commands/sync", post(api_command_sync))
         .route("/api/commands/ingest", post(api_command_ingest))
@@ -534,6 +535,17 @@ async fn api_set_notes(
     Json(body): Json<SetNotesBody>,
 ) -> impl IntoResponse {
     match s.do_set_notes(&id, body.notes.as_deref()) {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => error_response(e),
+    }
+}
+
+/// `DELETE /api/sessions/{id}` — 세션 완전 삭제 (Web UI 삭제 버튼).
+async fn api_delete_session(
+    State(s): State<Arc<SeCallMcpServer>>,
+    AxumPath(id): AxumPath<String>,
+) -> impl IntoResponse {
+    match s.do_delete_session(&id) {
         Ok(json) => (StatusCode::OK, Json(json)).into_response(),
         Err(e) => error_response(e),
     }

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -1049,6 +1049,17 @@ impl SeCallMcpServer {
         }))
     }
 
+    /// 세션 완전 삭제 — sessions / turns / turns_fts / turn_vectors 전부 제거.
+    /// Web UI 세션 삭제 버튼용. 되돌릴 수 없음.
+    pub fn do_delete_session(&self, session_id: &str) -> anyhow::Result<serde_json::Value> {
+        let db = self
+            .db
+            .lock()
+            .map_err(|_| anyhow::anyhow!("db lock poisoned"))?;
+        db.delete_session_full(session_id)?;
+        Ok(serde_json::json!({ "session_id": session_id, "deleted": true }))
+    }
+
     // ─── Job 시스템 (P33 Task 03) ──────────────────────────────────────────
 
     /// 메모리 또는 DB에서 단일 job 상태 조회. 둘 다 없으면 Ok(None).

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -340,6 +340,9 @@ impl Database {
     /// `--force` 재수집 시 기존 데이터를 정리하는 데 사용.
     pub fn delete_session_full(&self, session_id: &str) -> Result<()> {
         self.delete_session_vectors(session_id)?;
+        // 지식 그래프 노드/엣지 정리 (`session:{id}`) — DELETE 엔드포인트 및
+        // `--force` 재수집에서 고아 그래프 데이터가 남지 않도록 함.
+        self.delete_graph_for_session(session_id)?;
         // FTS5 행 삭제 (turns 삭제 전에 수행 — session_id로 매칭)
         self.conn().execute(
             "DELETE FROM turns_fts WHERE session_id = ?1",

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -43,9 +43,10 @@ export function DeleteSessionDialog({
           <DialogDescription>
             이 작업은 되돌릴 수 없습니다. 세션과 모든 turn·검색 인덱스가 영구
             삭제됩니다.
-            {session?.project ? (
+            {session ? (
               <span className="mt-2 block font-mono text-xs text-text-2">
-                {session.project} · {session.date}
+                {session.project ? `${session.project} · ` : ""}
+                {session.agent} · {session.date}
               </span>
             ) : null}
           </DialogDescription>

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -1,0 +1,68 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { SessionListItem as Session } from "@/lib/types";
+
+interface Props {
+  /** null이면 닫힘. 세션이 지정되면 열림. */
+  session: Session | null;
+  isDeleting: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * 세션 삭제 확인 모달.
+ *
+ * - 제목: "세션을 삭제하시겠습니까?"
+ * - 삭제(destructive=빨강) / 취소(outline=중립) 버튼
+ * - 삭제는 되돌릴 수 없음을 명시.
+ */
+export function DeleteSessionDialog({
+  session,
+  isDeleting,
+  onConfirm,
+  onCancel,
+}: Props) {
+  return (
+    <Dialog
+      open={!!session}
+      onOpenChange={(open) => {
+        if (!open && !isDeleting) onCancel();
+      }}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>세션을 삭제하시겠습니까?</DialogTitle>
+          <DialogDescription>
+            이 작업은 되돌릴 수 없습니다. 세션과 모든 turn·검색 인덱스가 영구
+            삭제됩니다.
+            {session?.project ? (
+              <span className="mt-2 block font-mono text-xs text-text-2">
+                {session.project} · {session.date}
+              </span>
+            ) : null}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel} disabled={isDeleting}>
+            취소
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isDeleting}
+          >
+            {isDeleting ? "삭제 중…" : "삭제"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,9 +1,15 @@
 import { Loader2 } from "lucide-react";
+import { useState } from "react";
 import { useNavigate, useParams } from "react-router";
+import { DeleteSessionDialog } from "./DeleteSessionDialog";
 import { SessionListItem } from "./SessionListItem";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { useListHotkeys } from "@/hooks/useListHotkeys";
-import { useInfiniteSessions, useSemanticRecall } from "@/hooks/useSessions";
+import {
+  useDeleteSession,
+  useInfiniteSessions,
+  useSemanticRecall,
+} from "@/hooks/useSessions";
 import type {
   RecallResultItem,
   SearchMode,
@@ -55,6 +61,21 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const trimmed = query.trim();
+
+  // 세션 삭제 — 확인 모달 대상(null이면 닫힘) + mutation.
+  const [pendingDelete, setPendingDelete] = useState<Session | null>(null);
+  const deleteMutation = useDeleteSession();
+  const confirmDelete = () => {
+    if (!pendingDelete) return;
+    const deletingId = pendingDelete.id;
+    deleteMutation.mutate(deletingId, {
+      onSuccess: () => {
+        setPendingDelete(null);
+        // 삭제한 세션이 현재 열려 있으면 목록으로 이동.
+        if (id === deletingId) navigate("/sessions");
+      },
+    });
+  };
 
   // 시맨틱 모드 + 비어있지 않은 query에서만 recall 호출. 그 외엔 keyword 리스트.
   const useSemantic = mode === "semantic" && trimmed.length > 0;
@@ -150,6 +171,7 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
                   onSelect={() =>
                     navigate(`/sessions/${encodeURIComponent(s.id)}`)
                   }
+                  onDelete={() => setPendingDelete(s)}
                 />
                 {typeof score === "number" && (
                   <span className="absolute right-ds-3 bottom-ds-2 font-mono text-t-caption text-text-4 tabular-nums pointer-events-none">
@@ -160,6 +182,12 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
             );
           })}
         </div>
+        <DeleteSessionDialog
+          session={pendingDelete}
+          isDeleting={deleteMutation.isPending}
+          onConfirm={confirmDelete}
+          onCancel={() => setPendingDelete(null)}
+        />
       </div>
     );
   }
@@ -205,6 +233,7 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
             query={query}
             selected={s.id === id}
             onSelect={() => navigate(`/sessions/${encodeURIComponent(s.id)}`)}
+            onDelete={() => setPendingDelete(s)}
           />
         ))}
       </div>
@@ -224,6 +253,12 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
             끝 — 총 {total} 세션
           </div>
         )}
+      <DeleteSessionDialog
+        session={pendingDelete}
+        isDeleting={deleteMutation.isPending}
+        onConfirm={confirmDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
     </div>
   );
 }

--- a/web/src/components/SessionListItem.tsx
+++ b/web/src/components/SessionListItem.tsx
@@ -1,4 +1,4 @@
-import { Star } from "lucide-react";
+import { Star, X } from "lucide-react";
 import { useMemo } from "react";
 import { AgentDot } from "@/components/AgentDot";
 import { highlightTerms, tokenizeQuery } from "@/lib/highlight";
@@ -19,6 +19,8 @@ interface Props {
   query?: string;
   selected?: boolean;
   onSelect: () => void;
+  /** 지정 시 우측 상단에 삭제(X) 버튼 노출. 클릭하면 호출된다. */
+  onDelete?: () => void;
 }
 
 const MAX_TAGS = 3;
@@ -28,6 +30,7 @@ export function SessionListItem({
   query,
   selected = false,
   onSelect,
+  onDelete,
 }: Props) {
   const tags = session.tags.slice(0, MAX_TAGS);
   const hidden = Math.max(0, session.tags.length - tags.length);
@@ -36,7 +39,8 @@ export function SessionListItem({
   const project = session.project ?? null;
 
   return (
-    <button
+    <div className="relative group">
+      <button
       type="button"
       onClick={onSelect}
       className={[
@@ -110,5 +114,19 @@ export function SessionListItem({
         </div>
       )}
     </button>
+      {onDelete && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          aria-label="세션 삭제"
+          className="absolute right-ds-2 top-ds-2 flex size-6 items-center justify-center rounded-md text-text-4 opacity-0 transition-opacity hover:bg-surface-3 hover:text-status-danger focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-status-danger group-hover:opacity-100"
+        >
+          <X className="size-3.5" />
+        </button>
+      )}
+    </div>
   );
 }

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -1,4 +1,9 @@
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import type { SessionFilterState, SessionsListParams } from "@/lib/types";
 
@@ -101,5 +106,20 @@ export function useSemanticRecall(
     enabled: opts.enabled && trimmed.length > 0,
     staleTime: 60_000,
     placeholderData: (prev) => prev,
+  });
+}
+
+/**
+ * 세션 삭제 — `DELETE /api/sessions/:id`.
+ *
+ * 성공 시 `["sessions"]` 쿼리(list/infinite/detail)를 무효화해 리스트가 자동 갱신된다.
+ */
+export function useDeleteSession() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.deleteSession(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["sessions"] });
+    },
   });
 }

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -120,6 +120,9 @@ export function useDeleteSession() {
     mutationFn: (id: string) => api.deleteSession(id),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["sessions"] });
+      // 시맨틱 검색 결과(["recall","semantic",...])도 무효화 — 시맨틱 모드에서
+      // 삭제 시 목록에서 즉시 사라지도록.
+      qc.invalidateQueries({ queryKey: ["recall"] });
     },
   });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -157,6 +157,13 @@ export const api = {
       { method: "PATCH", body: JSON.stringify({ notes }) },
     ),
 
+  /** 세션 완전 삭제 (`DELETE /api/sessions/:id`). sessions/turns/fts/vectors 제거. */
+  deleteSession: (id: string) =>
+    jfetch<{ session_id: string; deleted: boolean }>(
+      `/api/sessions/${encodeURIComponent(id)}`,
+      { method: "DELETE" },
+    ),
+
   status: () => jfetch<StatusResponse>("/api/status"),
 
   daily: (date?: string) =>


### PR DESCRIPTION
## Summary

Adds the ability to delete a session directly from the web UI session list. Previously, removing a session required CLI/DB access.

## Changes

**Backend**
- New `DELETE /api/sessions/{id}` route → `SeCallMcpServer::do_delete_session` → `delete_session_full`, which removes the session and its `turns`, `turns_fts`, and `turn_vectors` rows. This reuses the same cleanup path already used by `--force` re-ingest, so DB state stays consistent with ingest.

**Web UI**
- `SessionListItem`: hover-revealed top-right **X** button. It calls `stopPropagation` so clicking it never triggers row selection.
- `DeleteSessionDialog`: confirmation modal — "세션을 삭제하시겠습니까?" with a destructive **삭제** and a neutral **취소**.
- `useDeleteSession` mutation invalidates the `["sessions"]` query so the list auto-refreshes after deletion, and navigates back to `/sessions` when the currently-open session is the one deleted.

## Notes
- The session list and DB reflect the deletion immediately. The in-memory ANN (vector) index is rebuilt on the next `serve` start, so semantic search fully reflects deletions after a restart (stale vectors resolve to no session metadata and are filtered out in the meantime).

## Test plan
- `pnpm -C web build` (tsc + vite) — passes
- `cargo build --release` — passes
- `DELETE /api/sessions/{id}` → `200 {"deleted":true}` (idempotent for unknown ids)
- Manual: hover a session row → X → confirm modal → 삭제 removes the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
