### PR TITLE
feat(web): 그래프 live 시뮬레이션 — 300-tick freeze 제거 + Obsidian 순차 등장

### DIFF
--- a/web/src/components/ObsidianGraph.tsx
+++ b/web/src/components/ObsidianGraph.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 import {
   forceCenter,
   forceCollide,
@@ -123,7 +123,8 @@ export function ObsidianGraph({ nodes, edges, hiddenTypes, onSessionClick }: Pro
     return { adjacency: adj, degree: deg };
   }, [fEdges]);
 
-  // d3-force simulation: 마운트 시 한 번 ticking 한 뒤 좌표 고정
+  // 노드/링크 구성만 (좌표는 랜덤 시작 — 실제 배치는 아래 live 시뮬이 애니메이션).
+  // 링크 필터는 id Set 으로 O(E) (이전 some×some = O(E×N) 제거).
   const positioned = useMemo(() => {
     if (fNodes.length === 0) return { nodes: [] as SimNode[], edges: [] as SimLink[] };
     const simNodes: SimNode[] = fNodes.map((n) => ({
@@ -133,14 +134,22 @@ export function ObsidianGraph({ nodes, edges, hiddenTypes, onSessionClick }: Pro
       x: (Math.random() - 0.5) * 100,
       y: (Math.random() - 0.5) * 100,
     }));
+    const idSet = new Set(simNodes.map((n) => n.id));
     const simLinks: SimLink[] = fEdges
-      .filter((e) => simNodes.some((n) => n.id === e.source) && simNodes.some((n) => n.id === e.target))
+      .filter((e) => idSet.has(e.source) && idSet.has(e.target))
       .map((e) => ({ source: e.source, target: e.target }));
+    return { nodes: simNodes, edges: simLinks };
+  }, [fNodes, fEdges]);
 
-    const sim: Simulation<SimNode, SimLink> = forceSimulation(simNodes)
+  // live d3-force 시뮬레이션 — 메인스레드 동기 300-tick(freeze) 대신 rAF 애니메이션.
+  // 노드가 랜덤 시작점에서 퍼지며 순차 등장(Obsidian 거동). alpha 가 식으면 스스로 정지.
+  const [tick, bumpTick] = useReducer((c: number) => c + 1, 0);
+  useEffect(() => {
+    if (positioned.nodes.length === 0) return;
+    const sim: Simulation<SimNode, SimLink> = forceSimulation(positioned.nodes)
       .force(
         "link",
-        forceLink<SimNode, SimLink>(simLinks)
+        forceLink<SimNode, SimLink>(positioned.edges)
           .id((d) => d.id)
           .distance(70)
           .strength(0.35),
@@ -148,12 +157,12 @@ export function ObsidianGraph({ nodes, edges, hiddenTypes, onSessionClick }: Pro
       .force("charge", forceManyBody().strength(-180))
       .force("center", forceCenter(0, 0).strength(0.06))
       .force("collide", forceCollide<SimNode>().radius((d) => baseRadius(d.type) + 6))
-      .stop();
-
-    // pre-tick to settle
-    for (let i = 0; i < 300; i++) sim.tick();
-    return { nodes: simNodes, edges: simLinks };
-  }, [fNodes, fEdges]);
+      .on("tick", bumpTick);
+    // 필터 토글 등으로 positioned 가 새로 만들어지면 이전 시뮬 정지(타이머 누수 방지).
+    return () => {
+      sim.stop();
+    };
+  }, [positioned]);
 
   const radius = (n: SimNode): number => {
     const d = degree.get(n.id) ?? 0;
@@ -179,7 +188,8 @@ export function ObsidianGraph({ nodes, edges, hiddenTypes, onSessionClick }: Pro
       w: Math.max(200, maxX - minX + pad * 2),
       h: Math.max(200, maxY - minY + pad * 2),
     };
-  }, [positioned.nodes]);
+    // tick 을 deps 에 포함 — 시뮬 애니메이션 중 노드가 움직이면 viewBox 도 따라 갱신.
+  }, [positioned.nodes, tick]);
 
   const isLit = (id: string): boolean =>
     !!hover && (id === hover || (adjacency.get(hover)?.has(id) ?? false));


### PR DESCRIPTION
실사용 피드백 #2. 병렬 진단으로 원인 규명.

## 원인

`ObsidianGraph.tsx`의 `positioned` useMemo가 렌더 도중 d3-force를 **300회 동기 tick**(for 루프)으로 돌린다. React는 useMemo 반환까지 commit/paint를 못 하므로, 데이터 도착~레이아웃 완료까지 **메인스레드가 freeze**. 필터 토글마다 통째로 재실행되고, 결과가 정적 스냅샷이라 애니메이션(순차 등장)이 불가능.

## 수정 (live 애니메이션 시뮬)

- 동기 pre-tick 제거 → `useEffect`에서 `sim.on('tick')`으로 rAF 애니메이션
- 노드가 랜덤 시작점에서 퍼지며 **순차 등장(Obsidian 거동)**, alpha 식으면 자동 정지
- cleanup에서 `sim.stop()` (필터 토글 시 이전 시뮬 타이머 누수/중복 방지)
- viewBox는 tick을 deps에 넣어 애니메이션 추종
- 링크 필터 `some×some`(O(E×N)) → id Set O(E)

## 검증
`tsc` / `vite build` / `vitest` 15 passed. **실제 애니메이션은 로컬 확인 필요.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7GAhYSbQZZQ29xiwX9pa8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 그래프 노드 배치가 한 번에 고정되지 않고, 시뮬레이션이 진행되는 동안 자연스럽게 애니메이션으로 표시됩니다.
  * 애니메이션 중에도 화면 범위가 함께 갱신되어 그래프 이동을 더 잘 따라볼 수 있습니다.

* **개선**
  * 링크와 노드 표시 방식이 더 안정적으로 정리되어, 그래프 렌더링 흐름이 더 부드러워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->