### PR TITLE
feat(embedding): 기본 임베딩 모델 bge-m3 → qwen3-embedding:0.6b + 죽은 참고링크 제거

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -792,7 +792,8 @@ For auto-sync on session start/end:
 
 This project is built on ideas from:
 
-- **[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** by Andrej Karpathy — The pattern of using LLMs to incrementally build a persistent, interlinked knowledge base from raw sources. seCall's two-layer vault architecture (raw sessions + AI-generated wiki) directly implements this concept.- **[qmd](https://github.com/tobi/qmd)** by Tobi Lütke — A local search engine for markdown files with hybrid BM25/vector search. seCall's search pipeline (FTS5 BM25, vector embeddings, RRF k=60) was designed with reference to qmd's approach.
+- **[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** by Andrej Karpathy — The pattern of using LLMs to incrementally build a persistent, interlinked knowledge base from raw sources. seCall's two-layer vault architecture (raw sessions + AI-generated wiki) directly implements this concept.
+- **[qmd](https://github.com/tobi/qmd)** by Tobi Lütke — A local search engine for markdown files with hybrid BM25/vector search. seCall's search pipeline (FTS5 BM25, vector embeddings, RRF k=60) was designed with reference to qmd's approach.
 - **[graphify](https://github.com/safishamsi/graphify)** by Safi Shamsi — Turns file folders into queryable knowledge graphs. seCall P16's deterministic graph extraction and confidence labeling were inspired by this project.
 
 This project was developed using AI coding agents (Claude Code, Codex) orchestrated via [tunaFlow](https://github.com/hang-in/tunaFlow), a multi-agent workflow platform.

--- a/README.en.md
+++ b/README.en.md
@@ -278,7 +278,7 @@ Running `secall init` without arguments starts an interactive wizard:
 - Git remote (optional)
 - Tokenizer selection (lindera/kiwi)
 - Embedding backend selection (ollama/none)
-- Ollama installation check + automatic `bge-m3` model pull
+- Ollama installation check + automatic `qwen3-embedding:0.6b` model pull
 
 ### Step 3. Ingest Sessions
 
@@ -542,7 +542,7 @@ secall wiki status
 # Backfill page embeddings for semantic / hybrid wiki search (P40)
 secall wiki vectorize                      # incremental — skips unchanged pages by content_hash
 secall wiki vectorize --force              # full reindex (use after switching embedding model)
-secall wiki vectorize --model bge-m3 \
+secall wiki vectorize --model qwen3-embedding:0.6b \
     --ollama-url http://localhost:11434    # explicit overrides
 ```
 
@@ -554,7 +554,7 @@ curl -s -X POST http://localhost:3000/api/wiki \
   -H 'content-type: application/json' \
   -d '{"query":"vault auto commit"}'
 
-# Pure semantic (page-level cosine over bge-m3 embeddings)
+# Pure semantic (page-level cosine over qwen3-embedding:0.6b embeddings)
 curl -s -X POST http://localhost:3000/api/wiki \
   -d '{"query":"git automation","mode":"semantic"}'
 
@@ -679,7 +679,7 @@ secall serve --port 8080 --allow-config-edit
 | `search.tokenizer` | Tokenizer (`lindera` / `kiwi`) | `lindera` |
 | `search.default_limit` | Search result count | `10` |
 | `embedding.backend` | Embedding backend (`ollama` / `ort` / `openai` / `openvino` / `ollama_cloud`) | `ollama` |
-| `embedding.ollama_model` | Ollama model name | `bge-m3` |
+| `embedding.ollama_model` | Ollama model name | `qwen3-embedding:0.6b` |
 | `embedding.pool_size` | ORT session pool size (null = auto from RAM) | `null` |
 | `embedding.cloud_host` | Ollama Cloud API host | `https://ollama.com` |
 | `embedding.cloud_model` | Ollama Cloud embedding model name | `null` |
@@ -792,8 +792,7 @@ For auto-sync on session start/end:
 
 This project is built on ideas from:
 
-- **[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** by Andrej Karpathy — The pattern of using LLMs to incrementally build a persistent, interlinked knowledge base from raw sources. seCall's two-layer vault architecture (raw sessions + AI-generated wiki) directly implements this concept. See also [Tobi Lütke's implementation](https://github.com/tobi/llm-wiki).
-- **[qmd](https://github.com/tobi/qmd)** by Tobi Lütke — A local search engine for markdown files with hybrid BM25/vector search. seCall's search pipeline (FTS5 BM25, vector embeddings, RRF k=60) was designed with reference to qmd's approach.
+- **[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** by Andrej Karpathy — The pattern of using LLMs to incrementally build a persistent, interlinked knowledge base from raw sources. seCall's two-layer vault architecture (raw sessions + AI-generated wiki) directly implements this concept.- **[qmd](https://github.com/tobi/qmd)** by Tobi Lütke — A local search engine for markdown files with hybrid BM25/vector search. seCall's search pipeline (FTS5 BM25, vector embeddings, RRF k=60) was designed with reference to qmd's approach.
 - **[graphify](https://github.com/safishamsi/graphify)** by Safi Shamsi — Turns file folders into queryable knowledge graphs. seCall P16's deterministic graph extraction and confidence labeling were inspired by this project.
 
 This project was developed using AI coding agents (Claude Code, Codex) orchestrated via [tunaFlow](https://github.com/hang-in/tunaFlow), a multi-agent workflow platform.

--- a/README.ja.md
+++ b/README.ja.md
@@ -277,7 +277,7 @@ secall init --git git@github.com:you/obsidian-vault.git
 - Gitリモート (オプション)
 - トークナイザー選択 (lindera/kiwi)
 - エンベディングバックエンド選択 (ollama/none)
-- Ollama インストール確認 + `bge-m3` モデル自動pull
+- Ollama インストール確認 + `qwen3-embedding:0.6b` モデル自動pull
 
 ### Step 3. セッション収集
 
@@ -660,7 +660,7 @@ secall serve --port 8080 --allow-config-edit
 | `search.tokenizer` | トークナイザー (`lindera` / `kiwi`) | `lindera` |
 | `search.default_limit` | 検索結果数 | `10` |
 | `embedding.backend` | エンベディングバックエンド (`ollama` / `ort` / `openai` / `openvino` / `ollama_cloud`) | `ollama` |
-| `embedding.ollama_model` | Ollama モデル名 | `bge-m3` |
+| `embedding.ollama_model` | Ollama モデル名 | `qwen3-embedding:0.6b` |
 | `embedding.pool_size` | ORT session pool サイズ (未設定 = RAM ベース自動) | `null` |
 | `embedding.cloud_host` | Ollama Cloud API ホスト | `https://ollama.com` |
 | `embedding.cloud_model` | Ollama Cloud embedding モデル名 | `null` |
@@ -771,7 +771,7 @@ Claude Code 設定 (`~/.claude/settings.json`) に追加:
 
 本プロジェクトは以下のアイデア・プロジェクトをベースにしています:
 
-- **[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** (Andrej Karpathy) — LLM を用いて原本ソースから段階的にナレッジベースを構築するパターン。seCall の 2層ボールトアーキテクチャ (原本セッション + AI 生成 Wiki) はこのコンセプトを直接実装したものです。[Tobi Lütke の実装](https://github.com/tobi/llm-wiki) も参考。
+- **[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** (Andrej Karpathy) — LLM を用いて原本ソースから段階的にナレッジベースを構築するパターン。seCall の 2層ボールトアーキテクチャ (原本セッション + AI 生成 Wiki) はこのコンセプトを直接実装したものです。
 - **[qmd](https://github.com/tobi/qmd)** (Tobi Lütke) — マークダウンファイル向けローカル検索エンジン。seCall の検索パイプライン (FTS5 BM25、ベクトルエンベディング、RRF k=60) は qmd のアプローチを参考に設計されています。
 - **[graphify](https://github.com/safishamsi/graphify)** (Safi Shamsi) — ファイルフォルダを knowledge graph に変換するツール。seCall P16 の決定論的グラフ抽出と confidence ラベリングはこのプロジェクトに着想を得ています。
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ secall init --git git@github.com:you/obsidian-vault.git
 | Git remote | 여러 기기 동기화용 원격 저장소                                             |
 | 토크나이저      | `lindera` 또는 `kiwi`                                           |
 | 임베딩 백엔드    | `ollama`, `ort`, `openai`, `openvino`, `ollama_cloud`, `none` |
-| Ollama 모델  | 기본값 `bge-m3`                                                  |
+| Ollama 모델  | 기본값 `qwen3-embedding:0.6b`                                                  |
 
 ---
 
@@ -548,7 +548,7 @@ secall serve --port 8080 --allow-config-edit
 | `search.tokenizer`       | `lindera` 또는 `kiwi`  | `lindera`                 |
 | `search.default_limit`   | 기본 검색 결과 수           | `10`                      |
 | `embedding.backend`      | 임베딩 백엔드              | `ollama`                  |
-| `embedding.ollama_model` | Ollama 임베딩 모델        | `bge-m3`                  |
+| `embedding.ollama_model` | Ollama 임베딩 모델        | `qwen3-embedding:0.6b`                  |
 | `embedding.cloud_host`   | Ollama Cloud API 호스트 | `https://ollama.com`      |
 | `output.timezone`        | IANA 타임존             | `UTC`                     |
 | `graph.semantic_backend` | 그래프 시맨틱 추출 백엔드       | `none`                    |
@@ -702,7 +702,6 @@ interfaces
 ## 참고한 프로젝트와 아이디어
 
 * [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — LLM으로 원본 자료에서 점진적 지식 베이스를 만드는 패턴
-* [tobi/llm-wiki](https://github.com/tobi/llm-wiki) — LLM Wiki 구현 참고
 * [qmd](https://github.com/tobi/qmd) — Markdown 파일용 로컬 검색 엔진
 * [graphify](https://github.com/safishamsi/graphify) — 파일 폴더를 Knowledge Graph로 변환하는 접근
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -277,7 +277,7 @@ secall init --git git@github.com:you/obsidian-vault.git
 - Git remote（可选）
 - 分词器选择（lindera/kiwi）
 - 嵌入后端选择（ollama/none）
-- Ollama 安装检查 + 自动 pull `bge-m3` 模型
+- Ollama 安装检查 + 自动 pull `qwen3-embedding:0.6b` 模型
 
 ### Step 3. 收集会话
 
@@ -660,7 +660,7 @@ secall serve --port 8080 --allow-config-edit
 | `search.tokenizer` | 分词器（`lindera` / `kiwi`） | `lindera` |
 | `search.default_limit` | 检索结果数 | `10` |
 | `embedding.backend` | 嵌入后端（`ollama` / `ort` / `openai` / `openvino` / `ollama_cloud`） | `ollama` |
-| `embedding.ollama_model` | Ollama 模型名 | `bge-m3` |
+| `embedding.ollama_model` | Ollama 模型名 | `qwen3-embedding:0.6b` |
 | `embedding.pool_size` | ORT session pool 大小（未设置 = 根据 RAM 自动） | `null` |
 | `embedding.cloud_host` | Ollama Cloud API host | `https://ollama.com` |
 | `embedding.cloud_model` | Ollama Cloud embedding 模型名 | `null` |
@@ -771,7 +771,7 @@ secall serve --port 8080 --allow-config-edit
 
 本项目基于以下想法与项目:
 
-- **[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** (Andrej Karpathy) — 用 LLM 从原始素材逐步构建知识库的模式。seCall 的双层 vault 架构（原始会话 + AI 生成 wiki）正是该理念的直接落地。也可参考 [Tobi Lütke 的实现](https://github.com/tobi/llm-wiki)。
+- **[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** (Andrej Karpathy) — 用 LLM 从原始素材逐步构建知识库的模式。seCall 的双层 vault 架构（原始会话 + AI 生成 wiki）正是该理念的直接落地。
 - **[qmd](https://github.com/tobi/qmd)** (Tobi Lütke) — 面向 Markdown 文件的本地搜索引擎。seCall 的搜索流水线（FTS5 BM25、向量嵌入、RRF k=60）参考了 qmd 的思路。
 - **[graphify](https://github.com/safishamsi/graphify)** (Safi Shamsi) — 将文件夹转换为 knowledge graph 的工具。seCall P16 的确定性图谱抽取与 confidence 标注从该项目获得灵感。
 

--- a/crates/secall-core/src/search/embedding.rs
+++ b/crates/secall-core/src/search/embedding.rs
@@ -45,7 +45,7 @@ impl OllamaEmbedder {
         OllamaEmbedder {
             client: Client::new(),
             base_url: base_url.unwrap_or("http://localhost:11434").to_string(),
-            model: model.unwrap_or("bge-m3").to_string(),
+            model: model.unwrap_or("qwen3-embedding:0.6b").to_string(),
             api_key: None,
         }
     }
@@ -122,7 +122,7 @@ impl Embedder for OllamaEmbedder {
     }
 
     fn dimensions(&self) -> usize {
-        1024 // bge-m3 default
+        1024 // qwen3-embedding:0.6b / bge-m3 (both 1024-dim)
     }
 
     fn model_name(&self) -> &str {

--- a/crates/secall/src/commands/graph.rs
+++ b/crates/secall/src/commands/graph.rs
@@ -55,7 +55,11 @@ pub async fn run_semantic(
 
     // 임베딩 모델 언로드 (gemma4와 동시 로드 방지)
     if config.embedding.backend == "ollama" {
-        let embed_model = config.embedding.ollama_model.as_deref().unwrap_or("bge-m3");
+        let embed_model = config
+            .embedding
+            .ollama_model
+            .as_deref()
+            .unwrap_or("qwen3-embedding:0.6b");
         let ollama_url = config
             .embedding
             .ollama_url

--- a/crates/secall/src/commands/ingest.rs
+++ b/crates/secall/src/commands/ingest.rs
@@ -883,14 +883,18 @@ pub async fn extract_one_session_semantic(
 
 /// P37 Task 01 — 시맨틱 추출 직전 임베딩 모델 unload.
 ///
-/// 16GB 시스템에서 bge-m3(임베딩) 와 gemma4(LLM) 동시 로드 시
+/// 16GB 시스템에서 qwen3-embedding(임베딩) 와 gemma4(LLM) 동시 로드 시
 /// OOM 위험을 줄이기 위해 시맨틱 backend 가 ollama 인 경우에만 발사.
 /// ingest 와 graph rebuild 둘 다 진입 시점에 한 번 호출한다.
 pub async fn unload_embedding_model_if_needed(config: &Config) {
     if config.embedding.backend != "ollama" || config.graph.semantic_backend != "ollama" {
         return;
     }
-    let embed_model = config.embedding.ollama_model.as_deref().unwrap_or("bge-m3");
+    let embed_model = config
+        .embedding
+        .ollama_model
+        .as_deref()
+        .unwrap_or("qwen3-embedding:0.6b");
     let ollama_url = config
         .embedding
         .ollama_url
@@ -914,7 +918,11 @@ pub async fn unload_ollama_embed_model(config: &Config) {
     if config.embedding.backend != "ollama" {
         return;
     }
-    let embed_model = config.embedding.ollama_model.as_deref().unwrap_or("bge-m3");
+    let embed_model = config
+        .embedding
+        .ollama_model
+        .as_deref()
+        .unwrap_or("qwen3-embedding:0.6b");
     let ollama_url = config
         .embedding
         .ollama_url

--- a/crates/secall/src/commands/init.rs
+++ b/crates/secall/src/commands/init.rs
@@ -146,7 +146,7 @@ fn run_interactive() -> Result<()> {
     // Step 5: 임베딩 백엔드
     println!("  Step 5/6: 임베딩 백엔드");
     let backend_items = vec![
-        "ollama — 로컬 임베딩 (bge-m3, 무료)",
+        "ollama — 로컬 임베딩 (qwen3-embedding:0.6b, 무료)",
         "none — 벡터 검색 비활성화 (BM25만 사용)",
     ];
     let backend_default = if config.embedding.backend == "none" {
@@ -215,7 +215,7 @@ fn check_and_setup_ollama() -> Result<()> {
         println!();
         println!("    설치 후 다음 명령을 실행하세요:");
         println!("      ollama serve          # 서버 시작");
-        println!("      ollama pull bge-m3    # 임베딩 모델 다운로드");
+        println!("      ollama pull qwen3-embedding:0.6b  # 임베딩 모델 다운로드");
         println!();
         println!("    Ollama 없이도 BM25 검색은 사용 가능합니다.");
         println!("    나중에 `secall config set embedding.backend ollama`로 변경할 수 있습니다.");
@@ -235,22 +235,24 @@ fn check_and_setup_ollama() -> Result<()> {
     };
 
     let models = String::from_utf8_lossy(&list_output.stdout);
-    if models.contains("bge-m3") {
-        println!("  ✓ bge-m3 모델이 이미 설치되어 있습니다.");
+    if models.contains("qwen3-embedding:0.6b") {
+        println!("  ✓ qwen3-embedding:0.6b 모델이 이미 설치되어 있습니다.");
         return Ok(());
     }
 
-    println!("  ⟳ ollama pull bge-m3 실행 중... (최초 ~1.5GB 다운로드)");
+    println!("  ⟳ ollama pull qwen3-embedding:0.6b 실행 중... (최초 ~640MB 다운로드)");
     let status = Command::new("ollama")
-        .args(["pull", "bge-m3"])
+        .args(["pull", "qwen3-embedding:0.6b"])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()?;
 
     if status.success() {
-        println!("  ✓ bge-m3 모델 준비 완료.");
+        println!("  ✓ qwen3-embedding:0.6b 모델 준비 완료.");
     } else {
-        println!("  ⚠ 모델 다운로드 실패. 나중에 `ollama pull bge-m3`로 재시도하세요.");
+        println!(
+            "  ⚠ 모델 다운로드 실패. 나중에 `ollama pull qwen3-embedding:0.6b`로 재시도하세요."
+        );
     }
     Ok(())
 }

--- a/crates/secall/src/commands/status.rs
+++ b/crates/secall/src/commands/status.rs
@@ -20,7 +20,11 @@ pub fn run() -> Result<()> {
 
     let embedding_detail = match config.embedding.backend.as_str() {
         "ollama" => {
-            let model = config.embedding.ollama_model.as_deref().unwrap_or("bge-m3");
+            let model = config
+                .embedding
+                .ollama_model
+                .as_deref()
+                .unwrap_or("qwen3-embedding:0.6b");
             format!("ollama ({})", model)
         }
         "ort" => "ort (local ONNX, CPU)".to_string(),

--- a/crates/secall/src/main.rs
+++ b/crates/secall/src/main.rs
@@ -386,7 +386,7 @@ enum WikiAction {
         force: bool,
 
         /// Embedding model ID
-        #[arg(long, default_value = "bge-m3")]
+        #[arg(long, default_value = "qwen3-embedding:0.6b")]
         model: String,
 
         /// Ollama base URL


### PR DESCRIPTION
## 요약
fresh-install 기본 임베딩 모델을 `bge-m3` → `qwen3-embedding:0.6b` 로 전환하고, README(ko/en/ja/zh)를 갱신하며, 죽은 참고 링크(`github.com/tobi/llm-wiki`, 404)를 제거합니다.

## 배경
- tunaRound 벤치(실코퍼스 18발언/12질의): qwen3-embedding:0.6b 가 MRR 우위 (vecMRR 0.958 vs bge-m3 0.903, hybMRR 1.000 vs 0.917). R@5 는 둘 다 1.000(소코퍼스 포화). 둘 다 1024-dim → 드롭인 교체.
- 운영 DB 는 이미 qwen 전량이라 **재색인 불필요**. 이 PR 은 신규 설치 기본값 + 문서 정합화.

## 변경
- 임베딩 default(`unwrap_or`) 5곳: `embedding.rs` · `status.rs` · `ingest.rs`(×2) · `graph.rs`
- `main.rs` `wiki vectorize --model` 기본값
- `init.rs` 자동 pull 플로우(안내문구 · pull 대상 · 다운로드 크기 ~640MB)
- README 기본값·설치안내·예시 갱신 (버전이력 CHANGELOG 항목은 역사적 기록이라 의도적으로 유지)
- 죽은 링크 `tobi/llm-wiki` 제거 — 실제 출처('LLM Wiki' 패턴=Karpathy, Tobi=`qmd`)는 README 에 이미 링크됨

## 유지(비변경)
- ort/openvino ONNX 경로 `BAAI/bge-m3` (qwen ONNX 미지원)

## 검증
- `cargo fmt --check` ✓ · `cargo clippy --all-targets` 0 warning ✓ · `cargo test -p secall-core --lib` 448 passed ✓

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Updates**
  * Switched the default Ollama embedding model from `bge-m3` to `qwen3-embedding:0.6b` across initialization, status reporting, semantic search, wiki vectorization, and Ollama model unload/install flows.
* **Documentation**
  * Updated README files (all languages) to reflect the new default model in examples, configuration defaults (`embedding.ollama_model`), and the wiki vectorize `--model` guidance.
  * Cleaned up related reference links in the acknowledgments/source sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->