### PR TITLE
docs: wiki 백엔드 호환성 명시 + 잘못된 생성 예시 정정

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ vault/
     └── graph.json   # 노드/엣지 데이터
 ```
 
-- **위키 생성**: pluggable LLM backend 기반 (`secall wiki update --backend claude|codex|haiku|ollama|lmstudio`)
+- **위키 생성**: pluggable LLM backend 기반 (`secall wiki update --backend claude|codex|haiku` — 생성은 도구 호출 가능 백엔드만; ollama/lmstudio 는 review 전용)
 - **Obsidian 백링크** (`[[]]`)로 세션 ↔ 위키 페이지 연결
 - Dataview 쿼리를 위한 frontmatter 메타데이터 (`summary` 필드로 세션 내용 즉시 파악)
 
@@ -526,18 +526,18 @@ secall wiki update
 # Codex CLI 백엔드
 secall wiki update --backend codex
 
-# 로컬 LLM 백엔드
-secall wiki update --backend ollama
-secall wiki update --backend lmstudio
-
 # Anthropic API (haiku — 직접 API 호출)
 secall wiki update --backend haiku
 
 # 특정 세션만 증분 업데이트
-secall wiki update --backend lmstudio --session <id>
+secall wiki update --backend codex --session <id>
 
 # 오프라인 / 수동 sync 모드
 secall wiki update --no-pull
+
+# 백엔드 호환성: 생성(generation)은 도구 호출이 가능한 claude/codex/haiku 만 동작.
+# ollama/lmstudio 는 생성 불가(도구 호출 미지원) — review 백엔드로만 사용.
+# 자세한 표: docs/reference/wiki-setup.md "백엔드 호환성"
 
 # 위키 상태 확인
 secall wiki status

--- a/docs/reference/wiki-setup.md
+++ b/docs/reference/wiki-setup.md
@@ -54,8 +54,8 @@ Claude Code 메타에이전트를 활용해 에이전트 세션 로그에서 Obs
 | `claude` | ✅ | ✅ | Claude Code CLI (MCP 통합). 단 2026-06-15 이후 구독은 credit pool 소진 — 대량 생성 시 비용 주의 |
 | `codex` | ✅ | ✅ | Codex CLI |
 | `haiku` | ✅ | ✅ | Anthropic API — 세션 데이터를 prompt 에 inline (도구 불필요). `ANTHROPIC_API_KEY` 필요 |
-| `ollama` | ❌ | — | HTTP, 도구 호출 불가 → 생성 시 명시적 에러 (issue #88) |
-| `lmstudio` | ❌ | — | 위와 동일 |
+| `ollama` | ❌ | ✅ | 생성은 도구 호출 불가 → 명시적 에러 (issue #88). 검토는 `OllamaReviewer` 로 지원 |
+| `lmstudio` | ❌ | ✅ | 위와 동일 (`LmStudioReviewer`) |
 | `ollama_cloud` | ⚠️ 비권장 | ✅ | review 는 정상. 생성은 도구 호출 불가라 빈 결과가 날 수 있음 — `--review` 백엔드로만 권장 |
 
 > **참고**: graph 시맨틱 추출과 log 일기는 별개로, 이미 `ollama_cloud` (`OLLAMA_CLOUD_API_KEY`) 를 기본으로 외부 에이전트 CLI 없이 동작합니다. 즉 **외부 CLI 가 꼭 필요한 건 wiki 본문 생성 뿐**입니다.

--- a/docs/reference/wiki-setup.md
+++ b/docs/reference/wiki-setup.md
@@ -42,6 +42,26 @@ Claude Code 메타에이전트를 활용해 에이전트 세션 로그에서 Obs
 
 ---
 
+## 백엔드 호환성
+
+`wiki update` 의 **생성(generation)** 과 **검토(review)** 는 요구하는 능력이 다릅니다.
+
+- **생성(batch / incremental)** — prompt 가 MCP 도구 호출(`secall recall`/`get`/`status`)과 `wiki/` 파일 쓰기를 능동적으로 수행해야 합니다. 따라서 **도구 호출이 가능한 에이전트 CLI** 만 동작합니다.
+- **검토(`--review`)** — 생성된 페이지 텍스트를 받아 평가만 하므로 일반 LLM HTTP 백엔드로도 됩니다.
+
+| backend | 생성 (`wiki update`) | 검토 (`--review`) | 비고 |
+|---|---|---|---|
+| `claude` | ✅ | ✅ | Claude Code CLI (MCP 통합). 단 2026-06-15 이후 구독은 credit pool 소진 — 대량 생성 시 비용 주의 |
+| `codex` | ✅ | ✅ | Codex CLI |
+| `haiku` | ✅ | ✅ | Anthropic API — 세션 데이터를 prompt 에 inline (도구 불필요). `ANTHROPIC_API_KEY` 필요 |
+| `ollama` | ❌ | — | HTTP, 도구 호출 불가 → 생성 시 명시적 에러 (issue #88) |
+| `lmstudio` | ❌ | — | 위와 동일 |
+| `ollama_cloud` | ⚠️ 비권장 | ✅ | review 는 정상. 생성은 도구 호출 불가라 빈 결과가 날 수 있음 — `--review` 백엔드로만 권장 |
+
+> **참고**: graph 시맨틱 추출과 log 일기는 별개로, 이미 `ollama_cloud` (`OLLAMA_CLOUD_API_KEY`) 를 기본으로 외부 에이전트 CLI 없이 동작합니다. 즉 **외부 CLI 가 꼭 필요한 건 wiki 본문 생성 뿐**입니다.
+
+---
+
 ## 수동 실행
 
 ### 전체 배치 업데이트


### PR DESCRIPTION
## Summary
2026-06 외부 CLI 변동(Gemini CLI 6/18 종료 → Antigravity, Claude Code 6/15 credit pool 빌링) 점검 중 발견한 **문서-동작 불일치** 수정.

wiki **generation** 은 MCP 도구 호출(`secall recall`/`get` + `wiki/` 파일 쓰기)이 가능한 백엔드만 동작하는데(claude/codex/haiku), README 가 `ollama`/`lmstudio` 를 generation 예시로 안내해 오해 소지가 있었습니다. (P86 에서 ollama/lmstudio generation 은 이미 차단, `ollama_cloud` 는 fail-fast 에서 누락돼 도구 호출 불가인데도 통과 → review 전용으로만 권장.)

## 변경 (문서만, 코드 0)
- `docs/reference/wiki-setup.md` — **"백엔드 호환성" 섹션** 추가: 생성/검토 능력 매트릭스. graph/log 는 `ollama_cloud` default 라 외부 CLI 불필요 → **외부 에이전트 CLI 가 꼭 필요한 건 wiki 본문 생성뿐** 임을 명시.
- `README.md` — `--backend ollama|lmstudio` 생성 예시 제거 + 호환성 주석 + wiki-setup.md 링크. 기능 요약 줄도 정정.

## 배경 (참고)
- secall 핵심 운영(검색/graph/log/wiki review)은 `OLLAMA_CLOUD_API_KEY` 로 외부 CLI 없이 동작 → Gemini CLI 종료/Claude 빌링 변경의 직접 타격 작음.
- Antigravity(`agy`) 세션 ingest 는 포맷이 `.pb`(protobuf)/`.db`(sqlite, 비공개 schema)라 별도 큰 작업 — 이 PR 범위 밖.

## Test plan
- [x] 문서만 변경 (cargo 영향 없음)
- [x] 마크다운 표/링크 sanity

## Follow-up (별도, 이 PR 아님)
- P86 fail-fast 에 `ollama_cloud` generation 추가 (도구 호출 불가인데 통과하는 누락) — 코드 정합성 fix 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)