### PR TITLE
docs(api): REST 응답 형식 한 줄 명시 (CodeRabbit 동작 확인)

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -26,6 +26,8 @@ secall serve --port 8080
 secall serve --allow-config-edit
 ```
 
+> 모든 응답 본문은 JSON 이다. 오류는 표준 HTTP 상태코드 + `{ "error": "..." }` 형태로 반환된다.
+
 ### 읽기 / 검색
 
 | 엔드포인트 | 설명 |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -26,7 +26,7 @@ secall serve --port 8080
 secall serve --allow-config-edit
 ```
 
-> 모든 응답 본문은 JSON 이다. 오류는 표준 HTTP 상태코드 + `{ "error": "..." }` 형태로 반환된다.
+> 모든 응답 본문은 JSON 이다(단, SSE 스트림인 `/api/jobs/{id}/stream` 은 `text/event-stream`, 개별 이벤트만 JSON). 오류는 표준 HTTP 상태코드 + `{ "error": "..." }` 형태로 반환된다.
 
 ### 읽기 / 검색
 


### PR DESCRIPTION
CodeRabbit 자동 리뷰 동작 확인용 테스트 PR. api.md 에 'REST 응답은 JSON, 오류는 표준 상태코드 + `{error}`' 한 줄 추가.

CodeRabbit 리뷰가 정상적으로 달리는지 확인 후, 내용 자체는 사소하므로 유지/머지 또는 close 판단.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added REST API response guidelines, clarifying that all response bodies are JSON.
  * Documented standardized error handling using standard HTTP status codes and a consistent `{"error":"..."}` response format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->