### PR TITLE
fix(web): 세션 삭제 낙관적 처리 + 우측 카드 sticky 고정

### DIFF
--- a/web/src/components/SessionAside.tsx
+++ b/web/src/components/SessionAside.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 export function SessionAside({ sessionId, detail }: Props) {
   return (
-    <aside className="w-full max-w-[300px] shrink-0 space-y-ds-4">
+    <aside className="w-full max-w-[300px] shrink-0 space-y-ds-4 lg:sticky lg:top-ds-6 lg:self-start">
       <MetaCard detail={detail} />
       <MiniChartCard detail={detail} />
       <RelatedCard sessionId={sessionId} />

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -68,13 +68,11 @@ export function SessionList({ query, mode, filters, pageSize = 100 }: Props) {
   const confirmDelete = () => {
     if (!pendingDelete) return;
     const deletingId = pendingDelete.id;
-    deleteMutation.mutate(deletingId, {
-      onSuccess: () => {
-        setPendingDelete(null);
-        // 삭제한 세션이 현재 열려 있으면 목록으로 이동.
-        if (id === deletingId) navigate("/sessions");
-      },
-    });
+    // 낙관적 삭제(useDeleteSession onMutate)로 목록에서 즉시 사라지므로,
+    // 서버 응답을 기다리지 않고 모달을 닫고 라우팅한다 (UI 멈춤 제거).
+    setPendingDelete(null);
+    if (id === deletingId) navigate("/sessions");
+    deleteMutation.mutate(deletingId);
   };
 
   // 시맨틱 모드 + 비어있지 않은 query에서만 recall 호출. 그 외엔 keyword 리스트.

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -123,11 +123,14 @@ export function useDeleteSession() {
     onMutate: async (id: string) => {
       await qc.cancelQueries({ queryKey: ["sessions"] });
       await qc.cancelQueries({ queryKey: ["recall"] });
+      // 낙관 업데이트 대상 쿼리만 정밀 백업 — ["sessions"] 전체는 detail 쿼리까지
+      // 잡아 롤백 시 무관한 상세 변경이 유실될 수 있어 제외.
       const prev = [
-        ...qc.getQueriesData({ queryKey: ["sessions"] }),
+        ...qc.getQueriesData({ queryKey: ["sessions", "infinite"] }),
+        ...qc.getQueriesData({ queryKey: ["sessions", "list"] }),
         ...qc.getQueriesData({ queryKey: ["recall"] }),
       ];
-      // 무한 스크롤 리스트: pages[].items 에서 제거
+      // 무한 스크롤 리스트: pages[].items 제거 + total 차감(카운트/끝 표시 정합).
       qc.setQueriesData(
         { queryKey: ["sessions", "infinite"] },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -136,36 +139,38 @@ export function useDeleteSession() {
             ? {
                 ...old,
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                pages: old.pages.map((p: any) => ({
-                  ...p,
+                pages: old.pages.map((p: any) => {
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  items: p.items.filter((s: any) => s.id !== id),
-                })),
+                  const items = p.items.filter((s: any) => s.id !== id);
+                  const removed = p.items.length - items.length;
+                  return { ...p, items, total: Math.max(0, p.total - removed) };
+                }),
               }
             : old,
       );
-      // 단일 리스트: items 에서 제거
+      // 단일 리스트: items 제거 + total 차감.
       qc.setQueriesData(
         { queryKey: ["sessions", "list"] },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (old: any) =>
-          old?.items
-            ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              { ...old, items: old.items.filter((s: any) => s.id !== id) }
-            : old,
+        (old: any) => {
+          if (!old?.items) return old;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const items = old.items.filter((s: any) => s.id !== id);
+          const removed = old.items.length - items.length;
+          return { ...old, items, total: Math.max(0, (old.total ?? 0) - removed) };
+        },
       );
-      // 시맨틱 결과: results 에서 제거
+      // 시맨틱 결과: results 제거 + count 차감.
       qc.setQueriesData(
         { queryKey: ["recall"] },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (old: any) =>
-          old?.results
-            ? {
-                ...old,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                results: old.results.filter((r: any) => r.session_id !== id),
-              }
-            : old,
+        (old: any) => {
+          if (!old?.results) return old;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const results = old.results.filter((r: any) => r.session_id !== id);
+          const removed = old.results.length - results.length;
+          return { ...old, results, count: Math.max(0, (old.count ?? 0) - removed) };
+        },
       );
       return { prev };
     },

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -118,10 +118,64 @@ export function useDeleteSession() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.deleteSession(id),
-    onSuccess: () => {
+    // 낙관적 삭제 — 백엔드 응답을 기다리지 않고 캐시에서 즉시 제거해 UI "멈춤" 체감을 없앤다.
+    // (백엔드 delete_session_full 의 turns_fts 풀스캔 지연은 별건으로 근본 수정 예정.)
+    onMutate: async (id: string) => {
+      await qc.cancelQueries({ queryKey: ["sessions"] });
+      await qc.cancelQueries({ queryKey: ["recall"] });
+      const prev = [
+        ...qc.getQueriesData({ queryKey: ["sessions"] }),
+        ...qc.getQueriesData({ queryKey: ["recall"] }),
+      ];
+      // 무한 스크롤 리스트: pages[].items 에서 제거
+      qc.setQueriesData(
+        { queryKey: ["sessions", "infinite"] },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (old: any) =>
+          old?.pages
+            ? {
+                ...old,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                pages: old.pages.map((p: any) => ({
+                  ...p,
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  items: p.items.filter((s: any) => s.id !== id),
+                })),
+              }
+            : old,
+      );
+      // 단일 리스트: items 에서 제거
+      qc.setQueriesData(
+        { queryKey: ["sessions", "list"] },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (old: any) =>
+          old?.items
+            ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              { ...old, items: old.items.filter((s: any) => s.id !== id) }
+            : old,
+      );
+      // 시맨틱 결과: results 에서 제거
+      qc.setQueriesData(
+        { queryKey: ["recall"] },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (old: any) =>
+          old?.results
+            ? {
+                ...old,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                results: old.results.filter((r: any) => r.session_id !== id),
+              }
+            : old,
+      );
+      return { prev };
+    },
+    onError: (_err, _id, ctx) => {
+      // 실패 시 스냅샷 롤백
+      ctx?.prev?.forEach(([key, data]) => qc.setQueryData(key, data));
+    },
+    onSettled: () => {
+      // 서버 상태와 최종 동기화
       qc.invalidateQueries({ queryKey: ["sessions"] });
-      // 시맨틱 검색 결과(["recall","semantic",...])도 무효화 — 시맨틱 모드에서
-      // 삭제 시 목록에서 즉시 사라지도록.
       qc.invalidateQueries({ queryKey: ["recall"] });
     },
   });


### PR DESCRIPTION
실사용 피드백 2건 (저위험·즉효). 원인은 병렬 진단 워크플로우로 규명.

## #3-A 세션 삭제 UI 멈춤

**원인**: `useDeleteSession`에 낙관적 업데이트가 없어 `mutate`가 DELETE 왕복 + refetch를 await → 그동안 모달이 잠긴 채 UI가 멈춘 것처럼 보임. (백엔드 `delete_session_full`의 `turns_fts` FTS5 풀스캔이 0-turn 세션도 O(코퍼스)로 느린 게 근본 지연 — **별건으로 근본 수정 예정**.)

**수정**: `onMutate`로 sessions(infinite/list)·recall 캐시에서 즉시 제거 + `onError` 롤백 + `onSettled` 재동기화. `confirmDelete`는 서버 응답을 안 기다리고 모달 즉시 닫음.

## #4 우측 카드가 스크롤 따라 사라짐

**원인**: `SessionAside`의 `<aside>`가 position:static이라 공유 스크롤 컨테이너(`SessionsRoute`)에서 본문과 함께 밀려 올라감.

**수정**: `lg:sticky lg:top-ds-6 lg:self-start`. `self-start`로 stretch를 무력화해 sticky가 실제 고정되게 하고, 2-column(lg) 폭에서만 적용(모바일 1열은 자연 흐름 유지). (RelatedSessions.tsx는 미사용 데드코드라 손대지 않음.)

## 검증
`tsc --noEmit` / `vite build` / `vitest` 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7GAhYSbQZZQ29xiwX9pa8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 세션 삭제가 낙관적 방식으로 즉시 반영되어, 목록에서 더 빠르게 사라집니다.
  * 현재 세션을 삭제할 때 즉시 세션 목록 화면으로 이동하도록 개선했습니다.
  * 세션 사이드바가 큰 화면에서 반응형 스티키로 동작해 스크롤 시 위치가 더 안정적입니다.

* **Bug Fixes**
  * 삭제 모달이 서버 응답 대기 없이 즉시 닫히도록 변경했습니다.
  * 삭제 실패 시 이전 상태로 되돌려 데이터 일관성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->