### PR TITLE
docs: README 슬림화 — API 상세 분리 + 버전 이력 CHANGELOG 통합

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-> NOTE: v0.3.x ~ v0.4.x 의 상세 변경 이력은 `README.md` 의 "버전 히스토리" 표 참고. CHANGELOG.md 는 v0.2.x 시점에서 README 로 SSOT 이전됨.
+> NOTE: 전체 버전 · 개발 Phase 이력의 단일 SSOT. (README 의 "버전 히스토리" 표는 2026-07-02 이 파일로 통합됨.)
 
 ## v0.6.4 (2026-06-28)
 
@@ -139,6 +139,25 @@ P49 ~ P55 누적 — 데이터 품질 / 클라우드 LLM 통합 / 거대 함수 
 - log diary cloud: kimi-k2.6:cloud 15s 한국어 일기 정상
 - wiki claude CLI 5분 hang → P52 timeout 정확히 300s 발동 + SIGKILL 차단
 - embed 1240/26946 chunks 정상 (local Ollama)
+
+## v0.3.0 – v0.4.x + 개발 Phase (2026-04 ~ 2026-05)
+
+> 이 구간(v0.3.x · v0.4.0 및 개발 Phase P35~P44)은 이전에 README "버전 히스토리" 표로만 관리되었다. CHANGELOG 단일 SSOT 통합 시 이관 (2026-07-02).
+
+| 날짜 | 버전 / Phase | 요약 |
+| --- | --- | --- |
+| 2026-05-10 | P44 | Wiki cross-host merge, `--no-pull`, sources 합집합 기반 자동 재생성 |
+| 2026-05-09 | P43 | Wiki review backend 확장, config 주석 보존 |
+| 2026-05-09 | P41 | LLM 설정 통합, `/api/config`, Web `/settings` |
+| 2026-05-06 | P40 | Wiki 검색 hybrid 모드, wiki vectorize, page-level embedding |
+| 2026-05-03 | P38 | REST route와 session repo 테스트 보강 |
+| 2026-05-03 | P37 | Graph rebuild CLI / REST / Web UI 추가 |
+| 2026-05-02 | P36 | Job cancellation 추가 |
+| 2026-05-02 | P35 | Web UI 성능 개선, tags API, 무한 스크롤, code split |
+| 2026-05-02 | v0.4.0 | Web UI 명령 실행, Job 시스템, SSE 진행 표시 |
+| 2026-04-17 | v0.3.3 | LM Studio backend, `sync --no-semantic`, Gemini Web ZIP ingest |
+| 2026-04-15 | v0.3.2 | Gemini API backend, REST API, Obsidian plugin, 작업 일기 |
+| 2026-04-12 | v0.3.0 | 세션 분류, 위키 backend 확장, automated 세션 필터 |
 
 ## v0.2.3 (2026-04-09)
 

--- a/README.md
+++ b/README.md
@@ -220,68 +220,20 @@ Web UI에서 할 수 있는 일:
 | 태그 / 즐겨찾기 | 세션 메타데이터 편집                                 |
 | 사용자 노트    | 세션별 Markdown 노트 작성                          |
 
+REST API 엔드포인트 전체(검색 · 세션 메타 · 명령 · Job · SSE)는 **[API 레퍼런스](docs/reference/api.md)** 를 참고하세요.
+
 ---
 
 ## MCP 서버
 
-MCP 호환 AI 에이전트에서 seCall 검색을 사용할 수 있습니다.
-
-stdio 모드:
+MCP 호환 AI 에이전트(Claude Code, Cursor 등)에서 seCall 검색을 사용할 수 있습니다.
 
 ```bash
-secall mcp
+secall mcp                        # stdio 모드
+secall mcp --http 127.0.0.1:8080  # HTTP 모드
 ```
 
