### PR TITLE
perf(web): 그래프 hang 완화 — 고립 topic 필터 + 조기 수렴

### DIFF
--- a/web/src/components/ObsidianGraph.tsx
+++ b/web/src/components/ObsidianGraph.tsx
@@ -127,7 +127,12 @@ export function ObsidianGraph({ nodes, edges, hiddenTypes, onSessionClick }: Pro
   // 링크 필터는 id Set 으로 O(E) (이전 some×some = O(E×N) 제거).
   const positioned = useMemo(() => {
     if (fNodes.length === 0) return { nodes: [] as SimNode[], edges: [] as SimLink[] };
-    const simNodes: SimNode[] = fNodes.map((n) => ({
+    // 고립/저차수 topic 노드 제외 — degree < 2 인 topic 은 레이아웃에 거의 기여하지 않으면서
+    // 매 tick SVG+라벨 렌더 비용만 유발한다(5000+ → 수백). session/project/agent/tool 은 유지.
+    const visible = fNodes.filter(
+      (n) => n.type !== "topic" || (degree.get(n.id) ?? 0) >= 2,
+    );
+    const simNodes: SimNode[] = visible.map((n) => ({
       id: n.id,
       type: n.type,
       label: n.label,
@@ -139,7 +144,7 @@ export function ObsidianGraph({ nodes, edges, hiddenTypes, onSessionClick }: Pro
       .filter((e) => idSet.has(e.source) && idSet.has(e.target))
       .map((e) => ({ source: e.source, target: e.target }));
     return { nodes: simNodes, edges: simLinks };
-  }, [fNodes, fEdges]);
+  }, [fNodes, fEdges, degree]);
 
   // live d3-force 시뮬레이션 — 메인스레드 동기 300-tick(freeze) 대신 rAF 애니메이션.
   // 노드가 랜덤 시작점에서 퍼지며 순차 등장(Obsidian 거동). alpha 가 식으면 스스로 정지.
@@ -147,6 +152,10 @@ export function ObsidianGraph({ nodes, edges, hiddenTypes, onSessionClick }: Pro
   useEffect(() => {
     if (positioned.nodes.length === 0) return;
     const sim: Simulation<SimNode, SimLink> = forceSimulation(positioned.nodes)
+      // 조기 수렴: alpha 를 빨리 식혀 ~300 tick → ~60 tick 에 정지. 매 tick 재렌더 횟수와
+      // 탭 이탈 시 시뮬이 아직 도는 확률을 줄인다.
+      .alphaMin(0.05)
+      .alphaDecay(0.06)
       .force(
         "link",
         forceLink<SimNode, SimLink>(positioned.edges)


### PR DESCRIPTION
실사용 발견(#2 후속). 그래프 탭 → 다른 탭 이동이 느린(hang) 문제.

## 원인 (진단)

- `sim.stop()` cleanup은 **정상**(시뮬 미정지 아님)
- 진짜 원인: **topic 노드 5178개(전량)를 매 tick마다 SVG로 재렌더** + 수렴까지 ~300 tick. 탭 이동 = 수렴 전 렌더 포화 + 거대 SVG 언마운트가 겹침
- 뿌리: `GraphRoute`가 session만 상위 80 캡하고 topic/project/agent/tool은 전량 표시 → topic 5178개

## 수정

- **A. 고립/저차수 topic 필터** — `degree < 2`인 topic은 레이아웃 기여 없이 렌더 비용만 유발 → `positioned`에서 제외(5000+ → 수백). session/project/agent/tool은 유지
- **C. 조기 수렴** — `alphaMin(0.05)` + `alphaDecay(0.06)` → ~300 tick을 ~60으로. 매 tick 재렌더 횟수와 탭 이탈 시 시뮬 잔류 확률 감소

(D. viewBox tick 추종 제거는 A로 노드가 수백으로 줄면 재계산도 가벼워져 보류 — 부족하면 후속.)

## 검증
`tsc` / `vite build`. **실제 체감은 재빌드·재설치 후 브라우저 스모크로 확인 예정.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7GAhYSbQZZQ29xiwX9pa8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 그래프에서 연결이 거의 없는 주제 노드가 배치 계산에서 제외되어, 노드가 더 안정적으로 표시됩니다.
  * 노드 간 거리 정보가 배치에 반영되도록 업데이트되어, 그래프 레이아웃이 더 일관되게 조정됩니다.
  * 시뮬레이션 수렴 방식이 개선되어 그래프가 더 빠르게 안정된 상태로 멈춥니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->