### PR TITLE
fix(web+core): 데일리 노트 timezone 매칭 — 브라우저 tz offset 전달

### DIFF
--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -77,6 +77,8 @@ impl From<RestGetParams> for GetParams {
 #[derive(Debug, Deserialize)]
 struct RestDailyParams {
     date: Option<String>, // "YYYY-MM-DD", 기본 오늘
+    #[serde(default)]
+    tz_offset: i64, // 요청자 로컬 - UTC (분). 미전달 시 0(UTC 기준 매칭).
 }
 
 #[derive(Debug, Deserialize)]
@@ -310,7 +312,7 @@ async fn api_daily(
     let date = p
         .date
         .unwrap_or_else(|| chrono::Local::now().format("%Y-%m-%d").to_string());
-    match s.do_daily(&date) {
+    match s.do_daily(&date, p.tz_offset) {
         Ok(json) => (StatusCode::OK, Json(json)).into_response(),
         Err(e) => error_response(e),
     }

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -886,13 +886,13 @@ impl SeCallMcpServer {
         }))
     }
 
-    pub fn do_daily(&self, date: &str) -> anyhow::Result<serde_json::Value> {
+    pub fn do_daily(&self, date: &str, tz_offset_min: i64) -> anyhow::Result<serde_json::Value> {
         let db = self
             .db
             .lock()
             .map_err(|e| anyhow::anyhow!("DB lock: {e}"))?;
 
-        let sessions = db.get_sessions_for_date(date)?;
+        let sessions = db.get_sessions_for_date(date, tz_offset_min)?;
         let total_sessions = sessions.len();
 
         // 자동화/노이즈 세션 필터링: 최소 2턴, automated 제외

--- a/crates/secall-core/src/store/db.rs
+++ b/crates/secall-core/src/store/db.rs
@@ -628,11 +628,11 @@ mod tests {
         }];
         db.insert_session(&s2).unwrap();
 
-        let rows = db.get_sessions_for_date("2026-04-10").unwrap();
+        let rows = db.get_sessions_for_date("2026-04-10", 0).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].0, "date-001");
 
