### PR TITLE
feat(sync): 시맨틱 엣지 추출 진행을 CLI 에 세션별 출력

### DIFF
--- a/crates/secall/src/commands/ingest.rs
+++ b/crates/secall/src/commands/ingest.rs
@@ -775,6 +775,7 @@ async fn extract_semantic_edges_batch(
         // 동작 변경 없음 — 기존 tracing::warn/debug 메시지 그대로 보존.
         match extract_one_session_semantic(db, config, session_id).await {
             ExtractOneResult::Extracted(n) => {
+                eprintln!("  [{}/{}] {} — {} edges", sem_idx + 1, total_sem, short, n);
                 tracing::debug!(session = short, edges = n, "semantic edges extracted");
                 // P37 rework — 추출 성공 세션은 timestamp 갱신.
                 // graph rebuild 경로(graph.rs:280) 와 동일 동작 → ingest 후 NULL 로 남지 않음.
@@ -788,9 +789,23 @@ async fn extract_semantic_edges_batch(
                 }
             }
             ExtractOneResult::Skipped(reason) => {
+                eprintln!(
+                    "  [{}/{}] {} — skipped ({})",
+                    sem_idx + 1,
+                    total_sem,
+                    short,
+                    reason
+                );
                 tracing::debug!(session = short, "semantic extraction skipped: {}", reason)
             }
             ExtractOneResult::Failed(e) => {
+                eprintln!(
+                    "  [{}/{}] {} — FAILED: {}",
+                    sem_idx + 1,
+                    total_sem,
+                    short,
+                    e
+                );
                 tracing::warn!(session = short, "semantic extraction skipped: {}", e)
             }
         }


### PR DESCRIPTION
## 배경

`secall sync` 의 ingest phase 시맨틱 추출(`extract_semantic_edges_batch`)이 세션별 진행을 `tracing::debug` 로만 남겨, CLI(`NoopSink`)에서는 시작 헤더 한 줄 뒤 **무출력**이었다. ollama_cloud(gemma4:31b-cloud) LLM 호출이 세션 수만큼 도는 동안 멈춘 것처럼 보여, 사용자가 진행 여부를 알 수 없었다.

## 변경

`graph semantic`(`graph.rs:119`)과 동일 톤으로 세션별 `[i/N]` stderr 라인을 추가:

```
Extracting semantic edges for 12 session(s)...
  [1/12] a1b2c3d4 — 5 edges
  [2/12] e5f6a7b8 — skipped (no vault_path)
  [3/12] 90abcdef — FAILED: timeout
```

- `crates/secall/src/commands/ingest.rs` 의 `extract_semantic_edges_batch` 루프 3개 분기(Extracted/Skipped/Failed)에 eprintln 추가
- 기존 tracing 메시지/동작은 그대로 유지 (출력만 추가, 로직 변경 없음)

## 영향

- CLI sync 에서 시맨틱 단계 진행이 보임 (요청사항)
- 헤더 eprintln(기존 line 752)과 동일하게 sink 무관 출력 → 웹/REST 경유 sync 시에도 서버 stderr 로그에 동일 라인 남음 (기존 헤더와 일관)

## 검증

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ (전 suite 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)