-HTTP 모드:
-
-```bash
-secall mcp --http 127.0.0.1:8080
-```
-
-제공 도구:
-
-| 도구            | 설명                 |
-| ------------- | ------------------ |
-| `recall`      | 세션 검색              |
-| `get`         | 특정 세션 조회           |
-| `status`      | 인덱스 상태 확인          |
-| `wiki_search` | 위키 문서 검색           |
-| `graph_query` | Knowledge Graph 탐색 |
-
-Claude Code 설정 예시:
-
-```json
-{
-  "mcpServers": {
-    "secall": {
-      "command": "secall",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-세션 시작 / 종료 시 자동 동기화 예시:
-
-```json
-{
-  "hooks": {
-    "SessionStart": [{
-      "matcher": "startup|resume",
-      "hooks": [{
-        "type": "command",
-        "command": "secall sync --local-only"
-      }]
-    }],
-    "SessionEnd": [{
-      "hooks": [{
-        "type": "command",
-        "command": "secall sync"
-      }]
-    }]
-  }
-}
-```
+제공 도구(`recall` / `get` / `status` / `wiki_search` / `graph_query`), MCP 클라이언트 설정, 세션 hooks 자동 동기화 예시는 **[API 레퍼런스](docs/reference/api.md)** 를 참고하세요.
 
 ---
 
@@ -760,28 +712,7 @@ seCall은 AI 코딩 에이전트인 Claude Code와 Codex를 [tunaFlow](https://g
 
 ## 업데이트 이력
 
-전체 변경 이력은 git tag와 `CHANGELOG.md`를 기준으로 관리하는 것을 권장합니다.
-
-최근 주요 변경:
-
-| 날짜         | 버전 / Phase | 요약                                                                                                 |
-| ---------- | ---------- | -------------------------------------------------------------------------------------------------- |
-| 2026-05-15 | v0.5.0     | `raw/.sessions/` 구조 변경, LLM backend 통합, graph/log 기본 backend 변경, wiki review/generation backend 확장 |
-| 2026-05-10 | P44        | Wiki cross-host merge, `--no-pull`, sources 합집합 기반 자동 재생성                                          |
-| 2026-05-09 | P43        | Wiki review backend 확장, config 주석 보존                                                               |
-| 2026-05-09 | P41        | LLM 설정 통합, `/api/config`, Web `/settings`                                                          |
-| 2026-05-06 | P40        | Wiki 검색 hybrid 모드, wiki vectorize, page-level embedding                                            |
-| 2026-05-03 | P38        | REST route와 session repo 테스트 보강                                                                    |
-| 2026-05-03 | P37        | Graph rebuild CLI / REST / Web UI 추가                                                               |
-| 2026-05-02 | P36        | Job cancellation 추가                                                                                |
-| 2026-05-02 | P35        | Web UI 성능 개선, tags API, 무한 스크롤, code split                                                         |
-| 2026-05-02 | v0.4.0     | Web UI 명령 실행, Job 시스템, SSE 진행 표시                                                                   |
-| 2026-04-17 | v0.3.3     | LM Studio backend, `sync --no-semantic`, Gemini Web ZIP ingest                                     |
-| 2026-04-15 | v0.3.2     | Gemini API backend, REST API, Obsidian plugin, 작업 일기                                               |
-| 2026-04-12 | v0.3.0     | 세션 분류, 위키 backend 확장, automated 세션 필터                                                              |
-| 2026-04-09 | v0.2.3     | ChatGPT export parser                                                                              |
-| 2026-04-05 | v0.2       | claude.ai export parser                                                                            |
-| 2026-03-31 | MVP        | Claude Code / Codex / Gemini parser, BM25 + vector search, MCP, Obsidian vault                     |
+전체 버전 · Phase 변경 이력은 **[CHANGELOG.md](CHANGELOG.md)** 에서 관리합니다.
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,135 @@
+---
+type: reference
+status: done
+updated_at: 2026-07-02
+canonical: true
+---
+
+# seCall API 레퍼런스 (REST + MCP)
+
+seCall 의 프로그래매틱 인터페이스 두 가지 — **REST API**(Web UI · Obsidian 플러그인 공용)와 **MCP 서버**(MCP 호환 AI 에이전트용) — 의 상세 문서.
+
+> 이 문서는 README 에서 분리된 API 상세다. README 에는 "바로 시작"에 필요한 요약만 두고, 엔드포인트/도구 전체 목록은 여기서 관리한다. 엔드포인트의 최종 기준(SSOT)은 코드(`crates/secall-core/src/mcp/rest.rs`)다.
+
+---
+
+## REST API
+
+`secall serve` 는 REST API 와 Web UI 를 **동일 포트(기본 8080)** 에서 제공한다. Obsidian 플러그인도 같은 API 를 공유한다.
+
+```bash
+# REST API + Web UI 서버 시작
+secall serve --port 8080
+# 브라우저: http://127.0.0.1:8080
+
+# /settings 에서 config 저장을 허용하려면 (기본은 read-only)
+secall serve --allow-config-edit
+```
+
+### 읽기 / 검색
+
+| 엔드포인트 | 설명 |
+| --- | --- |
+| `GET /api/recall` | 세션 검색 (BM25 / 벡터 / hybrid) |
+| `GET /api/get` | 특정 세션 조회 |
+| `GET /api/status` | 인덱스 상태 |
+| `GET /api/daily` | 데일리 노트 |
+| `GET /api/graph` | Knowledge Graph 조회 |
+| `GET /api/wiki` | 위키 검색 |
+| `GET /api/wiki/{project}` | 위키 본문 |
+
+### 세션 메타
+
+| 엔드포인트 | 설명 |
+| --- | --- |
+| `GET /api/sessions` | 세션 목록 |
+| `GET /api/projects` | 프로젝트 목록 |
+| `GET /api/agents` | 에이전트 목록 |
+| `GET /api/tags?with_counts={true\|false}` | 태그 목록 (`true`: `{name,count}` / `false`: 이름만) |
+| `PATCH /api/sessions/{id}/tags` | 태그 편집 |
+| `PATCH /api/sessions/{id}/favorite` | 즐겨찾기 토글 |
+| `PATCH /api/sessions/{id}/notes` | 세션 노트 저장 |
+
+### 설정
+
+| 엔드포인트 | 설명 |
+| --- | --- |
+| `GET /api/config` | 설정 조회 |
+| `PATCH /api/config/{section}` | 설정 수정 (`--allow-config-edit` 필요, secret 키는 응답/저장에서 필터) |
+
+### 명령 (비동기 Job)
+
+| 엔드포인트 | 설명 |
+| --- | --- |
+| `POST /api/commands/{sync,ingest,wiki-update}` | 각 작업 트리거 → `{ job_id, status: "started" }` (HTTP 202) |
+| `POST /api/commands/graph-rebuild` | 그래프 재구축. body: `{ since?, session?, all?, retry_failed? }` |
+
+> **단일 큐 정책**: 다른 mutating job 실행 중이면 `409 Conflict`. 우선순위(graph-rebuild): `session` > `all` > `retry_failed` > `since`.
+
+### Job
+
+| 엔드포인트 | 설명 |
+| --- | --- |
+| `GET /api/jobs` | Job 목록 |
+| `GET /api/jobs/{id}` | Job 상태 |
+| `GET /api/jobs/{id}/stream` | 진행 스트리밍 (SSE) |
+| `POST /api/jobs/{id}/cancel` | Job 취소 — `200 {cancelled:true}` (idempotent) / `404` (미등록·evict) |
+
+---
+
+## MCP 서버
+
+MCP 호환 AI 에이전트(Claude Code, Cursor 등)에서 seCall 검색을 사용한다.
+
+```bash
+# stdio 모드
+secall mcp
+
+# HTTP 모드
+secall mcp --http 127.0.0.1:8080
+```
+
+### 제공 도구
+
+| 도구 | 설명 |
+| --- | --- |
+| `recall` | 세션 검색 |
+| `get` | 특정 세션 조회 |
+| `status` | 인덱스 상태 확인 |
+| `wiki_search` | 위키 문서 검색 |
+| `graph_query` | Knowledge Graph 탐색 |
+
+### Claude Code 설정 예시
+
+```json
+{
+  "mcpServers": {
+    "secall": {
+      "command": "secall",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### 세션 시작 / 종료 시 자동 동기화 (hooks)
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": "startup|resume",
+      "hooks": [{
+        "type": "command",
+        "command": "secall sync --local-only"
+      }]
+    }],
+    "SessionEnd": [{
+      "hooks": [{
+        "type": "command",
+        "command": "secall sync"
+      }]
+    }]
+  }
+}
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -33,6 +33,7 @@ seCall 의 현재 기준 사실(SSOT) 문서 인덱스. 모든 항목은 "지금
 
 ### 운영·설정 가이드
 