-        let empty = db.get_sessions_for_date("2026-04-12").unwrap();
+        let empty = db.get_sessions_for_date("2026-04-12", 0).unwrap();
         assert!(empty.is_empty());
     }
 

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -687,17 +687,18 @@ impl Database {
     /// Returns: (id, project, summary, turn_count, tools_used, session_type)
     pub fn get_sessions_for_date(
         &self,
-        date: &str, // "YYYY-MM-DD"
+        date: &str,         // "YYYY-MM-DD" (요청자 로컬 날짜)
+        tz_offset_min: i64, // 로컬 - UTC (분). 한국=540. UTC start_time 을 로컬로 이동해 날짜 비교.
     ) -> Result<Vec<DailySessionRow>> {
-        let pattern = format!("{}%", date);
+        let modifier = format!("{} minutes", tz_offset_min);
         let mut stmt = self.conn().prepare(
             "SELECT id, project, summary, turn_count, tools_used, session_type
              FROM sessions
-             WHERE start_time LIKE ?1
+             WHERE DATE(start_time, ?1) = ?2
              ORDER BY start_time",
         )?;
         let rows = stmt
-            .query_map([pattern], |row| {
+            .query_map(rusqlite::params![modifier, date], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     row.get::<_, Option<String>>(1)?,

--- a/crates/secall/src/commands/log.rs
+++ b/crates/secall/src/commands/log.rs
@@ -19,19 +19,28 @@ pub async fn run(
     let config = Config::load_or_default();
     let db = Database::open(&get_default_db_path())?;
 
-    // 날짜 결정 (기본: 오늘)
+    // 날짜 결정 (기본: 오늘) — config timezone 기준
+    let tz = config.timezone();
     let target_date = match date {
         Some(d) => d,
-        None => {
-            let tz = config.timezone();
-            chrono::Utc::now()
-                .with_timezone(&tz)
-                .format("%Y-%m-%d")
-                .to_string()
-        }
+        None => chrono::Utc::now()
+            .with_timezone(&tz)
+            .format("%Y-%m-%d")
+            .to_string(),
     };
+    // config tz 의 UTC 오프셋(분) — get_sessions_for_date 가 UTC start_time 을 이 tz 로
+    // 이동해 날짜를 비교(target_date 와 동일 tz 기준으로 일관).
+    use chrono::Offset;
+    let tz_offset_min = i64::from(
+        chrono::Utc::now()
+            .with_timezone(&tz)
+            .offset()
+            .fix()
+            .local_minus_utc()
+            / 60,
+    );
 
-    let sessions = db.get_sessions_for_date(&target_date)?;
+    let sessions = db.get_sessions_for_date(&target_date, tz_offset_min)?;
     if sessions.is_empty() {
         eprintln!("No sessions found for {}", target_date);
         return Ok(());

--- a/web/src/hooks/useDaily.ts
+++ b/web/src/hooks/useDaily.ts
@@ -25,8 +25,10 @@ export interface DailyResponse {
 }
 
 export function useDaily(date: string) {
+  // 브라우저 로컬 tz 오프셋(분, 로컬-UTC). getTimezoneOffset 은 UTC-로컬이라 부호 반전.
+  const tzOffset = -new Date().getTimezoneOffset();
   return useQuery({
-    queryKey: ["daily", date],
-    queryFn: () => api.daily(date) as Promise<DailyResponse>,
+    queryKey: ["daily", date, tzOffset],
+    queryFn: () => api.daily(date, tzOffset) as Promise<DailyResponse>,
   });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -166,10 +166,10 @@ export const api = {
 
   status: () => jfetch<StatusResponse>("/api/status"),
 
-  daily: (date?: string) =>
+  daily: (date?: string, tzOffset?: number) =>
     jfetch<unknown>("/api/daily", {
       method: "POST",
-      body: JSON.stringify({ date }),
+      body: JSON.stringify({ date, tz_offset: tzOffset }),
     }),
 
   configGet: () => jfetch<AppConfig>("/api/config"),


### PR DESCRIPTION
실사용 피드백 #1. 병렬 진단으로 원인 규명.

## 원인

- 프론트(DailyRoute): `format(new Date(), "yyyy-MM-dd")` = **로컬(한국) 날짜**
- 백엔드(get_sessions_for_date): `WHERE start_time LIKE 'YYYY-MM-DD%'` — start_time은 **UTC 저장**(`timezone = UTC`)
- 결과: 한국 오전이면 UTC로 아직 전날이라 "오늘"(로컬) 데일리가 **빈 화면**

## 수정 (브라우저 tz offset 전달)

프론트가 로컬 날짜 + tz offset(분)을 함께 보내고, 백엔드가 UTC start_time을 그 tz로 이동해 `DATE`로 매칭. **기기별 tz 자동**(맥/윈도우), config 무관.

- `get_sessions_for_date`: `LIKE 'date%'` → `DATE(start_time, '±N minutes') = date`. `tz_offset_min` 인자(0 = UTC 폴백)
- `do_daily` / `api_daily`(`RestDailyParams.tz_offset`) / `api.daily` / `useDaily`(`-getTimezoneOffset()`) 연결
- CLI `secall log`: `config.timezone()` 오프셋 전달(target_date와 동일 tz 기준 일관)

## 검증
`cargo check`(secall·secall-core) · lib test 컴파일 · web `tsc`. **백엔드 변경이라 실동작엔 secall 재빌드·재설치 필요.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7GAhYSbQZZQ29xiwX9pa8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 일일 조회가 사용자의 로컬 시간대 오프셋을 반영하도록 개선되었습니다.
  * 날짜 조회 요청에 시간대 오프셋 정보가 함께 전달되어, 자정 전후의 항목도 더 정확하게 표시됩니다.
* **Bug Fixes**
  * 지역 시간 기준으로 세션이 잘못 포함되거나 누락되던 문제를 개선했습니다.
  * 일일 데이터 캐시가 시간대 변경을 반영하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->