### PR TITLE
docs: 참고 프로젝트에 nashsu/llm_wiki 추가

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -793,6 +793,7 @@ For auto-sync on session start/end:
 This project is built on ideas from:
 
 - **[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** by Andrej Karpathy — The pattern of using LLMs to incrementally build a persistent, interlinked knowledge base from raw sources. seCall's two-layer vault architecture (raw sessions + AI-generated wiki) directly implements this concept.
+- **[nashsu/llm_wiki](https://github.com/nashsu/llm_wiki)** by nashsu — A full desktop-app implementation of the same LLM Wiki pattern (source tracing, knowledge graph, semantic search, MCP, Obsidian-compatible). seCall specializes the pattern for **AI-agent session logs** as a CLI/MCP tool.
 - **[qmd](https://github.com/tobi/qmd)** by Tobi Lütke — A local search engine for markdown files with hybrid BM25/vector search. seCall's search pipeline (FTS5 BM25, vector embeddings, RRF k=60) was designed with reference to qmd's approach.
 - **[graphify](https://github.com/safishamsi/graphify)** by Safi Shamsi — Turns file folders into queryable knowledge graphs. seCall P16's deterministic graph extraction and confidence labeling were inspired by this project.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -772,6 +772,7 @@ Claude Code 設定 (`~/.claude/settings.json`) に追加:
 本プロジェクトは以下のアイデア・プロジェクトをベースにしています:
 
 - **[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** (Andrej Karpathy) — LLM を用いて原本ソースから段階的にナレッジベースを構築するパターン。seCall の 2層ボールトアーキテクチャ (原本セッション + AI 生成 Wiki) はこのコンセプトを直接実装したものです。
+- **[nashsu/llm_wiki](https://github.com/nashsu/llm_wiki)** (nashsu) — 同じ LLM Wiki パターンの本格的なデスクトップアプリ実装 (source 追跡・知識グラフ・セマンティック検索・MCP・Obsidian 互換)。seCall は同パターンを **AI エージェントのセッションログ** に特化した CLI/MCP ツール。
 - **[qmd](https://github.com/tobi/qmd)** (Tobi Lütke) — マークダウンファイル向けローカル検索エンジン。seCall の検索パイプライン (FTS5 BM25、ベクトルエンベディング、RRF k=60) は qmd のアプローチを参考に設計されています。
 - **[graphify](https://github.com/safishamsi/graphify)** (Safi Shamsi) — ファイルフォルダを knowledge graph に変換するツール。seCall P16 の決定論的グラフ抽出と confidence ラベリングはこのプロジェクトに着想を得ています。
 

--- a/README.md
+++ b/README.md
@@ -702,6 +702,7 @@ interfaces
 ## 참고한 프로젝트와 아이디어
 
 * [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — LLM으로 원본 자료에서 점진적 지식 베이스를 만드는 패턴
+* [nashsu/llm_wiki](https://github.com/nashsu/llm_wiki) — 위 패턴을 구현한 대표적 풀 데스크톱 앱(Tauri): source 추적 · 지식그래프 · 시맨틱 검색 · MCP · Obsidian 호환. seCall 은 같은 패턴을 **AI 에이전트 세션 로그**에 특화한 CLI/MCP 도구.
 * [qmd](https://github.com/tobi/qmd) — Markdown 파일용 로컬 검색 엔진
 * [graphify](https://github.com/safishamsi/graphify) — 파일 폴더를 Knowledge Graph로 변환하는 접근
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -772,6 +772,7 @@ secall serve --port 8080 --allow-config-edit
 本项目基于以下想法与项目:
 
 - **[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** (Andrej Karpathy) — 用 LLM 从原始素材逐步构建知识库的模式。seCall 的双层 vault 架构（原始会话 + AI 生成 wiki）正是该理念的直接落地。
+- **[nashsu/llm_wiki](https://github.com/nashsu/llm_wiki)** (nashsu) — 同一 LLM Wiki 模式的完整桌面应用实现 (source 追踪、知识图谱、语义搜索、MCP、兼容 Obsidian)。seCall 将该模式专门用于 **AI 智能体会话日志**，作为 CLI/MCP 工具。
 - **[qmd](https://github.com/tobi/qmd)** (Tobi Lütke) — 面向 Markdown 文件的本地搜索引擎。seCall 的搜索流水线（FTS5 BM25、向量嵌入、RRF k=60）参考了 qmd 的思路。
 - **[graphify](https://github.com/safishamsi/graphify)** (Safi Shamsi) — 将文件夹转换为 knowledge graph 的工具。seCall P16 的确定性图谱抽取与 confidence 标注从该项目获得灵感。
 


### PR DESCRIPTION
## 요약
README(ko/en/ja/zh) "참고한 프로젝트와 아이디어" 섹션에 **[nashsu/llm_wiki](https://github.com/nashsu/llm_wiki)** (13.5k⭐, Tauri 데스크톱 앱)를 추가.

Karpathy 의 "LLM Wiki" 패턴을 풀-앱으로 구현한 대표 프로젝트로, source 추적·지식그래프·시맨틱 검색·MCP·Obsidian 호환 등 seCall 위키 스택과 개념이 겹친다. 문구에 **seCall 은 같은 패턴을 AI 에이전트 세션 로그에 특화한 CLI/MCP 도구**임을 명시해 차별점을 드러냄.

Karpathy(패턴) 항목 바로 다음에 배치. 문서 변경만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README in English, Japanese, Korean, and Chinese.
  * Added a new referenced project to the acknowledgments/source lists.
  * Expanded the project description to clarify the app’s positioning and supported workflow compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->