### PR TITLE
fix: 백로그 정리 — wiki ollama_cloud fail-fast + gemini doc 잔재 + Antigravity 조사

### DIFF
--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -190,12 +190,17 @@ async fn run_update_with_sink(
         .unwrap_or_else(|| config.wiki.default_backend.clone());
     let resolved_model = resolve_backend_model(&config, &backend_name, model);
 
-    // P86 (issue #88): ollama / lmstudio 백엔드는 wiki update 의 prompt 가
-    // 가정하는 MCP 도구 호출 (`secall recall/get/status` + `wiki/` 파일 쓰기) 을
-    // 수행할 능력이 없다. batch / incremental / --since 모든 모드에서 모델이
+    // P86 (issue #88): ollama / lmstudio / ollama_cloud 백엔드는 wiki update 의
+    // prompt 가 가정하는 MCP 도구 호출 (`secall recall/get/status` + `wiki/` 파일
+    // 쓰기) 을 수행할 능력이 없다. batch / incremental / --since 모든 모드에서 모델이
     // "임무 이해" 응답만 출력하고 종료 → 사용자가 silent wait (timeout 까지)
     // 후 빈손으로 깨닫는 사고. 명시적 fail-fast + 가이드.
-    if matches!(backend_name.as_str(), "ollama" | "lmstudio") {
+    // ollama_cloud 도 원격 API 호출이라 MCP 도구가 없어 동일하게 빈손 실패한다.
+    // (build_wiki_backend 의 ollama_cloud arm 은 review backend 전용 — generation 불가)
+    if matches!(
+        backend_name.as_str(),
+        "ollama" | "lmstudio" | "ollama_cloud"
+    ) {
         anyhow::bail!(
             "wiki backend `{backend_name}` 는 wiki update 와 호환되지 않습니다.\n\
              도구 호출 (`secall recall`/`get`/`status` + `wiki/` 파일 쓰기) 능력이 없어\n\

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -306,7 +306,7 @@ enum LlmAction {
     Set { key: String, value: String },
     /// Test LLM backend connectivity and credentials
     Test {
-        /// Backend: claude | codex | haiku | ollama | lmstudio | gemini
+        /// Backend: claude | codex | haiku | ollama | lmstudio | ollama_cloud
         backend: Option<String>,
         /// Skip outbound network calls and only verify local prerequisites
         #[arg(long)]
@@ -411,16 +411,16 @@ enum GraphAction {
         /// 처리할 최대 세션 수 (기본: 전체)
         #[arg(long)]
         limit: Option<usize>,
-        /// LLM 백엔드 오버라이드: "ollama" | "gemini" | "anthropic" | "lmstudio" | "disabled"
+        /// LLM 백엔드 오버라이드: "ollama" | "ollama_cloud" | "anthropic" | "lmstudio" | "disabled"
         #[arg(long)]
         backend: Option<String>,
         /// API base URL (예: http://localhost:11434, Ollama 전용)
         #[arg(long)]
         api_url: Option<String>,
-        /// 모델명 오버라이드 (예: gemma4:e4b, gemini-2.5-flash)
+        /// 모델명 오버라이드 (예: gemma4:e4b)
         #[arg(long)]
         model: Option<String>,
-        /// API 키 오버라이드 (Gemini 등). 보안상 환경변수 SECALL_GRAPH_API_KEY 사용 권장
+        /// API 키 오버라이드 (ollama_cloud용 → cloud_api_key). 보안상 환경변수 OLLAMA_CLOUD_API_KEY 사용 권장
         #[arg(long)]
         api_key: Option<String>,
     },

--- a/docs/reference/antigravityIngestFeasibility.md
+++ b/docs/reference/antigravityIngestFeasibility.md
@@ -1,0 +1,76 @@
+---
+type: reference
+status: done
+updated_at: 2026-06-26
+canonical: true
+---
+
+# Antigravity CLI 세션 ingest — feasibility 조사
+
+> 2026-06-26 실데이터 조사. 핸드오프 `handoff_2026-06-25.md` §4 백로그
+> "Antigravity 세션 ingest (추측 구현 금지)" 항목의 근거 문서.
+> **결론: 현재는 보류. 정식 파서 = 비공개 protobuf schema 역공학이라 fragile.**
+
+---
+
+## 1. 데이터 위치 / 형식
+
+`~/.gemini/antigravity-cli/conversations/` — 대화 12개 (2026-06 기준):
+
+| 형식 | 개수 | 비고 |
+|---|---|---|
+| `.pb` (protobuf 바이너리) | 11 | 212KB ~ 27MB |
+| `.db` (SQLite, WAL) | 1 | 신형식으로 보임 — **마이그레이션 진행 중** (1/12만 전환) |
+
+부수 파일:
+- `~/.gemini/antigravity-cli/history.jsonl` (140줄) — user 프롬프트 인덱스
+- `~/.gemini/antigravity-cli/cache/*.json` — last_conversations / projects 메타데이터
+
+## 2. `.db` 구조 (SQLite로 직접 조회)
+
+`.db`도 결국 **protobuf blob 컨테이너**다. 핵심 테이블:
+
+- `trajectory_meta(trajectory_id, cascade_id, trajectory_type, source)`
+- `steps(idx, step_type, status, has_subtrajectory, metadata BLOB, ..., step_payload BLOB, step_format)`
+- `gen_metadata` / `executor_metadata` / `parent_references` / `trajectory_metadata_blob` / `battle_mode_infos` — 전부 `data BLOB`
+
+대화 본문은 `steps.step_payload`(BLOB)에 **protobuf로 인코딩**되어 들어있다.
+`step_type` 은 enum(관측값: 15/14/21/101/138/8/9/23/98 …), `step_format`/`trajectory_type`/`source` 도 정수 enum — **의미 미문서**.
+
+## 3. 텍스트는 복원되나 구조는 schema-lock
+
+- `strings` 로 본문 추출은 됨. 실제 확인된 예 (step_type 101, 16KB payload):
+  `[Message] timestamp=2026-06-19T03:41:55Z sender=.../task-20 priority=MESSAGE_PRIORITY_HIGH content=...`
+  + task 결과 / tool 출력 prose 포함.
+- 그러나 **구조 해독 불가**:
+  - 제공되는 `.proto` / descriptor **없음** (SDK 플러그인 dir·agentapi 바이너리에 타입명 미노출)
+  - `protoc` 미설치 (`--decode_raw` 도 불가)
+  - 데이터 모델이 **"trajectory + steps"(에이전트 스텝, `has_subtrajectory` 계층)** — Claude/Codex/Gemini-CLI 의 단순 user/assistant **turn** 모델과 근본적으로 다름. seCall `Session{turns:[{role,content}]}` 로 매핑하려면 step_type→role 해석 + sub-trajectory 평탄화가 필요.
+
+## 4. `history.jsonl` (쉬운 경로 후보) — 불충분
+
+- 키: `conversationId / display / timestamp / workspace`
+- **`display` = user 프롬프트만**. assistant 응답·tool·turn 구조 없음.
+- user-프롬프트-only "세션"은 즉시 가능하나 recall/wiki/graph 품질엔 거의 무가치.
+
+## 5. 판정
+
+| 경로 | 가능성 | 가치 | 평가 |
+|---|---|---|---|
+| `.pb`/`.db` protobuf 정식 파싱 | proto 없어 wire-format 역공학 필요 | 높음 (풀 대화) | ❌ 지금은 fragile |
+| `history.jsonl` ingest | 즉시 가능 (안정 JSON) | 낮음 (프롬프트만) | △ 품질 미달 |
+| 보류 (proto/schema 공개 대기) | — | — | ✅ **권장** |
+
+Google 프리뷰 제품이라 schema churn 위험이 크고, `.pb`→`.db` 마이그레이션도 진행 중.
+핸드오프의 "추측 구현 금지 / schema 안정화 후 별도 P" 가 실데이터로 확인됨.
+
+## 6. 재개 트리거 (구체적 조건)
+
+다음 중 하나가 충족되면 정식 파서 작성을 재검토한다 (그게 "schema 안정화"의 구체 정의):
+
+- Antigravity 가 `.proto` 정의 또는 protobuf descriptor 를 공개 / SDK 에 포함
+- `.db` 형식으로 전 대화 마이그레이션 완료 + 스키마 안정 (step_type enum 문서화)
+- 공식 export 명령(`agy export` 등) 제공 → 안정 포맷으로 우회
+
+조사 방법(재현): `.db` 는 read-only 복사 후 `sqlite3 <copy> ".schema"` + `step_payload` 를 `strings`.
+원본은 절대 수정하지 말 것 (실행 중 앱이 WAL 점유).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -41,6 +41,7 @@ seCall 의 현재 기준 사실(SSOT) 문서 인덱스. 모든 항목은 "지금
 
 - [adr-blocking-io-in-async.md](adr-blocking-io-in-async.md) — ADR: async 내 blocking I/O 는 `spawn_blocking` 으로 래핑 (CLI 특성상 정당) · 상태: done
 - [idea-two-tier-llm-pipeline.md](idea-two-tier-llm-pipeline.md) — 아이디어: 2계층 LLM 파이프라인 (저비용 초안 → 고품질 검수) · 상태: draft, canonical: false
+- [antigravityIngestFeasibility.md](antigravityIngestFeasibility.md) — Antigravity CLI 세션 ingest feasibility (비공개 protobuf schema → 현재 보류, 재개 트리거 명시) · 상태: done
 
 ## CLI Reference
 
@@ -52,18 +53,18 @@ seCall 의 현재 기준 사실(SSOT) 문서 인덱스. 모든 항목은 "지금
 |--------|------|--------|
 | `--delay <SECS>` | 세션 간 대기 시간 (소수점 가능) | 2.5 |
 | `--limit <N>` | 최대 처리 세션 수 | 전체 |
-| `--backend <NAME>` | LLM 백엔드 (`ollama`/`gemini`/`anthropic`/`disabled`) | config.toml |
+| `--backend <NAME>` | LLM 백엔드 (`ollama`/`ollama_cloud`/`anthropic`/`lmstudio`/`disabled`) | config.toml |
 | `--api-url <URL>` | API base URL (Ollama 전용) | config.toml |
-| `--model <NAME>` | 모델명 (예: `gemma4:e4b`, `gemini-2.5-flash`) | config.toml |
-| `--api-key <KEY>` | API 키 (Gemini 등). 환경변수 사용 권장 | config.toml |
+| `--model <NAME>` | 모델명 (예: `gemma4:e4b`) | config.toml |
+| `--api-key <KEY>` | API 키 (ollama_cloud용 → `cloud_api_key`). 환경변수 사용 권장 | config.toml |
 
 **환경변수** (우선순위: CLI 플래그 > 환경변수 > config.toml > 기본값):
 
 | 환경변수 | 용도 | 예시 값 |
 |----------|------|---------|
-| `SECALL_GRAPH_BACKEND` | 시맨틱 백엔드 | `gemini`, `ollama`, `disabled` |
+| `SECALL_GRAPH_BACKEND` | 시맨틱 백엔드 | `ollama_cloud`, `ollama`, `disabled` |
 | `SECALL_GRAPH_API_URL` | API base URL (Ollama용) | `http://localhost:11434` |
-| `SECALL_GRAPH_MODEL` | 모델명 | `gemma4:e4b`, `gemini-2.5-flash` |
-| `SECALL_GRAPH_API_KEY` | API 키 | `AIza...` |
+| `SECALL_GRAPH_MODEL` | 모델명 | `gemma4:e4b` |
+| `OLLAMA_CLOUD_API_KEY` | ollama_cloud API 키 (graph/log/embedding 공용) | `...` |
 
-> **참고**: `SECALL_GEMINI_API_KEY`(기존)와 `SECALL_GRAPH_API_KEY`(신규)가 모두 설정된 경우, `SECALL_GRAPH_API_KEY`가 우선 적용됩니다.
+> **참고**: ollama_cloud API 키는 `OLLAMA_CLOUD_API_KEY` 환경변수 또는 `--api-key` 플래그로 제공한다. anthropic 백엔드는 `ANTHROPIC_API_KEY` 를 직접 읽는다. (구 `SECALL_GEMINI_API_KEY`·`SECALL_GRAPH_API_KEY` 는 `apply_env_overrides` 에서 더 이상 읽지 않음 — gemini 백엔드 제거 잔재)


### PR DESCRIPTION
## 요약

핸드오프 `handoff_2026-06-25.md` §4 백로그 중 **실행 가능한 항목**을 처리하고, 보류 항목은 추측 구현 대신 **조사 결과를 문서화**했다.

## 변경

### #1 wiki generation fail-fast 에 `ollama_cloud` 추가 (동작 변경)
- `crates/secall/src/commands/wiki.rs`
- wiki generation 은 `haiku` 외 모든 백엔드가 MCP 도구호출 프롬프트(`load_batch/incremental_prompt`)를 받는다. `ollama_cloud` 는 원격 API 호출이라 도구가 없어 `ollama`/`lmstudio` 와 똑같이 빈손 silent fail → fail-fast 목록에 추가.
- `build_wiki_backend` 의 `ollama_cloud` arm 은 **review backend 전용**이지 generation 용이 아님.
- wiki 기본 백엔드 = `claude` 확인됨 → 명시적 `--backend ollama_cloud` 만 차단, 기본 동작 무영향.

### #2 gemini 백엔드 doc 잔재 정리 (문서)
- `crates/secall/src/main.rs`, `docs/reference/index.md`
- `test_backend`(config.rs) / graph `build_backend`(semantic.rs) 어디에도 `gemini` arm 없음(`_ => "unsupported backend"`) → 미연결 dead option. 백엔드 옵션 목록에서 제거하고 실제 dispatch arm(`ollama_cloud`/`anthropic`/`lmstudio`) 반영.
- ⚠️ **요청 범위 확장(보고)**: index.md CLI Reference 의 graph api-key env 문서가 **실제로 안 읽히는** `SECALL_GRAPH_API_KEY`·`SECALL_GEMINI_API_KEY` 를 권장하고 있었음(`apply_env_overrides` 에서 미독). 실제 동작하는 `OLLAMA_CLOUD_API_KEY` 환경변수 / `--api-key` 플래그로 정정. (gemini 백엔드는 ingest **세션 파싱**에서만 활성 — 건드리지 않음.)

### #3 Antigravity ingest feasibility 조사 (문서, 보류 유지)
- `docs/reference/antigravityIngestFeasibility.md` (신규)
- 실데이터 조사: `~/.gemini/antigravity-cli/conversations/` 는 protobuf(`.pb` 11 + SQLite-wrapped `.db` 1, 마이그레이션 중). 본문은 `steps.step_payload` protobuf blob, **제공 .proto/descriptor 없음**, `protoc` 미설치. 데이터 모델이 turn 이 아니라 "trajectory+steps".
- 결론: 정식 파서 = 비공개 schema 역공학이라 fragile → **보류**. 재개 트리거(proto 공개 / db 마이그레이션 완료 / 공식 export) 명시.

## 보류 (핸드오프 §4 — 사용자 결정 do-not-do)
- Gemini 리팩토링 2건("지금 건드리지 말 것"), local stale branch 2개("보존") → 그대로 둠.

## 검증 (로컬, CI 대체)
- ✅ `cargo fmt --check`
- ✅ `cargo clippy --workspace --all-targets -- -D warnings`
- ✅ `cargo test --workspace` (all passed)
- ✅ `cargo build -p secall`

## 후속 finding (이 PR 범위 밖)
- `docs/reference/llm-config.md` 에도 gemini 언급 잔재 가능성 — 미확인, 별도 점검 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
