### PR TITLE
feat(wiki): claude 백엔드 model 문자열 pass-through (Sonnet 5 등 선택 가능)

### DIFF
--- a/crates/secall-core/src/wiki/claude.rs
+++ b/crates/secall-core/src/wiki/claude.rs
@@ -27,14 +27,13 @@ impl WikiBackend for ClaudeBackend {
             );
         }
 
-        // P56: review default (WIKI_REVIEW_DEFAULT="haiku") 가 claude CLI 에서
-        // 의도대로 동작하도록 alias 추가. 이전엔 "haiku" → fallback sonnet 으로
-        // 매핑되어 review default 효과 없었음.
-        let model_id = match self.model.as_str() {
-            "opus" => "claude-opus-4-6",
-            "haiku" => "claude-haiku-4-5",
-            _ => "claude-sonnet-4-6",
-        };
+        // model 문자열을 Claude Code CLI 에 그대로 전달한다. CLI 가 alias
+        // ("sonnet"/"opus"/"haiku" → 각 tier 최신) 와 full model id 를 자체
+        // 해석하므로, seCall 이 특정 버전으로 하드코딩 매핑하지 않는다.
+        // (이전엔 catch-all 이 "sonnet" 등 모든 값을 claude-sonnet-4-6 으로
+        //  삼켜 Sonnet 5 등 신규 모델 선택이 불가능했다. pass-through 로
+        //  CLI 의 최신-tier 해석 + 명시 model id 지정을 모두 허용.)
+        let model_id = self.model.as_str();
 
         let mut child = tokio::process::Command::new(crate::resolve_program("claude"))
             .args(["-p", "--model", model_id])


### PR DESCRIPTION
## 배경
`wiki/claude.rs` 가 model 을 고정 id 로 하드코딩 매핑(`opus→claude-opus-4-6`, `haiku→claude-haiku-4-5`, **그 외 전부→`claude-sonnet-4-6`**)해서, `--model sonnet` 은 물론 `--model claude-sonnet-5` 를 줘도 Sonnet 4.6 으로 삼켜졌습니다 → Claude Code CLI 가 지원하는 신규 모델(Sonnet 5 등)을 선택할 수 없었음.

## 변경
- 하드코딩 매핑을 제거하고 model 문자열을 **Claude Code CLI 에 그대로 전달**. CLI 가 alias("sonnet"/"opus"/"haiku" → 각 tier 최신)와 full model id 를 자체 해석.
- 효과: (1) CLI 최신-tier alias 해석, (2) 명시 model id 지정 모두 허용. `WIKI_CLAUDE_DEFAULT="sonnet"` 이므로 기본 claude wiki 가 최신 sonnet(Sonnet 5)으로 상승.

## 테스트
- ✅ cargo clippy --workspace --all-targets -D warnings / cargo test --workspace.
- 실동작(`claude -p`)은 사용자 환경(Max 200 플랜)에서 wiki `--session` 소량으로 확인 권장.

## 참고
model 하드코딩 전반(defaults.rs, review.rs) 은 model discovery 고도화(별도 작업)에서 정리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded model selection support so the app can pass through full Claude model IDs directly, enabling use of newer or custom-supported models.

* **Bug Fixes**
  * Improved model handling for non-standard values, avoiding unexpected fallback to a default model in cases where a specific model was requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->