### PR TITLE
fix(wiki-search): 위키 시맨틱 검색 쿼리를 config 임베딩 경로로 통일

### DIFF
--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -14,7 +14,6 @@ use super::tools::{
 };
 use crate::search::bm25::{SearchFilters, SearchResult};
 use crate::search::hybrid::{diversify_by_session, parse_temporal_filter, SearchEngine};
-use crate::search::{Embedder, OllamaEmbedder};
 use crate::store::db::Database;
 use crate::store::{SessionRepo, WikiVectorRepo};
 use crate::vault::Config;
@@ -755,11 +754,12 @@ impl SeCallMcpServer {
             return Ok(Vec::new());
         }
 
-        let query_embedding = {
-            let base_url = std::env::var("OLLAMA_BASE_URL").ok();
-            let model = std::env::var("OLLAMA_EMBED_MODEL").ok();
-            let embedder = OllamaEmbedder::new(base_url.as_deref(), model.as_deref());
-            run_future_blocking(embedder.embed(&params.query))?
+        // 세션 recall(do_recall)과 동일하게 config 임베딩 경로(SearchEngine::embed_query)를 사용한다.
+        // (기존엔 OLLAMA_EMBED_MODEL env / OllamaEmbedder 기본값(bge-m3)으로 쿼리를 임베딩해,
+        //  config(qwen) 로 vectorize 된 wiki_vectors 와 교차모델 불일치 → 시맨틱 위키검색이 무의미했음)
+        let query_embedding = match run_future_blocking(self.search.embed_query(&params.query))? {
+            Some(vec) => vec,
+            None => return Ok(Vec::new()),
         };
 
         let category_prefix = params


### PR DESCRIPTION
## 문제
위키 시맨틱/hybrid 검색이 무관한 결과(near-zero cosine, 무작위 랭킹)를 반환. 세션 검색은 정상.

## 원인
`collect_semantic_matches`(mcp/server.rs)가 쿼리 임베딩을 `OLLAMA_EMBED_MODEL` env / `OllamaEmbedder` 기본값(v0.6.4=`bge-m3`)으로 생성 → config(`embedding.ollama_model`=qwen3-embedding:0.6b)로 vectorize 된 `wiki_vectors` 와 **교차모델 불일치**. 세션 recall(`do_recall`)은 config 경로(`self.search.embed_query`)를 쓰므로 정상 — 위키만 config 를 무시하던 버그.

## 수정
쿼리 임베딩을 세션 검색과 동일한 `self.search.embed_query()`(config 임베딩 경로)로 통일. 벡터 백엔드 미설정 시 빈 결과. MCP `wiki_search` 와 REST `/api/wiki` 가 같은 `do_wiki_search` 를 공유하므로 양쪽 모두 해결. 미사용 `Embedder`/`OllamaEmbedder` import 제거.

## 검증
`cargo fmt --check` ✓ · `cargo clippy -p secall-core --all-targets` 0 warning ✓ · `cargo test -p secall-core --lib` 448 passed ✓

## 배포 유의
런타임 반영엔 `cargo install --path crates/secall --force` (+MCP 재시작) 필요. 기존 qwen 으로 vectorize 된 wiki_vectors 는 그대로 재사용 가능(재vectorize 불요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wiki semantic search so it uses the app’s shared embedding path.
  * When embeddings aren’t available, semantic search now returns no matches instead of failing or producing inconsistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->