### PR TITLE
fix(web+core): 세션 상세 tool-use 렌더 — do_get vault 루트 결합 누락

### DIFF
--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -247,18 +247,28 @@ impl SeCallMcpServer {
             }
             if params.full.unwrap_or(false) {
                 let content = if let Some(rel) = &meta.vault_path {
-                    // vault_path 는 vault 루트 기준 상대경로 → self.vault_path 와 결합해야 한다.
-                    // (CLI get.rs 와 동일. 기존엔 상대경로를 직접 읽어 항상 실패 → 조용히 DB
-                    //  폴백으로 흘러 tool-use 턴이 빈 "## assistant" 헤더로만 렌더됐다.)
-                    let abs = self.vault_path.join(rel);
-                    match std::fs::read_to_string(&abs) {
-                        Ok(c) => Some(c),
+                    // vault_path 는 vault 루트 기준 상대경로. resolve_session_file 로 해석해야
+                    // `\`/`/` 혼재나 legacy(raw/sessions) 경로도 통일 처리된다(CodeRabbit 반영).
+                    // (기존엔 상대경로를 직접 읽어 항상 실패 → 조용히 DB 폴백 → tool-use 턴이
+                    //  빈 "## assistant" 헤더로만 렌더됐다.)
+                    match crate::vault::resolve_session_file(&self.vault_path, rel, &session_id) {
+                        Ok(abs) => match std::fs::read_to_string(&abs) {
+                            Ok(c) => Some(c),
+                            Err(e) => {
+                                tracing::warn!(
+                                    session = %session_id,
+                                    path = %abs.display(),
+                                    error = %e,
+                                    "vault md read 실패 → DB turns 폴백"
+                                );
+                                None
+                            }
+                        },
                         Err(e) => {
                             tracing::warn!(
                                 session = %session_id,
-                                path = %abs.display(),
                                 error = %e,
-                                "vault md read 실패 → DB turns 폴백"
+                                "세션 md 경로 해석 실패 → DB turns 폴백"
                             );
                             None
                         }

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -246,8 +246,23 @@ impl SeCallMcpServer {
                 );
             }
             if params.full.unwrap_or(false) {
-                let content = if let Some(vault_path) = &meta.vault_path {
-                    std::fs::read_to_string(vault_path).ok()
+                let content = if let Some(rel) = &meta.vault_path {
+                    // vault_path 는 vault 루트 기준 상대경로 → self.vault_path 와 결합해야 한다.
+                    // (CLI get.rs 와 동일. 기존엔 상대경로를 직접 읽어 항상 실패 → 조용히 DB
+                    //  폴백으로 흘러 tool-use 턴이 빈 "## assistant" 헤더로만 렌더됐다.)
+                    let abs = self.vault_path.join(rel);
+                    match std::fs::read_to_string(&abs) {
+                        Ok(c) => Some(c),
+                        Err(e) => {
+                            tracing::warn!(
+                                session = %session_id,
+                                path = %abs.display(),
+                                error = %e,
+                                "vault md read 실패 → DB turns 폴백"
+                            );
+                            None
+                        }
+                    }
                 } else {
                     None
                 };


### PR DESCRIPTION
실사용 발견. 세션 상세에서 tool-use 턴이 빈 `## assistant` 헤더로만 반복 렌더되던 버그.

## 원인 (서버 경로 버그)

`server.rs do_get`이 `sessions.vault_path`(**vault 루트 기준 상대경로**)를 `self.vault_path`와 결합하지 않고 그대로 `read_to_string` → **항상 실패** → `.ok()`로 **조용히 None** → **DB turns 폴백**으로 흘러감.

DB turns에는 tool 호출/결과 본문이 저장되지 않으므로, 콜아웃(`> [!tool]-`)이 없는 **빈 `## assistant` 헤더만 연속** 생성됨. CLI(`get.rs:32`)는 `vault.path.join(rel)`로 결합해 정상인데 서버만 빠져 있었음.

즉 "폴딩이 안 열린" 게 아니라, **폴딩 대상(콜아웃)이 담긴 vault 본문 대신 빈 폴백이 서빙**된 것. 웹 렌더러는 정상.

## 수정

- `self.vault_path.join(rel)`로 vault 루트 결합 (CLI와 동일)
- silent `.ok()` → `tracing::warn!` (경로 드리프트/read 실패를 조용히 삼키지 않도록 — CLAUDE.md "silent fallback 최소화")
- vault md 정상 서빙 → `remarkObsidianCallouts`가 `> [!tool]-`를 `<details>` 폴딩으로 렌더 → **tool-use 내용/폴딩 복구**

## 검증
`cargo check`. 재빌드·재설치 후 브라우저 스모크로 tool-use 폴딩 복구 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7GAhYSbQZZQ29xiwX9pa8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 세션 요청 시 세션 메타의 경로를 “vault 루트 기준 상대경로”로 해석해 파일을 더 정확하게 찾고 읽도록 개선했습니다.
  * 경로 해석 또는 파일 읽기 실패 시 경고를 남기고, 기존 방식대로 DB의 대체 콘텐츠를 생성해 반환하도록 동작을 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->