### PR TITLE
fix(reindex): zero-turn 세션 vault healing + 경로 canonical 통일

### DIFF
--- a/crates/secall-core/src/graph/build.rs
+++ b/crates/secall-core/src/graph/build.rs
@@ -41,7 +41,7 @@ pub fn build_graph(
     since: Option<&str>,
     force: bool,
 ) -> Result<BuildResult> {
-    let sessions_dir = vault_path.join("raw").join("sessions");
+    let sessions_dir = crate::vault::sessions_subdir(vault_path);
     if !sessions_dir.exists() {
         return Ok(BuildResult::default());
     }
@@ -237,7 +237,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn write_session_md(dir: &Path, session_id: &str, date: &str, project: &str) {
-        let date_dir = dir.join("raw").join("sessions").join(date);
+        let date_dir = crate::vault::sessions_subdir(dir).join(date);
         std::fs::create_dir_all(&date_dir).unwrap();
         let path = date_dir.join(format!("{}.md", session_id));
         let content = format!(

--- a/crates/secall-core/src/ingest/markdown.rs
+++ b/crates/secall-core/src/ingest/markdown.rs
@@ -86,6 +86,7 @@ pub fn parse_session_turns(content: &str) -> crate::error::Result<Vec<super::typ
     // (index, role, content lines)
     let mut cur: Option<(u32, Role, Vec<String>)> = None;
     let mut last_role: Option<Role> = None;
+    let mut in_code_block = false;
 
     fn flush(cur: &mut Option<(u32, Role, Vec<String>)>, turns: &mut Vec<Turn>) {
         if let Some((index, role, lines)) = cur.take() {
@@ -104,6 +105,23 @@ pub fn parse_session_turns(content: &str) -> crate::error::Result<Vec<super::typ
     }
 
     for line in body.lines() {
+        // fenced code block 토글 — 코드블록 내부의 "## Turn"/"### Turn" 라인을
+        // 실제 turn 헤더로 오인하지 않도록 추적한다 (세션 본문이 vault 포맷을
+        // 코드블록으로 인용하는 메타 세션에서 오파싱 방지).
+        if line.trim_start().starts_with("```") {
+            in_code_block = !in_code_block;
+            if let Some((_, _, lines)) = cur.as_mut() {
+                lines.push(line.to_string());
+            }
+            continue;
+        }
+        if in_code_block {
+            if let Some((_, _, lines)) = cur.as_mut() {
+                lines.push(line.to_string());
+            }
+            continue;
+        }
+
         if let Some(rest) = line.strip_prefix("## Turn ") {
             match parse_turn_heading_h2(rest) {
                 Some((n, role)) => {

--- a/crates/secall-core/src/ingest/markdown.rs
+++ b/crates/secall-core/src/ingest/markdown.rs
@@ -59,6 +59,106 @@ pub fn extract_body_text(content: &str) -> String {
         .to_string()
 }
 
+/// vault 세션 Markdown 본문을 turn 단위로 역파싱한다 (`render_session` 의 역방향).
+///
+/// 헤딩 규칙:
+/// - `## Turn N — Role` → turn (index=N-1, role=Role)
+/// - `### Turn N` → 직전 turn 의 role 을 상속 (P49 연속 role 헤더 축약의 역)
+///
+/// 본문(thinking/tool callout 포함)은 검색 가능한 텍스트 그대로 content 에 보존한다.
+/// frontmatter 및 첫 turn 이전 영역(세션 요약 등)은 turn content 에 포함하지 않는다.
+///
+/// 주의: 렌더링은 lossy 하다 (`escape_dataview_fields` 의 zero-width space 삽입,
+/// `collapse_blank_lines`, tool 출력 `TOOL_OUTPUT_MAX_CHARS` 절단). 따라서 복원된
+/// turn 은 원본과 byte-identical 하지 않은 **재구성본**이며 FTS/임베딩 검색 목적에
+/// 한해 유효하다. CRLF/LF 모두 지원하며 malformed 헤딩은 panic 없이 처리한다.
+pub fn parse_session_turns(content: &str) -> crate::error::Result<Vec<super::types::Turn>> {
+    use super::types::Turn;
+
+    // CRLF/LF normalize 후 frontmatter 제거
+    let normalized = content.replace("\r\n", "\n");
+    let body = normalized
+        .split_once("\n---\n")
+        .map(|(_, b)| b)
+        .unwrap_or(normalized.as_str());
+
+    let mut turns: Vec<Turn> = Vec::new();
+    // (index, role, content lines)
+    let mut cur: Option<(u32, Role, Vec<String>)> = None;
+    let mut last_role: Option<Role> = None;
+
+    fn flush(cur: &mut Option<(u32, Role, Vec<String>)>, turns: &mut Vec<Turn>) {
+        if let Some((index, role, lines)) = cur.take() {
+            let content = lines.join("\n").trim().to_string();
+            turns.push(Turn {
+                index,
+                role,
+                timestamp: None,
+                content,
+                actions: Vec::new(),
+                tokens: None,
+                thinking: None,
+                is_sidechain: false,
+            });
+        }
+    }
+
+    for line in body.lines() {
+        if let Some(rest) = line.strip_prefix("## Turn ") {
+            match parse_turn_heading_h2(rest) {
+                Some((n, role)) => {
+                    flush(&mut cur, &mut turns);
+                    last_role = Some(role);
+                    cur = Some((n.saturating_sub(1), role, Vec::new()));
+                }
+                // malformed h2 헤딩: 유실 방지 위해 현재 turn 본문으로 취급
+                None => {
+                    if let Some((_, _, lines)) = cur.as_mut() {
+                        lines.push(line.to_string());
+                    }
+                }
+            }
+        } else if let Some(rest) = line.strip_prefix("### Turn ") {
+            match parse_turn_heading_h3(rest) {
+                Some(n) => {
+                    let role = last_role.unwrap_or(Role::User);
+                    flush(&mut cur, &mut turns);
+                    cur = Some((n.saturating_sub(1), role, Vec::new()));
+                }
+                None => {
+                    if let Some((_, _, lines)) = cur.as_mut() {
+                        lines.push(line.to_string());
+                    }
+                }
+            }
+        } else if let Some((_, _, lines)) = cur.as_mut() {
+            lines.push(line.to_string());
+        }
+        // 첫 turn 헤딩 이전 라인(요약/헤더)은 무시
+    }
+    flush(&mut cur, &mut turns);
+
+    Ok(turns)
+}
+
+/// `## Turn ` 접두 제거 후 나머지("N — Role" 또는 "N — Role (HH:MM)")에서 (N, Role) 추출.
+fn parse_turn_heading_h2(rest: &str) -> Option<(u32, Role)> {
+    let (num_part, role_part) = rest.split_once(" — ")?;
+    let n: u32 = num_part.trim().parse().ok()?;
+    let role = match role_part.split_whitespace().next()? {
+        "User" => Role::User,
+        "Assistant" => Role::Assistant,
+        "System" => Role::System,
+        _ => return None,
+    };
+    Some((n, role))
+}
+
+/// `### Turn ` 접두 제거 후 나머지("N" 또는 "N (HH:MM)")에서 N 추출.
+fn parse_turn_heading_h3(rest: &str) -> Option<u32> {
+    rest.split_whitespace().next()?.parse().ok()
+}
+
 const TOOL_OUTPUT_MAX_CHARS: usize = 500;
 
 /// Render a Session to Obsidian-compatible Markdown string
@@ -881,5 +981,89 @@ mod tests {
             md.contains("## Turn 4 — User"),
             "role change back to User must emit h2 again"
         );
+    }
+
+    // ─── parse_session_turns (역파서) ──────────────────────────────────────────
+
+    #[test]
+    fn parse_h2_role_and_index() {
+        // `## Turn N — Role` 에서 role 과 index(0-based) 복원
+        let md = "---\nsession_id: x\n---\n\n## Turn 1 — User\n\nhello\n\n## Turn 2 — Assistant\n\nhi there\n";
+        let turns = parse_session_turns(md).unwrap();
+        assert_eq!(turns.len(), 2);
+        assert_eq!(turns[0].index, 0);
+        assert_eq!(turns[0].role, Role::User);
+        assert_eq!(turns[0].content, "hello");
+        assert_eq!(turns[1].index, 1);
+        assert_eq!(turns[1].role, Role::Assistant);
+        assert_eq!(turns[1].content, "hi there");
+    }
+
+    #[test]
+    fn parse_h3_inherits_previous_role() {
+        // 연속 role 의 `### Turn N` 은 직전 role 을 상속
+        let md = "---\ns: 1\n---\n\n## Turn 2 — Assistant\n\nfirst\n\n### Turn 3\n\nsecond\n";
+        let turns = parse_session_turns(md).unwrap();
+        assert_eq!(turns.len(), 2);
+        assert_eq!(turns[1].index, 2);
+        assert_eq!(turns[1].role, Role::Assistant, "h3 must inherit prior role");
+        assert_eq!(turns[1].content, "second");
+    }
+
+    #[test]
+    fn parse_supports_crlf() {
+        let md = "---\r\ns: 1\r\n---\r\n\r\n## Turn 1 — User\r\n\r\nline a\r\nline b\r\n";
+        let turns = parse_session_turns(md).unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].role, Role::User);
+        assert_eq!(turns[0].content, "line a\nline b");
+    }
+
+    #[test]
+    fn parse_excludes_frontmatter_and_summary() {
+        // 첫 `## Turn` 이전 영역(요약 blockquote 등)은 turn content 에 포함되지 않음
+        let md = "---\ns: 1\n---\n\n> **프로젝트**: p | **브랜치**: main\n\n## Turn 1 — User\n\nreal content\n";
+        let turns = parse_session_turns(md).unwrap();
+        assert_eq!(turns.len(), 1);
+        assert!(!turns[0].content.contains("프로젝트"));
+        assert_eq!(turns[0].content, "real content");
+    }
+
+    #[test]
+    fn parse_malformed_heading_no_panic() {
+        // `## Turn abc — User` 는 숫자 파싱 실패 → panic 없이 본문 취급
+        let md = "---\ns: 1\n---\n\n## Turn 1 — User\n\nbody\n\n## Turn abc — User\ntrailing\n";
+        let turns = parse_session_turns(md).unwrap();
+        assert_eq!(turns.len(), 1, "malformed heading must not create a turn");
+        assert!(turns[0].content.contains("body"));
+    }
+
+    #[test]
+    fn parse_roundtrip_from_render() {
+        // render_session → parse_session_turns 왕복: 개수/role/index 보존
+        let turns = vec![
+            make_turn(Role::User, "question one"),
+            make_turn(Role::Assistant, "answer one"),
+            make_turn(Role::Assistant, "answer one cont"),
+            make_turn(Role::User, "question two"),
+        ];
+        // make_turn 은 index 를 세팅하지 않으므로 명시적으로 부여
+        let turns: Vec<Turn> = turns
+            .into_iter()
+            .enumerate()
+            .map(|(i, mut t)| {
+                t.index = i as u32;
+                t
+            })
+            .collect();
+        let session = make_session(turns.clone());
+        let md = render_session(&session, chrono_tz::Tz::UTC);
+        let parsed = parse_session_turns(&md).unwrap();
+        assert_eq!(parsed.len(), turns.len());
+        for (orig, got) in turns.iter().zip(parsed.iter()) {
+            assert_eq!(orig.index, got.index);
+            assert_eq!(orig.role, got.role);
+            assert!(got.content.contains(&orig.content));
+        }
     }
 }

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -356,6 +356,38 @@ impl Database {
         Ok(())
     }
 
+    /// 세션의 turns_fts 행만 삭제 (sessions/turns/vectors/graph 는 보존).
+    /// reindex healing 시 legacy `turn_id=0` 단일 블롭 및 이전 healed FTS 행을
+    /// 제거해 per-turn 재삽입이 중복되지 않도록 한다.
+    pub fn clear_session_fts(&self, session_id: &str) -> Result<usize> {
+        let n = self.conn().execute(
+            "DELETE FROM turns_fts WHERE session_id = ?1",
+            rusqlite::params![session_id],
+        )?;
+        Ok(n)
+    }
+
+    /// 세션의 turns 행 개수 (healing 대상 판별용).
+    pub fn count_session_turns(&self, session_id: &str) -> Result<usize> {
+        let n: i64 = self.conn().query_row(
+            "SELECT COUNT(*) FROM turns WHERE session_id = ?1",
+            [session_id],
+            |r| r.get(0),
+        )?;
+        Ok(n as usize)
+    }
+
+    /// turns 가 0개인 세션 수 (healing 리포트용).
+    pub fn count_zero_turn_sessions(&self) -> Result<usize> {
+        let n: i64 = self.conn().query_row(
+            "SELECT COUNT(*) FROM sessions s WHERE NOT EXISTS \
+             (SELECT 1 FROM turns t WHERE t.session_id = s.id)",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(n as usize)
+    }
+
     /// 세션의 모든 벡터를 삭제. 부분 임베딩 정리 및 재임베딩 전 DELETE-first에 사용.
     pub fn delete_session_vectors(&self, session_id: &str) -> Result<usize> {
         // turn_vectors 테이블이 없으면 0 반환 (정상)

--- a/crates/secall-core/src/vault/mod.rs
+++ b/crates/secall-core/src/vault/mod.rs
@@ -16,6 +16,88 @@ use crate::ingest::{
     Session,
 };
 
+/// Canonical session storage subdirectory under a vault root.
+///
+/// P49/v0.5.0 부터 세션 md 는 `raw/.sessions/` (dot-prefix) 에 쓴다. 활성 코드는
+/// 직접 `join("raw").join("sessions")` (무점, legacy) 를 조립하지 말고 이 helper 를
+/// 사용한다. legacy 무점 경로는 더 이상 디스크에 존재하지 않는다.
+pub fn sessions_subdir(vault_path: &Path) -> PathBuf {
+    vault_path.join("raw").join(".sessions")
+}
+
+/// DB 에 저장된 `vault_path`(구분자 `\`·`/` 혼재 + legacy 무점 `raw/sessions` 가능)를
+/// 실제 존재하는 세션 md 파일로 해석한다.
+///
+/// 해석 우선순위:
+/// 1. 저장 경로 그대로 (구분자 정규화)
+/// 2. legacy `raw/sessions` → canonical `raw/.sessions` 치환
+/// 3. `raw/.sessions` 하위에서 8자리 session_id prefix 로 파일명 탐색
+///
+/// prefix 다중 매치는 임의 선택하지 않고 에러를 반환한다. 어디에서도 못 찾으면
+/// `SessionNotFound`.
+pub fn resolve_session_file(
+    vault_path: &Path,
+    stored_rel: &str,
+    session_id: &str,
+) -> crate::error::Result<PathBuf> {
+    // `\` 와 `/` 를 모두 컴포넌트 구분자로 취급해 OS-native path 로 재조립.
+    fn join_normalized(root: &Path, rel: &str) -> PathBuf {
+        let mut p = root.to_path_buf();
+        for comp in rel.split(['/', '\\']).filter(|c| !c.is_empty()) {
+            p.push(comp);
+        }
+        p
+    }
+
+    // (1) 저장 경로 그대로
+    let direct = join_normalized(vault_path, stored_rel);
+    if direct.is_file() {
+        return Ok(direct);
+    }
+
+    // (2) legacy 무점 `sessions` 컴포넌트를 `.sessions` 로 치환
+    let comps: Vec<&str> = stored_rel
+        .split(['/', '\\'])
+        .filter(|c| !c.is_empty())
+        .collect();
+    if comps.contains(&"sessions") {
+        let swapped: Vec<&str> = comps
+            .iter()
+            .map(|c| if *c == "sessions" { ".sessions" } else { *c })
+            .collect();
+        let cand = join_normalized(vault_path, &swapped.join("/"));
+        if cand.is_file() {
+            return Ok(cand);
+        }
+    }
+
+    // (3) prefix 탐색
+    let short = &session_id[..session_id.len().min(8)];
+    let sessions_dir = sessions_subdir(vault_path);
+    let mut matches: Vec<PathBuf> = Vec::new();
+    if sessions_dir.exists() {
+        for entry in walkdir::WalkDir::new(&sessions_dir)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let p = entry.path();
+            if p.extension().map(|x| x == "md").unwrap_or(false) {
+                let fname = p.file_name().unwrap_or_default().to_string_lossy();
+                if fname.contains(short) {
+                    matches.push(p.to_path_buf());
+                }
+            }
+        }
+    }
+    match matches.len() {
+        1 => Ok(matches.into_iter().next().unwrap()),
+        0 => Err(crate::SecallError::SessionNotFound(session_id.to_string())),
+        n => Err(crate::SecallError::Other(anyhow::anyhow!(
+            "ambiguous vault file for session {session_id}: {n} candidates match prefix '{short}'"
+        ))),
+    }
+}
+
 pub struct Vault {
     path: PathBuf,
 }
@@ -27,6 +109,11 @@ impl Vault {
 
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// Canonical `<vault>/raw/.sessions` directory.
+    pub fn sessions_dir(&self) -> PathBuf {
+        sessions_subdir(&self.path)
     }
 
     pub fn init(&self) -> Result<()> {
@@ -85,7 +172,7 @@ impl Vault {
     /// Check if a session has already been ingested (by ID)
     pub fn session_exists(&self, session_id: &str) -> bool {
         // Walk raw/.sessions/ looking for a file containing the session ID
-        let sessions_dir = self.path.join("raw").join(".sessions");
+        let sessions_dir = self.sessions_dir();
         if !sessions_dir.exists() {
             return false;
         }
@@ -392,6 +479,90 @@ mod tests {
             !content.contains("archived_at:"),
             "archived_at: should be removed"
         );
+    }
+
+    // ─── sessions_subdir / resolve_session_file ────────────────────────────────
+
+    #[test]
+    fn sessions_subdir_is_canonical_dot_path() {
+        let dir = TempDir::new().unwrap();
+        let sub = sessions_subdir(dir.path());
+        assert!(sub.ends_with(std::path::Path::new("raw").join(".sessions")));
+    }
+
+    fn write_md(root: &std::path::Path, rel: &str) -> std::path::PathBuf {
+        let p = root.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, "---\nsession_id: x\n---\n\n## Turn 1 — User\n\nhi\n").unwrap();
+        p
+    }
+
+    #[test]
+    fn resolve_direct_dot_path() {
+        let dir = TempDir::new().unwrap();
+        let real = write_md(
+            dir.path(),
+            "raw/.sessions/2026-04-01/claude-code_p_abcd1234.md",
+        );
+        let got = resolve_session_file(
+            dir.path(),
+            "raw/.sessions/2026-04-01/claude-code_p_abcd1234.md",
+            "abcd1234-0000",
+        )
+        .unwrap();
+        assert_eq!(got, real);
+    }
+
+    #[test]
+    fn resolve_legacy_backslash_no_dot_to_dot_file() {
+        // DB 에 저장된 legacy 백슬래시 무점 경로 → 실제 .sessions 파일로 해석
+        let dir = TempDir::new().unwrap();
+        let real = write_md(
+            dir.path(),
+            "raw/.sessions/2026-04-01/claude-code_p_abcd1234.md",
+        );
+        let stored = "raw\\sessions\\2026-04-01\\claude-code_p_abcd1234.md";
+        let got = resolve_session_file(dir.path(), stored, "abcd1234-0000").unwrap();
+        assert_eq!(got, real);
+    }
+
+    #[test]
+    fn resolve_by_prefix_when_path_differs() {
+        // 저장 경로의 날짜 버킷이 달라도 8자리 prefix 로 탐색
+        let dir = TempDir::new().unwrap();
+        let real = write_md(
+            dir.path(),
+            "raw/.sessions/2026-05-09/claude-code_p_deadbeef.md",
+        );
+        let stored = "raw\\sessions\\2026-04-01\\claude-code_p_deadbeef.md";
+        let got = resolve_session_file(dir.path(), stored, "deadbeef-1111").unwrap();
+        assert_eq!(got, real);
+    }
+
+    #[test]
+    fn resolve_missing_file_is_not_found() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(sessions_subdir(dir.path())).unwrap();
+        let err = resolve_session_file(
+            dir.path(),
+            "raw\\sessions\\2026-04-01\\claude-code_p_00000000.md",
+            "00000000-2222",
+        );
+        assert!(matches!(err, Err(crate::SecallError::SessionNotFound(_))));
+    }
+
+    #[test]
+    fn resolve_ambiguous_prefix_errors() {
+        // 동일 8자리 prefix 파일이 둘 → 임의 선택 금지, 에러
+        let dir = TempDir::new().unwrap();
+        write_md(
+            dir.path(),
+            "raw/.sessions/2026-04-01/claude-code_p_abcd1234.md",
+        );
+        write_md(dir.path(), "raw/.sessions/2026-04-02/codex_q_abcd1234.md");
+        let stored = "raw\\sessions\\2026-01-01\\missing_abcd1234.md";
+        let err = resolve_session_file(dir.path(), stored, "abcd1234-3333");
+        assert!(matches!(err, Err(crate::SecallError::Other(_))));
     }
 }
 

--- a/crates/secall-core/src/vault/mod.rs
+++ b/crates/secall-core/src/vault/mod.rs
@@ -73,6 +73,11 @@ pub fn resolve_session_file(
 
     // (3) prefix 탐색
     let short = &session_id[..session_id.len().min(8)];
+    // 빈 session_id 방어: short 가 "" 이면 fname.contains("") 가 항상 true 라
+    // 전체 .md 가 매칭되어 ambiguous/오탐 → 즉시 not-found 로 종료.
+    if short.is_empty() {
+        return Err(crate::SecallError::SessionNotFound(session_id.to_string()));
+    }
     let sessions_dir = sessions_subdir(vault_path);
     let mut matches: Vec<PathBuf> = Vec::new();
     if sessions_dir.exists() {

--- a/crates/secall-core/tests/reindex_healing.rs
+++ b/crates/secall-core/tests/reindex_healing.rs
@@ -1,0 +1,102 @@
+//! reindex healing 불변식 회귀 테스트.
+//!
+//! 실제 CLI orchestration(`secall reindex --repair-missing-turns`)이 사용하는 core
+//! 프리미티브(insert_session_from_vault → clear_session_fts → insert_turn/insert_fts)
+//! 의 조합을 직접 검증한다. zero-turn 세션 복구, 정상 세션 no-op, 재실행 무중복.
+
+use secall_core::ingest::markdown::{parse_session_turns, SessionFrontmatter};
+use secall_core::store::{Database, SearchRepo, SessionRepo};
+
+fn zero_turn_frontmatter(id: &str, turns: u32) -> SessionFrontmatter {
+    SessionFrontmatter {
+        session_id: id.to_string(),
+        agent: "claude-code".to_string(),
+        start_time: "2026-04-01T00:00:00Z".to_string(),
+        turns: Some(turns),
+        ..Default::default()
+    }
+}
+
+/// insert_session_from_vault 는 turns 를 저장하지 않아 zero-turn 세션이 된다.
+/// (현 운영 DB 상태 재현 — healing 대상)
+fn seed_zero_turn(db: &Database, id: &str) {
+    let fm = zero_turn_frontmatter(id, 2);
+    db.insert_session_from_vault(&fm, "some body text", "raw\\sessions\\2026-04-01\\x.md")
+        .unwrap();
+}
+
+/// CLI heal_session 과 동일한 순서로 turns 를 복구한다.
+fn heal(db: &Database, id: &str, md: &str, real_path: &str) -> usize {
+    let turns = parse_session_turns(md).unwrap();
+    db.clear_session_fts(id).unwrap();
+    for turn in &turns {
+        // 테스트에서는 토큰화 대신 raw content 를 FTS 에 넣는다(불변식 검증엔 무관).
+        db.insert_turn(id, turn).unwrap();
+        db.insert_fts(&turn.content, id, turn.index).unwrap();
+    }
+    db.update_session_vault_path(id, real_path).unwrap();
+    turns.len()
+}
+
+const SESSION_MD: &str =
+    "---\nsession_id: s1\n---\n\n## Turn 1 — User\n\nquestion\n\n## Turn 2 — Assistant\n\nanswer\n";
+
+#[test]
+fn zero_turn_session_is_healed_from_vault() {
+    let db = Database::open_memory().unwrap();
+    seed_zero_turn(&db, "s1");
+
+    assert_eq!(db.count_session_turns("s1").unwrap(), 0, "starts zero-turn");
+    assert_eq!(db.count_zero_turn_sessions().unwrap(), 1);
+    // insert_session_from_vault 는 turn_id=0 단일 FTS 블롭 1개를 남긴다.
+    assert_eq!(db.count_fts_rows().unwrap(), 1, "legacy single FTS blob");
+
+    let n = heal(&db, "s1", SESSION_MD, "raw/.sessions/2026-04-01/s1.md");
+    assert_eq!(n, 2);
+    assert_eq!(db.count_session_turns("s1").unwrap(), 2, "turns recovered");
+    assert_eq!(db.count_zero_turn_sessions().unwrap(), 0);
+    // legacy 블롭 제거 + per-turn 2개 → FTS 총 2개 (중복 없음)
+    assert_eq!(
+        db.count_fts_rows().unwrap(),
+        2,
+        "legacy blob replaced by per-turn"
+    );
+}
+
+#[test]
+fn healing_is_idempotent_on_reruns() {
+    let db = Database::open_memory().unwrap();
+    seed_zero_turn(&db, "s1");
+
+    heal(&db, "s1", SESSION_MD, "raw/.sessions/2026-04-01/s1.md");
+    // 재실행 — turns(OR IGNORE) 와 FTS(clear 후 재삽입) 모두 중복 누적되지 않아야 함
+    heal(&db, "s1", SESSION_MD, "raw/.sessions/2026-04-01/s1.md");
+
+    assert_eq!(
+        db.count_session_turns("s1").unwrap(),
+        2,
+        "no duplicate turns"
+    );
+    assert_eq!(db.count_fts_rows().unwrap(), 2, "no duplicate FTS rows");
+}
+
+#[test]
+fn healthy_session_turns_are_preserved() {
+    // 이미 turns 가 있는 세션은 healing 대상이 아님(reindex 는 count>0 이면 skip).
+    // 여기서는 재삽입이 OR IGNORE 로 기존 turns 를 늘리지 않음을 확인.
+    let db = Database::open_memory().unwrap();
+    seed_zero_turn(&db, "s1");
+    heal(&db, "s1", SESSION_MD, "raw/.sessions/2026-04-01/s1.md");
+    assert_eq!(db.count_session_turns("s1").unwrap(), 2);
+
+    // 동일 turns 재삽입 시도 → 개수 불변
+    let turns = parse_session_turns(SESSION_MD).unwrap();
+    for turn in &turns {
+        db.insert_turn("s1", turn).unwrap();
+    }
+    assert_eq!(
+        db.count_session_turns("s1").unwrap(),
+        2,
+        "OR IGNORE keeps existing turns"
+    );
+}

--- a/crates/secall-core/tests/reindex_healing.rs
+++ b/crates/secall-core/tests/reindex_healing.rs
@@ -100,3 +100,19 @@ fn healthy_session_turns_are_preserved() {
         "OR IGNORE keeps existing turns"
     );
 }
+
+#[test]
+fn turn_headers_inside_code_block_are_not_parsed_as_turns() {
+    // 세션 본문이 vault 포맷을 코드블록으로 인용할 때(메타 세션), 코드블록 내부의
+    // "## Turn"/"### Turn" 라인을 실제 turn 헤더로 오인하면 안 된다.
+    let md = "---\nsession_id: s1\n---\n\n## Turn 1 — User\n\n포맷 예시:\n\n```md\n## Turn 99 — Assistant\n### Turn 100\n```\n\n실제 turn 은 2개.\n\n## Turn 2 — Assistant\n\nanswer\n";
+    let turns = parse_session_turns(md).unwrap();
+    assert_eq!(
+        turns.len(),
+        2,
+        "코드블록 내부의 turn 헤더는 turn 으로 세지 않는다"
+    );
+    // 코드블록 원문은 첫 turn 본문에 보존된다.
+    assert!(turns[0].content.contains("## Turn 99 — Assistant"));
+    assert!(turns[0].content.contains("### Turn 100"));
+}

--- a/crates/secall/src/commands/embed.rs
+++ b/crates/secall/src/commands/embed.rs
@@ -6,10 +6,50 @@ use std::time::Instant;
 use anyhow::Result;
 use futures::stream::{self, StreamExt};
 use secall_core::{
-    ingest::Session,
+    ingest::{markdown::parse_session_turns, Session},
     store::{get_default_db_path, Database},
-    vault::Config,
+    vault::{resolve_session_file, Config},
 };
+
+/// 세션을 임베딩용으로 로드하되, DB turns 가 비어 있으면 vault markdown 에서 복구한다.
+///
+/// zero-turn 세션(과거 reindex 로 메타만 있고 turns 미저장)은 DB 만으로는 0 chunks 라
+/// 임베딩되지 않는다. 이 경우 vault_path 를 해석해 실제 md 를 읽고 `parse_session_turns`
+/// 로 turn 을 복원한다. 복구 불가(파일 부재/중복) 시 원래의 빈 세션을 그대로 반환해
+/// 상위에서 no-op skip 되게 한다.
+fn load_session_with_vault_fallback(
+    db: &Database,
+    vault_root: &std::path::Path,
+    session_id: &str,
+) -> Result<Session> {
+    let mut session = db.get_session_for_embedding(session_id)?;
+    if !session.turns.is_empty() {
+        return Ok(session);
+    }
+
+    let Some(vault_path) = db.get_session_vault_path(session_id)? else {
+        return Ok(session);
+    };
+
+    let file = match resolve_session_file(vault_root, &vault_path, session_id) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::debug!(session = %session_id, error = %e, "embed fallback: vault file unresolved");
+            return Ok(session);
+        }
+    };
+
+    let content = std::fs::read_to_string(&file)?;
+    let turns = parse_session_turns(&content)?;
+    if !turns.is_empty() {
+        tracing::info!(
+            session = %session_id, file = %file.display(), turns = turns.len(),
+            "embed: recovered turns from vault fallback"
+        );
+        session.turns = turns;
+    }
+    Ok(session)
+}
 
 enum WorkItem {
     /// Default mode — pre-filter loaded the Session, embed pending chunks.
@@ -47,6 +87,7 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
     let indexer = Arc::new(indexer.with_batch_size(batch_size));
 
     let tz = config.timezone();
+    let vault_root: Arc<PathBuf> = Arc::new(config.vault.path.clone());
     let candidate_ids: Vec<String> = db.list_all_session_ids()?;
 
     // Pre-filter pass — sessions whose chunks are all already embedded (or
@@ -64,7 +105,7 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
         eprintln!("Scanning {total_candidates} session(s) for pending chunks...");
         let mut filtered: Vec<WorkItem> = Vec::new();
         for sid in &candidate_ids {
-            let session = match db.get_session_for_embedding(sid) {
+            let session = match load_session_with_vault_fallback(&db, &vault_root, sid) {
                 Ok(s) => s,
                 Err(_) => {
                     // surface failure in the embed pass (worker reload path)
@@ -108,6 +149,7 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
             let db_path = Arc::clone(&db_path);
             let counter = Arc::clone(&counter);
             let total_chunks = Arc::clone(&total_chunks);
+            let vault_root = Arc::clone(&vault_root);
             async move {
                 let sid = item.id().to_string();
                 let short = &sid[..sid.len().min(8)];
@@ -132,7 +174,7 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
                                 return;
                             }
                         }
-                        match db.get_session_for_embedding(&sid) {
+                        match load_session_with_vault_fallback(&db, &vault_root, &sid) {
                             Ok(s) => s,
                             Err(e) => {
                                 let i = counter.fetch_add(1, Ordering::Relaxed) + 1;

--- a/crates/secall/src/commands/migrate.rs
+++ b/crates/secall/src/commands/migrate.rs
@@ -9,7 +9,7 @@ pub fn run_summary(dry_run: bool) -> Result<()> {
     let config = Config::load_or_default();
     let db = Database::open(&get_default_db_path())?;
 
-    let sessions_dir = config.vault.path.join("raw").join("sessions");
+    let sessions_dir = secall_core::vault::sessions_subdir(&config.vault.path);
     if !sessions_dir.exists() {
         println!("No vault sessions directory found.");
         return Ok(());

--- a/crates/secall/src/commands/reindex.rs
+++ b/crates/secall/src/commands/reindex.rs
@@ -1,11 +1,12 @@
 use anyhow::Result;
 use secall_core::{
-    ingest::markdown::{extract_body_text, parse_session_frontmatter},
-    store::{get_default_db_path, Database, SessionRepo},
+    ingest::markdown::{extract_body_text, parse_session_frontmatter, parse_session_turns},
+    search::tokenizer::{create_tokenizer, Tokenizer},
+    store::{get_default_db_path, Database, SearchRepo, SessionRepo},
     vault::Config,
 };
 
-pub fn run(from_vault: bool) -> Result<()> {
+pub fn run(from_vault: bool, repair_missing_turns: bool) -> Result<()> {
     if !from_vault {
         anyhow::bail!("--from-vault flag is required");
     }
@@ -13,14 +14,24 @@ pub fn run(from_vault: bool) -> Result<()> {
     let config = Config::load_or_default();
     let db = Database::open(&get_default_db_path())?;
 
-    let sessions_dir = config.vault.path.join("raw").join(".sessions");
+    let sessions_dir = secall_core::vault::sessions_subdir(&config.vault.path);
     if !sessions_dir.exists() {
         println!("No vault sessions directory found.");
         return Ok(());
     }
 
+    // healing 시에만 tokenizer 준비 (FTS 재삽입용).
+    let tokenizer: Option<Box<dyn Tokenizer>> = if repair_missing_turns {
+        Some(create_tokenizer(&config.search.tokenizer)?)
+    } else {
+        None
+    };
+
+    let zero_turn_before = db.count_zero_turn_sessions().unwrap_or(0);
+
     let mut indexed = 0usize;
     let mut skipped = 0usize;
+    let mut healed = 0usize;
     let mut errors = 0usize;
 
     for entry in walkdir::WalkDir::new(&sessions_dir)
@@ -53,10 +64,53 @@ pub fn run(from_vault: bool) -> Result<()> {
             continue;
         }
 
+        let vault_path = path
+            .strip_prefix(&config.vault.path)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_string();
+
         // 중복 체크
         match db.session_exists(&fm.session_id) {
             Ok(true) => {
-                skipped += 1;
+                // 기존 세션: repair 요청 + turns 0개면 vault 에서 turns 복구 (비파괴 healing).
+                if let Some(tok) = tokenizer.as_ref() {
+                    match db.count_session_turns(&fm.session_id) {
+                        Ok(0) => match heal_session(
+                            &db,
+                            tok.as_ref(),
+                            &fm.session_id,
+                            &content,
+                            &vault_path,
+                        ) {
+                            Ok(n) if n > 0 => {
+                                healed += 1;
+                                tracing::info!(
+                                    session = %fm.session_id, turns = n,
+                                    "healed zero-turn session from vault"
+                                );
+                            }
+                            Ok(_) => {
+                                // 파싱했지만 turn 0개 — 복구 불가로 간주, skip
+                                skipped += 1;
+                            }
+                            Err(e) => {
+                                tracing::warn!(session = %fm.session_id, error = %e, "heal failed");
+                                errors += 1;
+                            }
+                        },
+                        Ok(_) => {
+                            // 정상 turns 존재 → no-op
+                            skipped += 1;
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "count_turns failed");
+                            errors += 1;
+                        }
+                    }
+                } else {
+                    skipped += 1;
+                }
                 continue;
             }
             Ok(false) => {}
@@ -67,16 +121,24 @@ pub fn run(from_vault: bool) -> Result<()> {
             }
         }
 
-        let vault_path = path
-            .strip_prefix(&config.vault.path)
-            .unwrap_or(path)
-            .to_string_lossy()
-            .to_string();
-
+        // 신규 세션: 메타데이터 인덱싱.
         let body = extract_body_text(&content);
-
         match db.insert_session_from_vault(&fm, &body, &vault_path) {
-            Ok(()) => indexed += 1,
+            Ok(()) => {
+                indexed += 1;
+                // repair 모드: 새 세션도 turns 를 저장해 zero-turn 생성을 막는다.
+                // (repair 아니면 기존 동작대로 메타데이터만 — turns 미저장)
+                if let Some(tok) = tokenizer.as_ref() {
+                    match heal_session(&db, tok.as_ref(), &fm.session_id, &content, &vault_path) {
+                        Ok(n) if n > 0 => healed += 1,
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!(session = %fm.session_id, error = %e, "heal (new) failed");
+                            errors += 1;
+                        }
+                    }
+                }
+            }
             Err(e) => {
                 tracing::warn!(path = %path.display(), error = %e, "reindex failed");
                 errors += 1;
@@ -85,8 +147,54 @@ pub fn run(from_vault: bool) -> Result<()> {
     }
 
     eprintln!(
-        "\nReindex: {} indexed, {} skipped (duplicate), {} errors",
+        "\nReindex: {} indexed, {} skipped, {} errors",
         indexed, skipped, errors
     );
+
+    if repair_missing_turns {
+        let zero_turn_after = db.count_zero_turn_sessions().unwrap_or(0);
+        eprintln!(
+            "Repair: turns written to {} session(s) from vault. Zero-turn sessions {} -> {} \
+             ({} still zero-turn — vault file missing/unresolvable).",
+            healed, zero_turn_before, zero_turn_after, zero_turn_after
+        );
+    }
+
     Ok(())
+}
+
+/// 단일 세션을 vault markdown 에서 복구한다 (비파괴).
+///
+/// 1. legacy `turn_id=0` 블롭 및 이전 healed FTS 행 제거 (멱등성)
+/// 2. `parse_session_turns` 로 복원한 turn 을 `turns` + `turns_fts` 에 저장
+/// 3. vault_path 를 실제 파일 경로로 갱신 (status='indexed')
+///
+/// sessions row(favorite/notes/tags) 와 graph 는 건드리지 않는다.
+/// 반환값: 저장한 turn 수.
+fn heal_session(
+    db: &Database,
+    tokenizer: &dyn Tokenizer,
+    session_id: &str,
+    content: &str,
+    vault_rel_path: &str,
+) -> Result<usize> {
+    let turns = parse_session_turns(content)?;
+    if turns.is_empty() {
+        return Ok(0);
+    }
+
+    // FTS 재삽입 전 기존 행 제거 (legacy blob + 재실행 중복 방지)
+    db.clear_session_fts(session_id)?;
+
+    for turn in &turns {
+        let tokenized = tokenizer.tokenize_for_fts(&turn.content);
+        // insert_turn 은 INSERT OR IGNORE (UNIQUE(session_id, turn_index)) 라 멱등.
+        db.insert_turn(session_id, turn)?;
+        db.insert_fts(&tokenized, session_id, turn.index)?;
+    }
+
+    // vault_path 를 실제 파일 경로로 정정 (legacy 백슬래시/무점 경로 교체).
+    db.update_session_vault_path(session_id, vault_rel_path)?;
+
+    Ok(turns.len())
 }

--- a/crates/secall/src/commands/reindex.rs
+++ b/crates/secall/src/commands/reindex.rs
@@ -183,18 +183,24 @@ fn heal_session(
         return Ok(0);
     }
 
-    // FTS 재삽입 전 기존 행 제거 (legacy blob + 재실행 중복 방지)
-    db.clear_session_fts(session_id)?;
+    // 모든 DB 쓰기를 트랜잭션으로 묶어 원자성 보장 — 중간 실패로 turn 일부만
+    // 삽입되면 count>0 이 되어 다음 실행에서 영구 skip 되는 버그를 차단한다.
+    db.with_transaction(|| {
+        // FTS 재삽입 전 기존 행 제거 (legacy blob + 재실행 중복 방지)
+        db.clear_session_fts(session_id)?;
 
-    for turn in &turns {
-        let tokenized = tokenizer.tokenize_for_fts(&turn.content);
-        // insert_turn 은 INSERT OR IGNORE (UNIQUE(session_id, turn_index)) 라 멱등.
-        db.insert_turn(session_id, turn)?;
-        db.insert_fts(&tokenized, session_id, turn.index)?;
-    }
+        for turn in &turns {
+            let tokenized = tokenizer.tokenize_for_fts(&turn.content);
+            // insert_turn 은 INSERT OR IGNORE (UNIQUE(session_id, turn_index)) 라 멱등.
+            db.insert_turn(session_id, turn)?;
+            db.insert_fts(&tokenized, session_id, turn.index)?;
+        }
 
-    // vault_path 를 실제 파일 경로로 정정 (legacy 백슬래시/무점 경로 교체).
-    db.update_session_vault_path(session_id, vault_rel_path)?;
+        // vault_path 를 실제 파일 경로로 정정 (legacy 백슬래시/무점 경로 교체).
+        db.update_session_vault_path(session_id, vault_rel_path)?;
+
+        Ok(())
+    })?;
 
     Ok(turns.len())
 }

--- a/crates/secall/src/commands/status.rs
+++ b/crates/secall/src/commands/status.rs
@@ -62,7 +62,7 @@ pub fn run() -> Result<()> {
     println!();
 
     // Vault status
-    let sessions_dir = config.vault.path.join("raw").join("sessions");
+    let sessions_dir = secall_core::vault::sessions_subdir(&config.vault.path);
     if sessions_dir.exists() {
         let md_count = walkdir::WalkDir::new(&sessions_dir)
             .into_iter()

--- a/crates/secall/src/commands/sync.rs
+++ b/crates/secall/src/commands/sync.rs
@@ -167,7 +167,7 @@ pub async fn run_with_progress(args: SyncArgs, sink: &dyn ProgressSink) -> Resul
 
     if dry_run {
         // dry-run 경로: 나머지 phase는 안내만 출력하고 종료
-        let sessions_dir = config.vault.path.join("raw").join("sessions");
+        let sessions_dir = secall_core::vault::sessions_subdir(&config.vault.path);
         let md_count = if sessions_dir.exists() {
             walkdir::WalkDir::new(&sessions_dir)
                 .into_iter()
@@ -460,9 +460,9 @@ struct ReindexResult {
     skipped: usize,
 }
 
-/// vault/raw/sessions/ 스캔 -> DB에 없는 MD를 인덱싱
+/// vault/raw/.sessions/ 스캔 -> DB에 없는 MD를 인덱싱
 fn reindex_vault(config: &Config, db: &Database) -> Result<ReindexResult> {
-    let sessions_dir = config.vault.path.join("raw").join("sessions");
+    let sessions_dir = secall_core::vault::sessions_subdir(&config.vault.path);
     if !sessions_dir.exists() {
         return Ok(ReindexResult {
             indexed: 0,

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -233,6 +233,10 @@ enum Commands {
         /// Rebuild from vault markdown files
         #[arg(long)]
         from_vault: bool,
+        /// 기존 세션 중 turns 가 0개인 것을 vault markdown 에서 복구 (비파괴 healing).
+        /// 정상 turns 가 있는 세션과 graph/favorite/notes 는 건드리지 않음.
+        #[arg(long)]
+        repair_missing_turns: bool,
     },
 
     /// Manage wiki generation via pluggable LLM backends
@@ -609,8 +613,11 @@ async fn main() -> anyhow::Result<()> {
             )
             .await?;
         }
-        Commands::Reindex { from_vault } => {
-            commands::reindex::run(from_vault)?;
+        Commands::Reindex {
+            from_vault,
+            repair_missing_turns,
+        } => {
+            commands::reindex::run(from_vault, repair_missing_turns)?;
         }
         Commands::Wiki { action } => match action {
             WikiAction::Update {

--- a/docs/reference/handoff_2026-06-27.md
+++ b/docs/reference/handoff_2026-06-27.md
@@ -1,9 +1,10 @@
 ---
 type: reference
-status: draft
+status: done
 updated_at: 2026-06-27
-canonical: true
+canonical: false
 supersedes: handoff_2026-06-26.md
+superseded_by: handoff_2026-07-02.md
 ---
 
 # seCall 세션 핸드오프 — 2026-06-27

--- a/docs/reference/handoff_2026-07-02.md
+++ b/docs/reference/handoff_2026-07-02.md
@@ -1,0 +1,93 @@
+---
+type: reference
+status: draft
+updated_at: 2026-07-02
+canonical: true
+supersedes: handoff_2026-06-27.md
+---
+
+# seCall 세션 핸드오프 — 2026-07-02 (Windows 작업)
+
+> 작성 배경: **Windows 기기**(원 아키텍트는 macOS)에서 코드베이스 전수 조사 후,
+> 운영 DB의 zero-turn 세션 문제(2399건)를 발견해 **비파괴 healing 기능을 추가**하고
+> 실제 운영 DB를 복구했다. 이 PR은 그 코드 변경 + 이 문서를 macOS 쪽에서 pull/리뷰하기
+> 위한 것. cold-start 는 이 문서 + `handoff_2026-06-27.md`(직전 맥락) 만 읽으면 이어감.
+
+---
+
+## 1. 현재 상태 (cold-start 체크)
+
+- **레포**: GitHub `hang-in/seCall`. 이번 작업 기기 = Windows (`D:\privateProject\seCall`), 원 아키텍트 = macOS (`/Users/d9ng/privateProject/seCall`).
+- **버전**: `0.6.4` (Cargo.toml). 이 PR 은 버전 bump 없음(기능 추가, 릴리스는 별도).
+- **브랜치**: `fix/reindex-zero-turn-healing` (이 PR). base = `main`.
+- **DB 는 기기-로컬**(gitignore) — Windows DB 복구는 macOS DB 에 반영 안 됨. 코드(feature)만 PR 로 이동. macOS 에서도 zero-turn 있으면 동일 명령으로 복구 가능.
+- **임베딩 백엔드**: config `ollama_url = http://127.0.0.1:11435` → **서버 GPU(5060ti 16GB) 프록시**(로컬 11434 아님).
+
+---
+
+## 2. 이번 세션 결과 (2026-07-02)
+
+### 2.1 zero-turn 세션 healing 기능 추가 (이 PR)
+
+**근본 원인** (Windows 운영 DB 3142 세션 중 2399 zero-turn):
+1. 활성 코드가 stale 무점 경로 `raw/sessions` 참조 (canonical 은 `raw/.sessions`, P49/v0.5.0+). `graph/build.rs`, `status.rs`, `sync.rs`, `migrate.rs`.
+2. `insert_session_from_vault` 가 turns 를 저장 안 함 → reindexed 세션은 `turns_fts` 에 `turn_id=0` 단일 블롭만, `turns` 테이블 0행.
+3. `session_exists` true 면 turns 유무 무관 무조건 skip.
+4. `embed` 에 vault 폴백 부재 → zero-turn 세션 "0 chunks".
+5. (검증으로 발견) vault_path 가 **백슬래시**(`raw\sessions\…`) 저장 + zero-turn 절반은 vault md 파일 자체가 없음.
+
+**변경 (10 파일 + 신규 테스트 1)**:
+- `vault/mod.rs` — `sessions_subdir()`/`Vault::sessions_dir()` 경로 helper, `resolve_session_file()`(구분자 `\`·`/` 정규화 → legacy 무점 치환 → 8자리 prefix 탐색, 다중매치는 에러).
+- `ingest/markdown.rs` — `parse_session_turns()` 역파서(`## Turn N — Role`/`### Turn N` role 상속, frontmatter·요약 제외, CRLF/LF, malformed no-panic). **렌더가 lossy 라 복원본은 "재구성본"**(검색/임베딩 용).
+- `store/session_repo.rs` — `clear_session_fts`, `count_session_turns`, `count_zero_turn_sessions`.
+- `commands/reindex.rs` — `--repair-missing-turns` 플래그. 비파괴 healing: 기존 zero-turn + 신규 세션 모두 turns 저장(FTS clear 후 per-turn 재삽입, graph/favorite/notes 보존).
+- `commands/embed.rs` — turns 빈 세션은 vault 파일 해석 후 `parse_session_turns` 로 폴백 임베딩.
+- `graph/build.rs`·`status.rs`·`sync.rs`·`migrate.rs` — stale 경로 → helper.
+- `main.rs` — 플래그 정의/디스패치.
+- `tests/reindex_healing.rs`(신규) — healing 불변식(복구/no-op/멱등/FTS 무중복) + markdown 역파서 6 + resolve 6 유닛 테스트.
+- 검증: `cargo fmt --check` / `clippy --workspace --all-targets -D warnings` / `cargo test --workspace` **전부 통과**.
+
+### 2.2 운영 DB 복구 실행 (Windows, 코드와 무관 — 참고 기록)
+- `secall reindex --from-vault --repair-missing-turns` 2회(코드 버그 수정 후 재실행): zero-turn **2399 → 1293**, 세션 3142 → **6403**(vault 전체 통합 — 사용자가 unified 선택), turns 53726 → 285249.
+- 남은 **1293 은 복구 불가 확정**: vault md 파일 없음 + 이 기기에 원본 로그 없음(`ingest --auto --force` 로도 0건 치유). → 원 소스 기기에서 sync push 하거나 vault git 히스토리 복원만이 방법.
+- 현재 `secall embed` 로 전체 재임베딩 진행 중(서버 GPU, ETA 길다. 재개 가능하므로 방치 완주 OK).
+
+---
+
+## 3. 다음 작업
+
+### 3.1 (이 PR) macOS 리뷰 & 머지
+- macOS 에서 `git pull` → 이 브랜치 확인. fork 아님(같은 오너)이라 CI 자동 실행되나, 로컬 게이트도 권장(§5).
+- 머지 후 macOS 자기 DB 에도 zero-turn 있으면 `secall reindex --from-vault --repair-missing-turns` 적용 가능.
+
+### 3.2 (carry-forward 최우선) 배포방법 고도화
+- 변동 없음 — `handoff_2026-06-26.md` §3.1 그대로. 권장 시작점: Linux 바이너리 + cargo-binstall + SHA256 체크섬.
+
+### 3.3 (대기) PR #108 — 외부 기여자 응답 대기.
+
+---
+
+## 4. 백로그 (carry-forward)
+
+- **`ingest --force` 벡터 삭제 함정**: `--force` 는 재수집 세션의 벡터를 지운다. `--no-embed` 와 조합 시 재생성 안 돼 Embedded 급감(41630→5055 실측). zero-turn 복구는 `reindex --repair-missing-turns`(비파괴) 를 먼저 쓸 것. `--force` 재수집은 로컬 원본 로그 있는 세션만 유효.
+- **`claude -p` 가 사용자 시스템에서 막히는 원인** 미진단 (빌링 아님).
+- **Gemini Code Assist(PR 리뷰 봇) 2026-07-17 종료** — 대안 결정 필요(임박).
+- **Antigravity ingest** 보류. **Gemini 리팩토링 2건** 건드리지 말 것. **local stale branch 2개** 삭제 금지.
+- 테스트 갭: REST API DTO/라우터 미테스트 46건.
+- flaky: `llm::model_discovery::cache_hit_returns_cached_source` (전역 캐시 레이스, 직렬 실행 시 통과).
+
+---
+
+## 5. 작업 방식 (반드시 지킬 것)
+
+- **검증 게이트**: `cargo fmt --check` + `clippy --workspace --all-targets -- -D warnings` + `cargo test --workspace`. 검증과 push 는 분리 배치.
+- **Windows 빌드**: `web/dist` 없으면 rust-embed 빌드 실패 → `cd web && pnpm build` 선행. `cargo install --path` 는 실행 중 `secall.exe`(MCP 서버 등) 가 잠그면 실패 → 프로세스 종료 후.
+- **Windows 경로**: DB vault_path 가 백슬래시로 저장됨. 경로 비교/정규화 시 `\`·`/` 양쪽 처리.
+- destructive 는 confirm, push/PR/머지는 위임.
+- config.toml 에 API 키 평문 — 편집 시 키 라인 노출 금지.
+
+---
+
+## 6. 한 줄 요약
+
+> v0.6.4. 이번 세션(Windows): zero-turn 세션 비파괴 healing 기능 추가(`secall reindex --from-vault --repair-missing-turns` + embed vault 폴백 + 경로 canonical 통일, 10파일+테스트, 전 검증 통과) → 이 PR. 운영 DB 는 2399→1293 zero-turn 으로 복구(나머지 1293 은 원본 부재로 복구 불가), 현재 재임베딩 중. **다음 = macOS 리뷰/머지 + 배포방법 고도화(carry-forward)**.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,7 +9,7 @@ seCall 의 현재 기준 사실(SSOT) 문서 인덱스. 모든 항목은 "지금
 새 세션에서 컨텍스트를 파악할 때 다음 순서로 읽으면 충분하다.
 
 1. 프로젝트 루트 [`CLAUDE.md`](../../CLAUDE.md) — 프로젝트 전체 규약과 현재 상태 요약
-2. [handoff_2026-06-27.md](handoff_2026-06-27.md) — 최신 세션 핸드오프 (현재 작업 맥락)
+2. [handoff_2026-07-02.md](handoff_2026-07-02.md) — 최신 세션 핸드오프 (현재 작업 맥락)
 3. [core-backlog.md](core-backlog.md) / [web-backlog.md](web-backlog.md) — 현 우선순위와 백로그
 4. 작업 영역별 reference (LLM 설정이면 `llm-config.md`, Wiki 작업이면 `wiki-setup.md` 등)
 5. (필요 시) 관련 [plans](../plans/index.md) / [prompts](../prompts/index.md)
@@ -25,7 +25,8 @@ seCall 의 현재 기준 사실(SSOT) 문서 인덱스. 모든 항목은 "지금
 
 ### 세션 핸드오프 (시간순 스냅샷, 최신만 우선 참고)
 
-- [handoff_2026-06-27.md](handoff_2026-06-27.md) — 최신 세션 핸드오프 (wiki 기본 백엔드 claude→codex 강등 PR #111 + claude -p 빌링 사실 확정; 다음=배포방법 고도화) · 상태: draft
+- [handoff_2026-07-02.md](handoff_2026-07-02.md) — 최신 세션 핸드오프 (Windows: zero-turn 세션 healing 기능 추가 `reindex --repair-missing-turns` + 운영 DB 복구 2399→1293; 다음=macOS 리뷰/머지 + 배포 고도화) · 상태: draft
+- [handoff_2026-06-27.md](handoff_2026-06-27.md) — 이전 세션 핸드오프 (wiki 기본 백엔드 claude→codex 강등 PR #111 + claude -p 빌링 사실 확정; 다음=배포방법 고도화) · 상태: draft
 - [handoff_2026-06-26.md](handoff_2026-06-26.md) — 이전 세션 핸드오프 (PR #108 archive 리뷰 + 백로그 정리 PR #110; 배포 고도화 §3.1 상세) · 상태: done
 - [handoff_2026-06-25.md](handoff_2026-06-25.md) — 이전 세션 핸드오프 (v0.6.0~0.6.3 릴리스 + 외부 PR + CLI 변동 점검) · 상태: done
 - [handoff_2026-05-19.md](handoff_2026-05-19.md) — 이전 세션 핸드오프 (v0.5.0+10 PR) · 상태: done


### PR DESCRIPTION
## 배경

Windows 운영 DB에서 **3142 세션 중 2399개가 zero-turn**(turns 테이블 0행, 임베딩 시 "0 chunks")인 문제를 발견. 근본 원인 조사 결과:

1. 활성 코드가 stale 무점 경로 `raw/sessions` 참조 (canonical은 `raw/.sessions`, P49/v0.5.0+) — `graph/build.rs`, `status.rs`, `sync.rs`, `migrate.rs`
2. `insert_session_from_vault`가 turns를 저장하지 않음 → reindexed 세션은 `turns_fts` 단일 블롭만, `turns` 0행
3. `session_exists` true면 turns 유무와 무관하게 무조건 skip
4. `embed`에 vault 폴백 부재
5. (검증으로 발견) vault_path가 **백슬래시**(`raw\sessions\…`)로 저장 + zero-turn 상당수는 vault md 파일이 아예 없음

## 변경

- **reindex**: `--repair-missing-turns` 플래그 — 기존 zero-turn + 신규 세션 모두 vault md에서 turns 복구. FTS clear 후 per-turn 재삽입(멱등), **graph/favorite/notes 보존**(비파괴)
- **markdown**: `parse_session_turns` 역파서 (`## Turn N — Role` / `### Turn N` role 상속, frontmatter·요약 제외, CRLF/LF, malformed no-panic). 렌더가 lossy이므로 복원본은 검색/임베딩용 재구성본
- **vault**: `sessions_subdir`/`Vault::sessions_dir` 경로 helper + `resolve_session_file`(구분자 `\`·`/` 정규화 → legacy 무점 치환 → 8자리 prefix 탐색, 다중매치는 에러)
- **embed**: turns 빈 세션은 vault 파일 해석 후 폴백 임베딩
- **store**: `clear_session_fts` / `count_session_turns` / `count_zero_turn_sessions`
- **graph/build·status·sync·migrate**: stale 경로 → helper 통일

## 테스트

- `tests/reindex_healing.rs`(신규): healing 불변식 — 복구 / no-op / 멱등 / FTS 무중복
- markdown 역파서 6개, `resolve_session_file` 6개(백슬래시 legacy·prefix·다중매치 에러 포함)
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --workspace --all-targets -- -D warnings`
- ✅ `cargo test --workspace`

## 운영 적용 결과 (Windows, 참고)

- `secall reindex --from-vault --repair-missing-turns`: zero-turn **2399 → 1293**, 세션 unified 6403
- 남은 1293은 vault md 및 로컬 원본 로그 부재로 복구 불가 (소스 기기 sync push 또는 vault git 히스토리 복원 필요)

상세 맥락: `docs/reference/handoff_2026-07-02.md`

## 리뷰 노트 (macOS)

- DB는 기기-로컬(gitignore)이라 이 PR은 **코드/문서만** 이동. macOS 자기 DB에 zero-turn 있으면 머지 후 동일 명령으로 복구 가능
- ⚠️ 운영 교훈: `ingest --force`는 재수집 세션의 벡터를 삭제하므로 `--no-embed`와 조합 시 Embedded 급감. zero-turn 복구는 `reindex --repair-missing-turns`(비파괴)를 먼저 쓸 것

🤖 Generated with [Claude Code](https://claude.com/claude-code)