+- [api.md](api.md) — API 레퍼런스 (REST 엔드포인트 + MCP 도구·설정). README 에서 분리된 API 상세 · 상태: done
 - [llm-config.md](llm-config.md) — LLM 백엔드 설정 (Ollama/Gemini/Anthropic, env/config.toml 우선순위) · 상태: done
 - [wiki-setup.md](wiki-setup.md) — Wiki 파이프라인 초기 설정 · 상태: done
 - [github-vault-sync.md](github-vault-sync.md) — Obsidian Vault ↔ GitHub 동기화 절차 · 상태: done


### PR DESCRIPTION
## 목적

README 를 '사용자가 바로 이해하고 시작하는 데 필요한 정보' 위주로 정리(798→729줄). 상세는 계층 문서로 분리.

## 변경
- **API 상세 → `docs/reference/api.md` (신규)**: MCP 도구 표·클라이언트 설정·hooks 예시 + REST 엔드포인트 전체. README 엔 요약 + 링크만.
- **버전/Phase 이력 → `CHANGELOG.md`**: README `## 업데이트 이력` 표 제거, 포인터로 대체. CHANGELOG 가 누락하던 **v0.3.x / v0.4.0 + 개발 Phase(P35~P44)** 구간을 이관(소실 방지) + 상단 NOTE 를 단일 SSOT 로 갱신.
- `docs/reference/index.md` 에 api.md 등록.

## 원칙
- 삭제 아닌 **이동(migrate)** + README→분리문서 링크. 코드/기능 변경 없음(docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)