### PR TITLE
feat(web): Sessions Linear 톤+반응형 파일럿 + 렌더/좌측패널 고도화 (셀프리뷰 회귀 11건 수정)

### DIFF
--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -455,7 +455,11 @@ impl From<SessionListQuery> for SessionListFilter {
             page_size: q.page_size.unwrap_or(30),
             include_archived: false,
             // 미지정/미인식 값은 enum parse 가 기본값(date/desc)으로 폴백 → 현행 보존.
-            sort: q.sort.as_deref().map(SessionSort::parse).unwrap_or_default(),
+            sort: q
+                .sort
+                .as_deref()
+                .map(SessionSort::parse)
+                .unwrap_or_default(),
             order: q.order.as_deref().map(SortOrder::parse).unwrap_or_default(),
             include_automated: q.include_automated.unwrap_or(false),
         }

--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -24,7 +24,7 @@ use super::tools::{
 use crate::jobs::{BroadcastSink, JobExecutor, JobKind, ProgressEvent};
 use crate::search::hybrid::SearchEngine;
 use crate::store::db::Database;
-use crate::store::session_repo::SessionListFilter;
+use crate::store::session_repo::{SessionListFilter, SessionSort, SortOrder};
 
 // ── REST 간소화 DTO ─────────────────────────────────────────
 // MCP 스키마를 직접 노출하지 않고 REST 클라이언트에 친화적인 형태로 받아서 변환
@@ -145,6 +145,8 @@ pub fn rest_router(server: SeCallMcpServer, executor: Arc<JobExecutor>) -> Route
         .route("/api/config", get(api_config_get))
         .route("/api/config/{section}", patch(api_config_patch))
         .route("/api/sessions", get(api_list_sessions))
+        // Phase 3 — 달력 날짜별 세션 수. static path 라 `/api/sessions/{id}` 와 충돌 없음.
+        .route("/api/sessions/calendar", get(api_sessions_calendar))
         .route("/api/projects", get(api_list_projects))
         .route("/api/agents", get(api_list_agents))
         .route("/api/tags", get(api_list_tags))
@@ -419,6 +421,12 @@ struct SessionListQuery {
     tags: Option<Vec<String>>,
     favorite: Option<bool>,
     q: Option<String>,
+    /// Phase 1 — 정렬 기준(date|turns|project|agent). 미지정 시 date.
+    sort: Option<String>,
+    /// Phase 1 — 정렬 방향(asc|desc). 미지정 시 desc (현행 동작 보존).
+    order: Option<String>,
+    /// Phase 2 — true 면 automated 세션 포함. 미지정 시 false(현행 제외).
+    include_automated: Option<bool>,
 }
 
 impl From<SessionListQuery> for SessionListFilter {
@@ -446,6 +454,10 @@ impl From<SessionListQuery> for SessionListFilter {
             page: q.page.unwrap_or(1),
             page_size: q.page_size.unwrap_or(30),
             include_archived: false,
+            // 미지정/미인식 값은 enum parse 가 기본값(date/desc)으로 폴백 → 현행 보존.
+            sort: q.sort.as_deref().map(SessionSort::parse).unwrap_or_default(),
+            order: q.order.as_deref().map(SortOrder::parse).unwrap_or_default(),
+            include_automated: q.include_automated.unwrap_or(false),
         }
     }
 }
@@ -473,6 +485,27 @@ async fn api_list_sessions(
     axum_extra::extract::Query(q): axum_extra::extract::Query<SessionListQuery>,
 ) -> impl IntoResponse {
     match s.do_list_sessions(q.into()) {
+        Ok(json) => (StatusCode::OK, Json(json)).into_response(),
+        Err(e) => error_response(e),
+    }
+}
+
+/// Phase 3 — `GET /api/sessions/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&tz_offset=<min>`.
+/// 응답: `[{ "date": "YYYY-MM-DD", "count": N }]` (로컬 날짜 기준, automated/archived 제외).
+#[derive(Debug, Deserialize, Default)]
+struct CalendarQuery {
+    from: Option<String>,
+    to: Option<String>,
+    /// 요청자 로컬 - UTC (분). 미전달 시 0(UTC 기준 매칭).
+    #[serde(default)]
+    tz_offset: i64,
+}
+
+async fn api_sessions_calendar(
+    State(s): State<Arc<SeCallMcpServer>>,
+    Query(q): Query<CalendarQuery>,
+) -> impl IntoResponse {
+    match s.do_sessions_calendar(q.from.as_deref(), q.to.as_deref(), q.tz_offset) {
         Ok(json) => (StatusCode::OK, Json(json)).into_response(),
         Err(e) => error_response(e),
     }

--- a/crates/secall-core/src/mcp/rest.rs
+++ b/crates/secall-core/src/mcp/rest.rs
@@ -492,6 +492,8 @@ async fn api_list_sessions(
 
 /// Phase 3 — `GET /api/sessions/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&tz_offset=<min>`.
 /// 응답: `[{ "date": "YYYY-MM-DD", "count": N }]` (로컬 날짜 기준, automated/archived 제외).
+/// 리스트와 동일한 필터(project/agent/tag/favorite/q/include_automated)를 받아 배지
+/// 카운트가 실제 필터된 리스트와 일치하게 한다.
 #[derive(Debug, Deserialize, Default)]
 struct CalendarQuery {
     from: Option<String>,
@@ -499,13 +501,58 @@ struct CalendarQuery {
     /// 요청자 로컬 - UTC (분). 미전달 시 0(UTC 기준 매칭).
     #[serde(default)]
     tz_offset: i64,
+    project: Option<String>,
+    agent: Option<String>,
+    tag: Option<String>,
+    /// 반복(`?tags=a&tags=b`) 또는 콤마 구분(`?tags=a,b`) 모두 수용.
+    tags: Option<Vec<String>>,
+    favorite: Option<bool>,
+    q: Option<String>,
+    include_automated: Option<bool>,
+}
+
+impl CalendarQuery {
+    /// 내용 필터만 담은 `SessionListFilter`. 날짜/페이지/정렬은 달력에서 미사용이라
+    /// 기본값이며 `session_calendar_counts` 가 무시한다.
+    fn to_filter(&self) -> SessionListFilter {
+        let tags: Vec<String> = self
+            .tags
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .flat_map(|s| {
+                s.split(',')
+                    .map(|t| t.trim().to_string())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|s| !s.is_empty())
+            .collect();
+        SessionListFilter {
+            project: self.project.clone(),
+            agent: self.agent.clone(),
+            date_from: None,
+            date_to: None,
+            tag: self.tag.clone(),
+            tags,
+            favorite: self.favorite,
+            q: self.q.clone(),
+            page: 1,
+            page_size: 30,
+            include_archived: false,
+            sort: SessionSort::default(),
+            order: SortOrder::default(),
+            include_automated: self.include_automated.unwrap_or(false),
+        }
+    }
 }
 
 async fn api_sessions_calendar(
     State(s): State<Arc<SeCallMcpServer>>,
-    Query(q): Query<CalendarQuery>,
+    // 반복 tags 파라미터 수용을 위해 axum_extra Query 사용 (리스트와 동일).
+    axum_extra::extract::Query(q): axum_extra::extract::Query<CalendarQuery>,
 ) -> impl IntoResponse {
-    match s.do_sessions_calendar(q.from.as_deref(), q.to.as_deref(), q.tz_offset) {
+    let filter = q.to_filter();
+    match s.do_sessions_calendar(&filter, q.from.as_deref(), q.to.as_deref(), q.tz_offset) {
         Ok(json) => (StatusCode::OK, Json(json)).into_response(),
         Err(e) => error_response(e),
     }

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -246,8 +246,33 @@ impl SeCallMcpServer {
                 );
             }
             if params.full.unwrap_or(false) {
-                let content = if let Some(vault_path) = &meta.vault_path {
-                    std::fs::read_to_string(vault_path).ok()
+                let content = if let Some(rel) = &meta.vault_path {
+                    // vault_path 는 vault 루트 기준 상대경로. resolve_session_file 로 해석해야
+                    // `\`/`/` 혼재나 legacy(raw/sessions) 경로도 통일 처리된다(CodeRabbit 반영).
+                    // (직접 상대경로를 읽으면 서버 CWD 기준이라 대개 실패 → 조용히 DB 폴백 →
+                    //  tool-use 턴이 빈 "## assistant" 헤더로만 렌더되는 회귀가 발생한다.)
+                    match crate::vault::resolve_session_file(&self.vault_path, rel, &session_id) {
+                        Ok(abs) => match std::fs::read_to_string(&abs) {
+                            Ok(c) => Some(c),
+                            Err(e) => {
+                                tracing::warn!(
+                                    session = %session_id,
+                                    path = %abs.display(),
+                                    error = %e,
+                                    "vault md read 실패 → DB turns 폴백"
+                                );
+                                None
+                            }
+                        },
+                        Err(e) => {
+                            tracing::warn!(
+                                session = %session_id,
+                                error = %e,
+                                "세션 md 경로 해석 실패 → DB turns 폴백"
+                            );
+                            None
+                        }
+                    }
                 } else {
                     None
                 };
@@ -977,6 +1002,7 @@ impl SeCallMcpServer {
     /// `tz_offset_min` 은 브라우저 로컬 - UTC (분), #131 데일리와 동일 방식.
     pub fn do_sessions_calendar(
         &self,
+        filter: &crate::store::session_repo::SessionListFilter,
         from: Option<&str>,
         to: Option<&str>,
         tz_offset_min: i64,
@@ -985,7 +1011,7 @@ impl SeCallMcpServer {
             .db
             .lock()
             .map_err(|_| anyhow::anyhow!("db lock poisoned"))?;
-        let days = db.session_calendar_counts(from, to, tz_offset_min)?;
+        let days = db.session_calendar_counts(filter, from, to, tz_offset_min)?;
         Ok(serde_json::to_value(days)?)
     }
 

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -973,6 +973,22 @@ impl SeCallMcpServer {
         Ok(serde_json::to_value(page)?)
     }
 
+    /// Phase 3 — 달력 뷰 날짜별 세션 수. `[{date, count}]` 배열을 반환.
+    /// `tz_offset_min` 은 브라우저 로컬 - UTC (분), #131 데일리와 동일 방식.
+    pub fn do_sessions_calendar(
+        &self,
+        from: Option<&str>,
+        to: Option<&str>,
+        tz_offset_min: i64,
+    ) -> anyhow::Result<serde_json::Value> {
+        let db = self
+            .db
+            .lock()
+            .map_err(|_| anyhow::anyhow!("db lock poisoned"))?;
+        let days = db.session_calendar_counts(from, to, tz_offset_min)?;
+        Ok(serde_json::to_value(days)?)
+    }
+
     pub fn do_list_projects(&self) -> anyhow::Result<serde_json::Value> {
         let db = self
             .db

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -902,10 +902,12 @@ impl Database {
         &self,
         f: &SessionListFilter,
     ) -> crate::error::Result<SessionListPage> {
-        let mut conditions: Vec<String> = vec![
-            // automated session_type은 기본 제외 — recall과 일관성
-            "session_type != 'automated'".to_string(),
-        ];
+        let mut conditions: Vec<String> = Vec::new();
+        // automated session_type은 기본 제외 — recall과 일관성.
+        // P?? Phase 2: include_automated 토글 시에만 포함 (기본 false → 현행 동작 보존).
+        if !f.include_automated {
+            conditions.push("session_type != 'automated'".to_string());
+        }
         if !f.include_archived {
             conditions.push("is_archived = 0".to_string());
         }
@@ -951,7 +953,24 @@ impl Database {
             params.push(Box::new(pat));
         }
 
-        let where_clause = format!("WHERE {}", conditions.join(" AND "));
+        // include_automated + include_archived 가 모두 true 이고 다른 필터가 없으면
+        // conditions 가 비어 `WHERE ` 만 남는 것을 방지 (기본 경로는 항상 ≥1 조건).
+        let where_clause = if conditions.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", conditions.join(" AND "))
+        };
+
+        // ORDER BY — 화이트리스트 컬럼/방향만 (SQL 인젝션 방지). 사용자 입력은
+        // enum(SessionSort/SortOrder)으로만 들어오고, 여기서 고정 문자열로 매핑된다.
+        let (sort_col, needs_tiebreak) = f.sort.order_column();
+        let dir = f.order.sql_keyword();
+        let order_clause = if needs_tiebreak {
+            // project/agent/turns 는 동률이 흔해 start_time DESC 로 페이지네이션 안정화.
+            format!("ORDER BY {sort_col} {dir}, start_time DESC")
+        } else {
+            format!("ORDER BY {sort_col} {dir}")
+        };
 
         let page = f.page.max(1);
         let page_size = f.page_size.clamp(1, 100);
@@ -969,7 +988,7 @@ impl Database {
         let sql = format!(
             "SELECT id, agent, project, model, start_time, turn_count, summary, tags, is_favorite, session_type, vault_path, notes, is_archived, archived_at
              FROM sessions {where_clause}
-             ORDER BY start_time DESC
+             {order_clause}
              LIMIT ? OFFSET ?"
         );
         let mut stmt = self.conn().prepare(&sql)?;
@@ -1030,6 +1049,51 @@ impl Database {
             page,
             page_size,
         })
+    }
+
+    /// Phase 3 — 달력 뷰용 날짜별 세션 수.
+    ///
+    /// `DATE(start_time, tz)` 로 UTC start_time 을 요청자 로컬 날짜로 이동한 뒤
+    /// 그 로컬 날짜(YYYY-MM-DD)로 GROUP BY 한다 (#131 데일리와 동일 tz offset 방식).
+    /// automated/archived 는 리스트 기본 동작과 동일하게 제외.
+    ///
+    /// `from`/`to`(YYYY-MM-DD, 로컬 날짜)가 주어지면 그 로컬 날짜 범위로 제한한다.
+    pub fn session_calendar_counts(
+        &self,
+        from: Option<&str>,
+        to: Option<&str>,
+        tz_offset_min: i64, // 로컬 - UTC (분). 한국=540.
+    ) -> Result<Vec<CalendarDayCount>> {
+        let modifier = format!("{} minutes", tz_offset_min);
+
+        // `?` 순서에 맞춰 params 를 lockstep 으로 구성.
+        let mut sql = String::from(
+            "SELECT DATE(start_time, ?) AS d, COUNT(*) AS c FROM sessions \
+             WHERE session_type != 'automated' AND is_archived = 0",
+        );
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(modifier.clone())];
+        if let Some(f) = from {
+            sql.push_str(" AND DATE(start_time, ?) >= ?");
+            params.push(Box::new(modifier.clone()));
+            params.push(Box::new(f.to_string()));
+        }
+        if let Some(t) = to {
+            sql.push_str(" AND DATE(start_time, ?) <= ?");
+            params.push(Box::new(modifier.clone()));
+            params.push(Box::new(t.to_string()));
+        }
+        sql.push_str(" GROUP BY d ORDER BY d");
+
+        let conn = self.conn();
+        let mut stmt = conn.prepare(&sql)?;
+        let params_ref: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        let rows = stmt.query_map(params_ref.as_slice(), |row| {
+            Ok(CalendarDayCount {
+                date: row.get(0)?,
+                count: row.get(1)?,
+            })
+        })?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
     /// 세션 태그 갱신. 정규화 후 반환된 태그를 응답에 사용.
@@ -1324,6 +1388,85 @@ pub struct SessionListFilter {
     pub page_size: usize,
     /// P45 — true 면 archived 세션 포함. 기본 false (제외).
     pub include_archived: bool,
+    /// Phase 1 — 정렬 기준. 기본 `Date`(= 기존 start_time 정렬).
+    pub sort: SessionSort,
+    /// Phase 1 — 정렬 방향. 기본 `Desc`(= 기존 최신순).
+    pub order: SortOrder,
+    /// Phase 2 — true 면 automated 세션 포함. 기본 false (현행 동작 보존).
+    pub include_automated: bool,
+}
+
+/// Phase 1 — 세션 리스트 정렬 기준. 컬럼명은 `order_column()`에서 화이트리스트
+/// 고정 문자열로만 매핑되어 SQL 인젝션이 불가능하다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionSort {
+    /// start_time (기본)
+    #[default]
+    Date,
+    /// turn_count
+    Turns,
+    /// project
+    Project,
+    /// agent
+    Agent,
+}
+
+impl SessionSort {
+    /// 쿼리스트링 값 → enum. 미인식 값은 기본값(Date)으로 폴백해 항상 안전.
+    pub fn parse(s: &str) -> Self {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "turns" | "turn_count" => Self::Turns,
+            "project" => Self::Project,
+            "agent" => Self::Agent,
+            _ => Self::Date,
+        }
+    }
+
+    /// (정렬 컬럼, start_time 2차 정렬 필요 여부). 컬럼은 고정 문자열(화이트리스트).
+    pub fn order_column(self) -> (&'static str, bool) {
+        match self {
+            Self::Date => ("start_time", false),
+            Self::Turns => ("turn_count", true),
+            Self::Project => ("project", true),
+            Self::Agent => ("agent", true),
+        }
+    }
+}
+
+/// Phase 1 — 정렬 방향. `sql_keyword()`가 고정 문자열만 반환.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Asc,
+    /// 기본 — 최신/큰 값 우선 (기존 동작 보존)
+    #[default]
+    Desc,
+}
+
+impl SortOrder {
+    /// 쿼리스트링 값 → enum. 미인식 값은 기본값(Desc)으로 폴백.
+    pub fn parse(s: &str) -> Self {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "asc" => Self::Asc,
+            _ => Self::Desc,
+        }
+    }
+
+    fn sql_keyword(self) -> &'static str {
+        match self {
+            Self::Asc => "ASC",
+            Self::Desc => "DESC",
+        }
+    }
+}
+
+/// Phase 3 — 달력 뷰용 날짜별 세션 수. `DATE(start_time, tz)` 로컬 날짜 기준 그룹.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CalendarDayCount {
+    /// "YYYY-MM-DD" (요청자 로컬 날짜)
+    pub date: String,
+    pub count: i64,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1394,7 +1537,7 @@ pub struct GraphRebuildFilter {
 mod tests {
     use crate::ingest::markdown::SessionFrontmatter;
     use crate::store::db::Database;
-    use crate::store::session_repo::SessionListFilter;
+    use crate::store::session_repo::{SessionListFilter, SessionSort, SortOrder};
 
     fn make_fm(session_id: &str, archived: Option<bool>) -> SessionFrontmatter {
         SessionFrontmatter {
@@ -1597,6 +1740,89 @@ mod tests {
             )
             .unwrap();
         assert_eq!(is_archived_after, 1);
+    }
+
+    // Phase 1 — sort/order 화이트리스트 정렬. 기본은 date desc(현행 보존).
+    #[test]
+    fn test_list_sessions_sort_by_turns_and_default() {
+        let db = Database::open_memory().unwrap();
+        let mut lo = make_fm("s-turns-lo", None);
+        lo.turns = Some(2);
+        lo.start_time = "2026-05-11T10:00:00+00:00".to_string();
+        let mut hi = make_fm("s-turns-hi", None);
+        hi.turns = Some(9);
+        hi.start_time = "2026-05-10T10:00:00+00:00".to_string(); // 더 과거
+        db.insert_session_from_vault(&lo, "body", "raw/sessions/lo.md")
+            .unwrap();
+        db.insert_session_from_vault(&hi, "body", "raw/sessions/hi.md")
+            .unwrap();
+
+        // 기본값(date desc) — 최신 start_time(lo=05-11) 먼저.
+        let def = SessionListFilter {
+            page: 1,
+            page_size: 100,
+            ..Default::default()
+        };
+        let p = db.list_sessions_filtered(&def).unwrap();
+        assert_eq!(p.items[0].id, "s-turns-lo", "기본 정렬은 date desc 여야 함");
+
+        // turns asc — 낮은 turn_count(2) 먼저.
+        let asc = SessionListFilter {
+            page: 1,
+            page_size: 100,
+            sort: SessionSort::Turns,
+            order: SortOrder::Asc,
+            ..Default::default()
+        };
+        assert_eq!(
+            db.list_sessions_filtered(&asc).unwrap().items[0].id,
+            "s-turns-lo"
+        );
+
+        // turns desc — 높은 turn_count(9) 먼저.
+        let desc = SessionListFilter {
+            page: 1,
+            page_size: 100,
+            sort: SessionSort::Turns,
+            order: SortOrder::Desc,
+            ..Default::default()
+        };
+        assert_eq!(
+            db.list_sessions_filtered(&desc).unwrap().items[0].id,
+            "s-turns-hi"
+        );
+    }
+
+    // Phase 3 — 달력 날짜별 세션 수, tz offset 로컬 날짜 GROUP BY.
+    #[test]
+    fn test_session_calendar_counts_groups_by_local_date() {
+        let db = Database::open_memory().unwrap();
+        let mut a = make_fm("cal-a", None);
+        a.start_time = "2026-05-12T10:00:00+00:00".to_string(); // KST 05-12 19:00
+        let mut b = make_fm("cal-b", None);
+        b.start_time = "2026-05-11T20:00:00+00:00".to_string(); // KST 05-12 05:00
+        let mut c = make_fm("cal-c", None);
+        c.start_time = "2026-05-12T16:00:00+00:00".to_string(); // KST 05-13 01:00
+        db.insert_session_from_vault(&a, "body", "raw/sessions/ca.md")
+            .unwrap();
+        db.insert_session_from_vault(&b, "body", "raw/sessions/cb.md")
+            .unwrap();
+        db.insert_session_from_vault(&c, "body", "raw/sessions/cc.md")
+            .unwrap();
+
+        let days = db.session_calendar_counts(None, None, 540).unwrap();
+        let map: std::collections::HashMap<&str, i64> =
+            days.iter().map(|d| (d.date.as_str(), d.count)).collect();
+        assert_eq!(map.get("2026-05-12"), Some(&2), "KST 05-12 에 a,b 2건");
+        assert_eq!(map.get("2026-05-13"), Some(&1), "KST 05-13 에 c 1건");
+
+        // from/to 범위 제한 — 05-13 만.
+        let ranged = db
+            .session_calendar_counts(Some("2026-05-13"), Some("2026-05-13"), 540)
+            .unwrap();
+        assert_eq!(ranged.len(), 1);
+        assert_eq!(ranged[0].date, "2026-05-13");
+        assert_eq!(ranged[0].count, 1);
     }
 
     // P89 (#100, Gemini PR #101): 재인덱싱 시 turn_count 가 frontmatter 값으로

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -1838,9 +1838,7 @@ mod tests {
             .unwrap();
 
         let all = SessionListFilter::default();
-        let days = db
-            .session_calendar_counts(&all, None, None, 540)
-            .unwrap();
+        let days = db.session_calendar_counts(&all, None, None, 540).unwrap();
         let map: std::collections::HashMap<&str, i64> =
             days.iter().map(|d| (d.date.as_str(), d.count)).collect();
         assert_eq!(map.get("2026-05-12"), Some(&2), "KST 05-12 에 a,b 2건");
@@ -2027,7 +2025,10 @@ mod tests {
             ..Default::default()
         };
         let page = db.list_sessions_filtered(&all).unwrap();
-        assert_eq!(page.total, 2, "필터 전부 해제 시 automated+archived 포함 전체");
+        assert_eq!(
+            page.total, 2,
+            "필터 전부 해제 시 automated+archived 포함 전체"
+        );
 
         // 달력도 동일한 빈 WHERE 경로에서 SQL 오류 없이 동작해야 한다.
         let cal_total: i64 = db

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -1080,7 +1080,9 @@ impl Database {
         to: Option<&str>,
         tz_offset_min: i64, // 로컬 - UTC (분). 한국=540.
     ) -> Result<Vec<CalendarDayCount>> {
-        let modifier = format!("{} minutes", tz_offset_min);
+        // SQLite DATE modifier 는 `±NNN minutes` 형태를 기대하므로 부호를 명시한다
+        // (`{:+}` → "+540"/"-720"). 부호 없는 양수도 대개 동작하나 호환성 위해 명시(리뷰 반영).
+        let modifier = format!("{:+} minutes", tz_offset_min);
 
         // `?` 순서에 맞춰 params 를 lockstep 으로 구성한다. SELECT 의 DATE(start_time, ?)
         // 가 첫 ? 이므로 modifier 를 먼저 bind한 뒤, 리스트와 동일한 필터 술어(공유 헬퍼)를

--- a/crates/secall-core/src/store/session_repo.rs
+++ b/crates/secall-core/src/store/session_repo.rs
@@ -897,22 +897,25 @@ impl Database {
 
     // ─── REST listing / mutation (P32 Task 02) ─────────────────────────────
 
-    /// 세션 리스트 조회 (페이지네이션 + 다중 필터).
-    pub fn list_sessions_filtered(
-        &self,
+    /// 리스트/달력이 공유하는 세션 필터 술어를 `conditions`/`params` 에 lockstep 으로 push.
+    ///
+    /// automated/archived 제외 규칙과 project/agent/tag/favorite/q 를 **동일하게** 적용해
+    /// 두 뷰(세션 리스트·달력 배지)의 카운트가 조용히 발산하지 않게 한다. 날짜 범위는
+    /// 리스트(start_time lexical)와 달력(DATE(start_time, tz) 로컬 날짜)이 의미가 달라
+    /// 여기 포함하지 않고 호출 측에서 각각 처리한다.
+    fn push_content_conditions(
         f: &SessionListFilter,
-    ) -> crate::error::Result<SessionListPage> {
-        let mut conditions: Vec<String> = Vec::new();
+        conditions: &mut Vec<String>,
+        params: &mut Vec<Box<dyn rusqlite::ToSql>>,
+    ) {
         // automated session_type은 기본 제외 — recall과 일관성.
-        // P?? Phase 2: include_automated 토글 시에만 포함 (기본 false → 현행 동작 보존).
+        // Phase 2: include_automated 토글 시에만 포함 (기본 false → 현행 동작 보존).
         if !f.include_automated {
             conditions.push("session_type != 'automated'".to_string());
         }
         if !f.include_archived {
             conditions.push("is_archived = 0".to_string());
         }
-        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
-
         if let Some(p) = &f.project {
             conditions.push("project = ?".to_string());
             params.push(Box::new(p.clone()));
@@ -920,15 +923,6 @@ impl Database {
         if let Some(a) = &f.agent {
             conditions.push("agent = ?".to_string());
             params.push(Box::new(a.clone()));
-        }
-        if let Some(d) = &f.date_from {
-            // start_time은 RFC3339. "YYYY-MM-DD" 비교는 prefix LIKE — 단순히 lex 비교 사용
-            conditions.push("start_time >= ?".to_string());
-            params.push(Box::new(format!("{d}T00:00:00")));
-        }
-        if let Some(d) = &f.date_to {
-            conditions.push("start_time <= ?".to_string());
-            params.push(Box::new(format!("{d}T23:59:59")));
         }
         if let Some(t) = &f.tag {
             // tags는 JSON 배열 문자열. "rust" → '%"rust"%' 패턴 LIKE.
@@ -951,6 +945,27 @@ impl Database {
             let pat = format!("%{q}%");
             params.push(Box::new(pat.clone()));
             params.push(Box::new(pat));
+        }
+    }
+
+    /// 세션 리스트 조회 (페이지네이션 + 다중 필터).
+    pub fn list_sessions_filtered(
+        &self,
+        f: &SessionListFilter,
+    ) -> crate::error::Result<SessionListPage> {
+        let mut conditions: Vec<String> = Vec::new();
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        // 리스트/달력 공통 필터(automated/archived 제외 + project/agent/tag/favorite/q).
+        Self::push_content_conditions(f, &mut conditions, &mut params);
+
+        // 날짜 범위 — 리스트 전용(start_time RFC3339 문자열 lexical 비교).
+        if let Some(d) = &f.date_from {
+            conditions.push("start_time >= ?".to_string());
+            params.push(Box::new(format!("{d}T00:00:00")));
+        }
+        if let Some(d) = &f.date_to {
+            conditions.push("start_time <= ?".to_string());
+            params.push(Box::new(format!("{d}T23:59:59")));
         }
 
         // include_automated + include_archived 가 모두 true 이고 다른 필터가 없으면
@@ -1060,29 +1075,39 @@ impl Database {
     /// `from`/`to`(YYYY-MM-DD, 로컬 날짜)가 주어지면 그 로컬 날짜 범위로 제한한다.
     pub fn session_calendar_counts(
         &self,
+        filter: &SessionListFilter,
         from: Option<&str>,
         to: Option<&str>,
         tz_offset_min: i64, // 로컬 - UTC (분). 한국=540.
     ) -> Result<Vec<CalendarDayCount>> {
         let modifier = format!("{} minutes", tz_offset_min);
 
-        // `?` 순서에 맞춰 params 를 lockstep 으로 구성.
-        let mut sql = String::from(
-            "SELECT DATE(start_time, ?) AS d, COUNT(*) AS c FROM sessions \
-             WHERE session_type != 'automated' AND is_archived = 0",
-        );
+        // `?` 순서에 맞춰 params 를 lockstep 으로 구성한다. SELECT 의 DATE(start_time, ?)
+        // 가 첫 ? 이므로 modifier 를 먼저 bind한 뒤, 리스트와 동일한 필터 술어(공유 헬퍼)를
+        // 얹어 배지 카운트가 필터된 리스트와 일치하게 한다. from/to 도 conditions 로 합쳐
+        // 필터가 모두 비었을 때 `WHERE` 없이 `AND` 만 남는 구문오류를 방지한다.
+        let mut conditions: Vec<String> = Vec::new();
         let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(modifier.clone())];
+        Self::push_content_conditions(filter, &mut conditions, &mut params);
         if let Some(f) = from {
-            sql.push_str(" AND DATE(start_time, ?) >= ?");
+            conditions.push("DATE(start_time, ?) >= ?".to_string());
             params.push(Box::new(modifier.clone()));
             params.push(Box::new(f.to_string()));
         }
         if let Some(t) = to {
-            sql.push_str(" AND DATE(start_time, ?) <= ?");
+            conditions.push("DATE(start_time, ?) <= ?".to_string());
             params.push(Box::new(modifier.clone()));
             params.push(Box::new(t.to_string()));
         }
-        sql.push_str(" GROUP BY d ORDER BY d");
+        let where_clause = if conditions.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", conditions.join(" AND "))
+        };
+        let sql = format!(
+            "SELECT DATE(start_time, ?) AS d, COUNT(*) AS c FROM sessions \
+             {where_clause} GROUP BY d ORDER BY d"
+        );
 
         let conn = self.conn();
         let mut stmt = conn.prepare(&sql)?;
@@ -1810,7 +1835,10 @@ mod tests {
         db.insert_session_from_vault(&c, "body", "raw/sessions/cc.md")
             .unwrap();
 
-        let days = db.session_calendar_counts(None, None, 540).unwrap();
+        let all = SessionListFilter::default();
+        let days = db
+            .session_calendar_counts(&all, None, None, 540)
+            .unwrap();
         let map: std::collections::HashMap<&str, i64> =
             days.iter().map(|d| (d.date.as_str(), d.count)).collect();
         assert_eq!(map.get("2026-05-12"), Some(&2), "KST 05-12 에 a,b 2건");
@@ -1818,11 +1846,195 @@ mod tests {
 
         // from/to 범위 제한 — 05-13 만.
         let ranged = db
-            .session_calendar_counts(Some("2026-05-13"), Some("2026-05-13"), 540)
+            .session_calendar_counts(&all, Some("2026-05-13"), Some("2026-05-13"), 540)
             .unwrap();
         assert_eq!(ranged.len(), 1);
         assert_eq!(ranged[0].date, "2026-05-13");
         assert_eq!(ranged[0].count, 1);
+    }
+
+    // #6 회귀 — 달력 카운트가 리스트와 동일한 필터(automated/archived 제외 + project)를
+    // 적용하는지. list 와 별개 하드코딩 WHERE 로 조용히 발산하지 않도록 공유 헬퍼 검증.
+    #[test]
+    fn test_session_calendar_counts_respects_filters() {
+        let db = Database::open_memory().unwrap();
+        // 같은 로컬 날짜(KST 05-12)에 interactive(secall)/automated/archived/다른 project.
+        let mut a = make_fm("cf-a", None);
+        a.project = Some("secall".to_string());
+        a.start_time = "2026-05-12T02:00:00+00:00".to_string();
+        let mut b = make_fm("cf-auto", None);
+        b.project = Some("secall".to_string());
+        b.start_time = "2026-05-12T03:00:00+00:00".to_string();
+        let mut c = make_fm("cf-arc", Some(true));
+        c.project = Some("secall".to_string());
+        c.start_time = "2026-05-12T04:00:00+00:00".to_string();
+        let mut d = make_fm("cf-other", None);
+        d.project = Some("other".to_string());
+        d.start_time = "2026-05-12T05:00:00+00:00".to_string();
+        db.insert_session_from_vault(&a, "body", "raw/sessions/cf-a.md")
+            .unwrap();
+        db.insert_session_from_vault(&b, "body", "raw/sessions/cf-auto.md")
+            .unwrap();
+        db.insert_session_from_vault(&c, "body", "raw/sessions/cf-arc.md")
+            .unwrap();
+        db.insert_session_from_vault(&d, "body", "raw/sessions/cf-other.md")
+            .unwrap();
+        // insert 경로가 session_type 을 안 넣으므로 automated 는 직접 지정.
+        db.conn()
+            .execute(
+                "UPDATE sessions SET session_type = 'automated' WHERE id = 'cf-auto'",
+                [],
+            )
+            .unwrap();
+
+        // 기본: automated(cf-auto)/archived(cf-arc) 제외 → a + other = 2.
+        let all = SessionListFilter::default();
+        let total: i64 = db
+            .session_calendar_counts(&all, None, None, 540)
+            .unwrap()
+            .iter()
+            .map(|x| x.count)
+            .sum();
+        assert_eq!(total, 2, "automated/archived 제외 → 2건");
+
+        // project=secall: other 제외 → a 만 1 (배지가 리스트와 일치해야 함).
+        let secall = SessionListFilter {
+            project: Some("secall".to_string()),
+            ..Default::default()
+        };
+        let total_secall: i64 = db
+            .session_calendar_counts(&secall, None, None, 540)
+            .unwrap()
+            .iter()
+            .map(|x| x.count)
+            .sum();
+        assert_eq!(total_secall, 1, "달력 배지는 project 필터를 반영해야 함");
+
+        // include_automated=true: a + auto + other = 3 (archived 만 제외).
+        let with_auto = SessionListFilter {
+            include_automated: true,
+            ..Default::default()
+        };
+        let total_auto: i64 = db
+            .session_calendar_counts(&with_auto, None, None, 540)
+            .unwrap()
+            .iter()
+            .map(|x| x.count)
+            .sum();
+        assert_eq!(total_auto, 3, "include_automated=true → automated 포함");
+    }
+
+    // #7 — 정렬 tiebreak: 동률(turn_count) 시 start_time DESC 로 안정 정렬되는지.
+    #[test]
+    fn test_list_sessions_sort_tiebreak_by_start_time() {
+        let db = Database::open_memory().unwrap();
+        let mut older = make_fm("tb-older", None);
+        older.turns = Some(5);
+        older.start_time = "2026-05-10T10:00:00+00:00".to_string();
+        let mut newer = make_fm("tb-newer", None);
+        newer.turns = Some(5); // 동일 turn_count → tiebreak 발동
+        newer.start_time = "2026-05-12T10:00:00+00:00".to_string();
+        db.insert_session_from_vault(&older, "body", "raw/sessions/tb-o.md")
+            .unwrap();
+        db.insert_session_from_vault(&newer, "body", "raw/sessions/tb-n.md")
+            .unwrap();
+
+        let asc = SessionListFilter {
+            page: 1,
+            page_size: 100,
+            sort: SessionSort::Turns,
+            order: SortOrder::Asc,
+            ..Default::default()
+        };
+        let items = db.list_sessions_filtered(&asc).unwrap().items;
+        assert_eq!(
+            items[0].id, "tb-newer",
+            "동률 turn_count 는 start_time DESC 로 tiebreak → 최신 먼저"
+        );
+        assert_eq!(items[1].id, "tb-older");
+    }
+
+    // #8 — sort=project / sort=agent 컬럼 매핑(화이트리스트) 검증.
+    #[test]
+    fn test_list_sessions_sort_by_project_and_agent() {
+        let db = Database::open_memory().unwrap();
+        let mut p1 = make_fm("sp-1", None);
+        p1.project = Some("alpha".to_string());
+        p1.agent = "gemini-cli".to_string();
+        let mut p2 = make_fm("sp-2", None);
+        p2.project = Some("zeta".to_string());
+        p2.agent = "claude-code".to_string();
+        db.insert_session_from_vault(&p1, "body", "raw/sessions/sp1.md")
+            .unwrap();
+        db.insert_session_from_vault(&p2, "body", "raw/sessions/sp2.md")
+            .unwrap();
+
+        let proj_asc = SessionListFilter {
+            page: 1,
+            page_size: 100,
+            sort: SessionSort::Project,
+            order: SortOrder::Asc,
+            ..Default::default()
+        };
+        assert_eq!(
+            db.list_sessions_filtered(&proj_asc).unwrap().items[0]
+                .project
+                .as_deref(),
+            Some("alpha"),
+            "sort=project asc → alpha 먼저"
+        );
+
+        let agent_asc = SessionListFilter {
+            page: 1,
+            page_size: 100,
+            sort: SessionSort::Agent,
+            order: SortOrder::Asc,
+            ..Default::default()
+        };
+        assert_eq!(
+            db.list_sessions_filtered(&agent_asc).unwrap().items[0].agent,
+            "claude-code",
+            "sort=agent asc → claude-code 먼저"
+        );
+    }
+
+    // #11 — include_automated + include_archived 모두 true 이고 다른 필터가 없으면
+    // conditions 가 비어 WHERE 절이 생략되는 경로. SQL 오류 없이 전체를 반환해야 한다
+    // (리스트·달력 공통 경로).
+    #[test]
+    fn test_list_sessions_all_included_empty_where() {
+        let db = Database::open_memory().unwrap();
+        let a = make_fm("ew-a", None);
+        let arc = make_fm("ew-arc", Some(true));
+        db.insert_session_from_vault(&a, "body", "raw/sessions/ew-a.md")
+            .unwrap();
+        db.insert_session_from_vault(&arc, "body", "raw/sessions/ew-arc.md")
+            .unwrap();
+        db.conn()
+            .execute(
+                "UPDATE sessions SET session_type = 'automated' WHERE id = 'ew-a'",
+                [],
+            )
+            .unwrap();
+
+        let all = SessionListFilter {
+            page: 1,
+            page_size: 100,
+            include_automated: true,
+            include_archived: true,
+            ..Default::default()
+        };
+        let page = db.list_sessions_filtered(&all).unwrap();
+        assert_eq!(page.total, 2, "필터 전부 해제 시 automated+archived 포함 전체");
+
+        // 달력도 동일한 빈 WHERE 경로에서 SQL 오류 없이 동작해야 한다.
+        let cal_total: i64 = db
+            .session_calendar_counts(&all, None, None, 540)
+            .unwrap()
+            .iter()
+            .map(|x| x.count)
+            .sum();
+        assert_eq!(cal_total, 2);
     }
 
     // P89 (#100, Gemini PR #101): 재인덱싱 시 turn_count 가 frontmatter 값으로

--- a/crates/secall-core/tests/rest_routes.rs
+++ b/crates/secall-core/tests/rest_routes.rs
@@ -467,6 +467,50 @@ async fn test_list_sessions_filter_by_since() {
     assert_eq!(body_past["total"], 1, "past since filter must yield all");
 }
 
+/// Phase 1 — `?sort=turns&order=asc` 정렬 파라미터가 라우트를 통해 파싱/적용되는지.
+/// 미인식/미지정 값은 기본(date desc)로 폴백하므로 여기선 200 + items 배열 형태만 회귀.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_list_sessions_sort_query_param() {
+    let env = make_test_env().await;
+    {
+        let db = env.db.lock().unwrap();
+        insert_minimal_session(&db, "sess-sort-1");
+    }
+
+    let (status, body) = send_request(
+        &env.router,
+        Method::GET,
+        "/api/sessions?sort=turns&order=asc",
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "expected 200, body={body}");
+    assert!(body["items"].is_array(), "items must be array: {body}");
+    assert_eq!(body["total"], 1);
+}
+
+/// Phase 3 — `GET /api/sessions/calendar` 라우트 회귀. 빈 DB → 빈 배열.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_sessions_calendar_route_returns_array() {
+    let env = make_test_env().await;
+
+    let (status, body) = send_request(
+        &env.router,
+        Method::GET,
+        "/api/sessions/calendar?tz_offset=540",
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "expected 200, body={body}");
+    assert!(
+        body.is_array(),
+        "calendar response must be a JSON array: {body}"
+    );
+    assert_eq!(body.as_array().unwrap().len(), 0, "empty DB → no days");
+}
+
 // ── 1.9 GET /api/projects ────────────────────────────────────────────────────
 
 /// 빈 DB → projects 빈 배열.

--- a/crates/secall-core/tests/rest_routes.rs
+++ b/crates/secall-core/tests/rest_routes.rs
@@ -511,6 +511,87 @@ async fn test_sessions_calendar_route_returns_array() {
     assert_eq!(body.as_array().unwrap().len(), 0, "empty DB → no days");
 }
 
+/// #9 — 달력 route 를 실데이터로 검증: 날짜별 집계 카운트 + `tz_offset` 로컬 날짜
+/// 경계 이동 + 신규 필터(project) 배선. 빈 DB 테스트만으로는 파라미터 전달·집계가
+/// 검증되지 않는다.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_sessions_calendar_route_populated_and_filters() {
+    let env = make_test_env().await;
+    {
+        let db = env.db.lock().unwrap();
+        // insert_minimal_session: start_time = 2026-05-01T00:00:00Z, project = test-proj.
+        insert_minimal_session(&db, "cal-1");
+        insert_minimal_session(&db, "cal-2");
+    }
+
+    // KST(+540): 2026-05-01T00:00Z → 로컬 2026-05-01 → 그 날짜에 2건.
+    let (status, body) = send_request(
+        &env.router,
+        Method::GET,
+        "/api/sessions/calendar?tz_offset=540",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    let day = body
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|d| d["date"] == "2026-05-01")
+        .cloned()
+        .unwrap_or_else(|| panic!("expected 2026-05-01 in {body}"));
+    assert_eq!(day["count"], 2, "KST 05-01 에 2건: {body}");
+
+    // UTC-12(-720): 2026-05-01T00:00Z → 로컬 2026-04-30 (날짜 경계 이동 검증).
+    let (_s, body_neg) = send_request(
+        &env.router,
+        Method::GET,
+        "/api/sessions/calendar?tz_offset=-720",
+        None,
+    )
+    .await;
+    assert!(
+        body_neg
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|d| d["date"] == "2026-04-30" && d["count"] == 2),
+        "tz_offset=-720 은 로컬 날짜를 2026-04-30 으로 이동해야 함: {body_neg}"
+    );
+
+    // 신규 필터 배선 — project=test-proj → 2건, 없는 project → 빈 배열.
+    let (_s, body_proj) = send_request(
+        &env.router,
+        Method::GET,
+        "/api/sessions/calendar?tz_offset=540&project=test-proj",
+        None,
+    )
+    .await;
+    assert_eq!(
+        body_proj
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|d| d["count"].as_i64().unwrap_or(0))
+            .sum::<i64>(),
+        2,
+        "project=test-proj → 2건: {body_proj}"
+    );
+
+    let (_s, body_none) = send_request(
+        &env.router,
+        Method::GET,
+        "/api/sessions/calendar?tz_offset=540&project=nonexistent",
+        None,
+    )
+    .await;
+    assert_eq!(
+        body_none.as_array().unwrap().len(),
+        0,
+        "없는 project → 빈 배열: {body_none}"
+    );
+}
+
 // ── 1.9 GET /api/projects ────────────────────────────────────────────────────
 
 /// 빈 DB → projects 빈 배열.

--- a/docs/prompts/2026-07-06/web_render_thinking_turnheader.md
+++ b/docs/prompts/2026-07-06/web_render_thinking_turnheader.md
@@ -1,0 +1,42 @@
+---
+type: prompt
+status: draft
+updated_at: 2026-07-06
+---
+
+# 세션 상세 렌더 개선 — 빈 콜아웃 숨김 + Turn 헤더 토글
+
+secall-web 세션 상세(마크다운) 렌더 2건. 프론트 전용, 즉효.
+
+## 배경
+- 세션 상세 본문은 vault `.md`(Obsidian 형식)를 `MarkdownView`(react-markdown + remark/rehype 파이프라인)로 렌더한다.
+- 콜아웃 `> [!thinking]- Thinking` / `> [!tool]- Bash` 는 `web/src/lib/remarkObsidianCallouts.ts` 가 `<details class="callout callout-*">` 로 변환한다.
+- Turn 구분은 md 안의 `## Turn N — Role` / `### Turn N (HH:MM)` 헤더로 들어온다.
+
+## 문제 & 근본
+1. **빈 Thinking 콜아웃**: claude-code 세션의 thinking 이 종종 redacted/빈(`Some("")`)이라, vault md 에 `> [!thinking]- Thinking` **헤더만** 있고 본문이 없다. 웹에서 열면 아무것도 안 나온다(빈 `<details>`).
+2. **Turn 헤더 과다**: `### Turn 3 (18:15)` 같은 헤더가 매 턴 나와서 본문 흐름을 끊고 시끄럽다.
+
+## 요구사항
+
+### R1 — 본문 없는 콜아웃 숨김
+- `<details class="callout ...">` 중 **summary 를 제외한 실제 본문이 비어있으면 렌더하지 않는다**(또는 시각적으로 감춘다).
+- 구현 위치는 `remarkObsidianCallouts.ts`(빈 콜아웃 노드를 아예 만들지 않기)가 가장 깔끔. 파싱 시 callout body 의 텍스트가 공백뿐이면 그 콜아웃을 skip.
+- thinking 뿐 아니라 tool 등 모든 타입에 공통 적용(본문 없는 콜아웃은 전부 숨김). 단 tool 콜아웃은 보통 본문(명령/Output)이 있으므로 영향 없어야 한다.
+- 주의: "본문 없음" 판정은 summary 라인(`> [!type]- Title`) 다음의 `> ...` 본문 라인들이 전부 빈 경우.
+
+### R2 — Turn 헤더 기본 숨김 + 옵션 토글
+- `## Turn N — Role` 및 `### Turn N (HH:MM)` 형태의 **Turn 구분 헤더를 기본적으로 숨긴다**(본문만 자연스럽게 이어지도록).
+- 세션 상세 화면 어딘가(헤더 근처)에 **"턴 구분 표시" 토글**(체크박스/스위치, 기본 OFF)을 두고, 켜면 Turn 헤더가 보이게 한다.
+- 구현 힌트: MarkdownView 에 `showTurnHeaders?: boolean` prop 추가 → 세션 상세 컴포넌트에서 로컬 state(토글)로 제어. 숨김은 (a) remark 플러그인에서 Turn 헤더 노드 제거 or (b) CSS 로 `h2/h3` 중 Turn 패턴만 감추기 중 안전한 쪽. Turn 헤더 판정은 텍스트가 `Turn <숫자>` 로 시작하는 heading.
+- 토글 상태는 localStorage 에 저장해 세션 이동해도 유지되면 좋다(선택).
+
+## 대상 파일 (추정 — 실제는 Read 로 확인)
+- `web/src/lib/remarkObsidianCallouts.ts` (R1)
+- `web/src/components/MarkdownView.tsx` (R2 prop + Turn 헤더 필터)
+- 세션 상세 렌더 컴포넌트(MarkdownView 를 쓰는 곳 — 토글 UI 추가)
+
+## Constraints
+- 기존 shadcn/ui + index.css 토큰만. 도메인 로직/데이터 훅 불변.
+- 다크/라이트 둘 다. tsc/vite build/vitest 통과. 커밋 금지. 변경 요약 반환.
+- **vault md 나 ingest(Rust) 는 건드리지 말 것** — 순수 프론트 렌더 레이어에서만 해결.

--- a/docs/prompts/2026-07-06/web_render_thinking_turnheader.md
+++ b/docs/prompts/2026-07-06/web_render_thinking_turnheader.md
@@ -19,16 +19,16 @@ secall-web 세션 상세(마크다운) 렌더 2건. 프론트 전용, 즉효.
 
 ## 요구사항
 
-### R1 — 본문 없는 콜아웃 숨김
-- `<details class="callout ...">` 중 **summary 를 제외한 실제 본문이 비어있으면 렌더하지 않는다**(또는 시각적으로 감춘다).
-- 구현 위치는 `remarkObsidianCallouts.ts`(빈 콜아웃 노드를 아예 만들지 않기)가 가장 깔끔. 파싱 시 callout body 의 텍스트가 공백뿐이면 그 콜아웃을 skip.
-- thinking 뿐 아니라 tool 등 모든 타입에 공통 적용(본문 없는 콜아웃은 전부 숨김). 단 tool 콜아웃은 보통 본문(명령/Output)이 있으므로 영향 없어야 한다.
-- 주의: "본문 없음" 판정은 summary 라인(`> [!type]- Title`) 다음의 `> ...` 본문 라인들이 전부 빈 경우.
+### R1 — 본문 없는 **thinking** 콜아웃만 숨김
+- **thinking 콜아웃**(`> [!thinking]- Thinking`)의 summary 를 제외한 실제 본문이 비어 있으면(claude-code 의 redacted/빈 thinking) 렌더하지 않는다.
+- 구현 위치는 `remarkObsidianCallouts.ts`(빈 콜아웃 노드를 아예 만들지 않기)가 가장 깔끔. 파싱 시 callout type 이 `thinking` 이고 body 텍스트가 공백뿐이면 그 콜아웃을 skip.
+- ⚠ **thinking 타입에 한정한다.** tool/warning 등 다른 콜아웃은 본문이 비어 제목만 있어도 summary/title 을 **보존**한다 — 모든 타입에 적용하면 제목만 있는 콜아웃의 헤더가 사라지는 content-loss 회귀가 된다.
+- 주의: "본문 없음" 판정은 summary 라인(`> [!thinking]- Title`) 다음의 `> ...` 본문 라인들이 전부 빈 경우.
 
 ### R2 — Turn 헤더 기본 숨김 + 옵션 토글
 - `## Turn N — Role` 및 `### Turn N (HH:MM)` 형태의 **Turn 구분 헤더를 기본적으로 숨긴다**(본문만 자연스럽게 이어지도록).
 - 세션 상세 화면 어딘가(헤더 근처)에 **"턴 구분 표시" 토글**(체크박스/스위치, 기본 OFF)을 두고, 켜면 Turn 헤더가 보이게 한다.
-- 구현 힌트: MarkdownView 에 `showTurnHeaders?: boolean` prop 추가 → 세션 상세 컴포넌트에서 로컬 state(토글)로 제어. 숨김은 (a) remark 플러그인에서 Turn 헤더 노드 제거 or (b) CSS 로 `h2/h3` 중 Turn 패턴만 감추기 중 안전한 쪽. Turn 헤더 판정은 텍스트가 `Turn <숫자>` 로 시작하는 heading.
+- 구현 힌트: MarkdownView 에 `showTurnHeaders?: boolean` prop 추가 → 세션 상세 컴포넌트에서 로컬 state(토글)로 제어. 숨김은 remark 플러그인(`remarkHideTurnHeadings`)에서 Turn 헤더 노드 제거. Turn 헤더 판정은 **markdown.rs 가 생성한 포맷에 정밀 매칭**한다 — `## Turn N — Role`(depth 2, em-dash 필수) 또는 `### Turn N`/`### Turn N (HH:MM)`(depth 3). 사용자가 본문에 쓴 "Turn 3 회고" 같은 heading 을 지우지 않도록 함.
 - 토글 상태는 localStorage 에 저장해 세션 이동해도 유지되면 좋다(선택).
 
 ## 대상 파일 (추정 — 실제는 Read 로 확인)

--- a/docs/prompts/2026-07-06/web_sessions_linear_pilot.md
+++ b/docs/prompts/2026-07-06/web_sessions_linear_pilot.md
@@ -1,0 +1,56 @@
+---
+type: prompt
+status: draft
+updated_at: 2026-07-06
+---
+
+# Sessions 라우트 — Linear 톤 + 반응형 파일럿
+
+## Phase
+secall-web UI 고도화 1차 파일럿. 이 결과가 좋으면 다른 라우트(Daily/Wiki/Graph/Commands)로 같은 패턴을 확산한다.
+
+## 배경 (읽고 시작)
+- secall-web = React + Vite + Tailwind + **shadcn/ui(이미 셋업됨)** + @tanstack/react-query + react-router.
+- 디자인 토큰은 `web/src/index.css` 에 **이미 정교하게 정의돼 있음** (Linear-tone, indigo accent, 라이트/다크):
+  - 색 계층: `--bg` / `--surface` / `--surface-2` / `--surface-3` / `--hairline` / `--border-soft` / `--border-strong`
+  - 텍스트: `--text` / `--text-2` / `--text-3` / `--text-4`
+  - accent: `--accent` / `--accent-hover` / `--accent-soft` / `--accent-border`
+  - 타이포: `--t-h1/h2/h3/body/prose/small/meta/caption/mono` (각 -lh, -tr 동반)
+  - 여백: `--s-1..--s-10` (8-grid), radius `--r-1..--r-5`
+  - **elevation: `--shadow-1/2/pop`**, **motion: `--ease` + `--t-fast(120ms)/--t-base(160ms)/--t-slow(240ms)`**
+- Tailwind 에서 이 토큰들은 이미 유틸(`bg-surface`, `text-text-2`, `p-ds-3`, `duration-fast` 등)로 매핑돼 있음 — 기존 컴포넌트 코드에서 사용 패턴을 그대로 참고할 것.
+- **문제**: 토큰은 훌륭한데 elevation/motion 이 거의 안 쓰여서 "스켈레톤처럼 밋밋"하고, **반응형 breakpoint 가 lg(1024px) 하나뿐**이라 모바일/태블릿에서 2-pane 이 깨진다.
+
+## 대상 파일 (이것만 수정)
+- `web/src/routes/SessionsRoute.tsx` — 2-pane 레이아웃 컨테이너
+- `web/src/components/SessionList.tsx` — 좌측 리스트 (가상화/무한스크롤/시맨틱)
+- `web/src/components/SessionListItem.tsx` — 리스트 행
+- `web/src/components/SessionAside.tsx` — 우측 4-card aside (메타/미니차트/related/notes)
+- (필요 시) 세션 상세 본문 컨테이너 컴포넌트
+
+## Focus 1 — Linear 톤 적용 (기존 토큰 활용, 새 토큰 만들지 말 것)
+1. **elevation 계층**: 배경(`--bg`) < 카드/리스트(`--surface`) < hover/선택(`--surface-2`) 로 미묘한 밝기 차. 카드·aside 카드에 `--shadow-1`, hover 시 `--shadow-2`. 구분선은 `--hairline` / `--border-soft`.
+2. **motion**: 리스트 행·카드·버튼 hover/선택 전환에 `transition` + `--t-fast`/`--t-base` + `--ease`. 선택 행 하이라이트 부드럽게. (진입 애니메이션은 과하지 않게 — 선택 사항)
+3. **타이포 위계**: 세션 제목(프로젝트/summary)은 `--t-h3`/`--t-body`, 메타(날짜/turns/agent)는 `--t-meta`/`--t-caption` + `--text-3`. 대비를 명확히.
+4. **여백 리듬**: `--s-*` 로 일관된 패딩/갭. 촘촘하되 답답하지 않게 (Linear 밀도감).
+5. **focus/hover 상태**: 키보드 focus-visible 링(이미 index.css 에 있음) 유지, hover 상태 시각적 피드백 강화.
+
+## Focus 2 — 반응형 (핵심)
+Tailwind breakpoint(`sm=640` `md=768` `lg=1024`)로 3-tier:
+- **데스크탑(lg+)**: 현행 2-pane 유지 (좌 리스트 `--list-w` + 우 상세/aside).
+- **태블릿(md~lg)**: 2-pane 유지하되 리스트 폭 축소, aside 는 상세 아래로 접거나 폭 축소.
+- **모바일(<md)**: **단일 컬럼**. 리스트만 전체 폭으로 보이고, 세션 선택 시 상세가 리스트를 덮는 전체화면(또는 뒤로가기로 리스트 복귀). aside 4-card 는 상세 하단에 세로 스택. 상단 네비는 좁은 화면에서 깨지지 않게.
+- 가로 스크롤이 생기지 않도록(overflow-x 방지), 이미지/코드블록/테이블은 자체 스크롤 컨테이너.
+
+## Constraints (반드시 지킬 것)
+- **기존 shadcn/ui 컴포넌트(`components/ui/*`)와 index.css 토큰만 사용.** 새 CSS 변수/새 디자인 토큰을 만들지 말 것.
+- **도메인 로직(검색/필터/무한스크롤/가상화/삭제 낙관/시맨틱 recall/단축키)은 절대 건드리지 말 것** — 시각/레이아웃만 변경.
+- 기존 데이터 훅(useInfiniteSessions/useSemanticRecall/useDeleteSession 등) 시그니처 유지.
+- **다크/라이트 둘 다** 정상 (토큰이 이미 양쪽 지원하니 하드코딩 색 쓰지 말 것).
+- `tsc --noEmit` 과 `vite build` 통과. 기존 vitest 회귀 없게.
+- 커밋하지 말 것 (변경만). 파일 목록과 주요 변경점을 요약해 반환.
+
+## 산출물
+- 위 4~5개 파일 수정.
+- 무엇을 어떻게 바꿨는지 (elevation/motion/타이포/반응형 각각) 파일:라인 수준 요약.
+- tsc/build 통과 여부.

--- a/docs/prompts/2026-07-06/web_sessions_panel.md
+++ b/docs/prompts/2026-07-06/web_sessions_panel.md
@@ -1,0 +1,39 @@
+---
+type: prompt
+status: draft
+updated_at: 2026-07-06
+---
+
+# 세션 좌측 패널 고도화 — 정렬 + 필터 + 달력
+
+secall-web 좌측 세션 리스트 패널 강화. **백엔드(Rust) + 프론트(React) 풀스택**. Phase 로 나눠 진행.
+
+## 배경 (반드시 Read 로 현재 구현 파악)
+- 프론트 리스트: `web/src/components/SessionList.tsx`(무한스크롤/가상화/시맨틱), `SessionListItem.tsx`, 필터 UI, `web/src/routes/SessionsRoute.tsx`.
+- 데이터 훅: `web/src/hooks/useSessions.ts` (`useInfiniteSessions`/`useSessionsList`/`useSemanticRecall`), `web/src/lib/api.ts` (`listSessions`), `web/src/lib/types.ts` (`SessionsListParams`, `SessionFilterState`).
+- 백엔드: `crates/secall-core/src/mcp/rest.rs` (`/api/sessions` = `api_list_sessions`), `crates/secall-core/src/store/session_repo.rs` (`SessionListFilter`, list 쿼리).
+- 현재 정렬은 `start_time DESC` 고정. 필터는 project/agent/date range/tags/favorite.
+
+## Phase 1 — 정렬 옵션
+- 정렬 기준: **날짜(start_time) / turns(turn_count) / 프로젝트(project) / 에이전트(agent)**, 각 asc/desc.
+- 백엔드: `SessionsListParams`/`SessionListFilter` 에 `sort`(enum: date|turns|project|agent) + `order`(asc|desc) 추가. `session_repo` list 쿼리의 `ORDER BY` 를 파라미터화(화이트리스트로 SQL 인젝션 방지 — 컬럼명을 match 로 고정). rest `api_list_sessions` 가 쿼리스트링에서 받아 전달. **기본값은 date desc(현행 동작 보존)**.
+- 프론트: `api.listSessions`/`useInfiniteSessions` 에 sort/order 전달. SessionList 상단에 **정렬 드롭다운(shadcn Select)** 추가. 변경 시 query key 에 포함돼 자동 refetch.
+- keyword 경로에만 적용(semantic recall 은 score 정렬이라 제외 — UI 에서 semantic 모드일 땐 정렬 컨트롤 비활성/숨김).
+
+## Phase 2 — 필터 보강 (여유 되면)
+- 기존 필터(project/agent/date range/tags/favorite) 유지. 세션 타입(interactive/automated) 토글 정도만 얇게 추가 검토(automated 는 기본 제외 유지). 과하게 늘리지 말 것.
+
+## Phase 3 — 달력 (날짜별 세션 수 + 클릭 필터)
+- **백엔드 신규 endpoint**: 날짜별 세션 count. 예 `GET /api/sessions/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD` → `[{date, count}]`. `session_repo` 에 `SELECT DATE(start_time, tz_offset) AS d, COUNT(*) ... GROUP BY d` (tz offset 은 #131 데일리와 동일하게 브라우저 offset 전달받아 로컬 날짜 기준). automated/노이즈 제외는 데일리(do_daily)와 동일 기준 권장.
+- **프론트 달력 컴포넌트**: 월 단위 미니 캘린더. 각 날짜 셀에 **세션 수 배지**(0이면 흐리게/생략). 날짜 클릭 → 해당 날짜로 date 필터 적용(리스트 필터링). 월 이동(이전/다음). 위치는 좌측 패널 상단 접이식 또는 필터 영역 내.
+- shadcn 에 calendar(react-day-picker) 가 있으면 활용, 없으면 간단 그리드로 자체 구현. index.css 토큰만 사용.
+
+## Constraints
+- **기본 동작 보존**: 정렬/필터 미지정 시 현행(date desc, 기존 필터)과 100% 동일.
+- 도메인 로직(무한스크롤/가상화/삭제 낙관/시맨틱/단축키) 불변. 데이터 훅 시그니처는 확장만(기존 호출 깨지지 않게 optional).
+- 백엔드: `cargo check`/`cargo test`(lib) 통과, **integration 테스트(tests/)의 기존 assert 깨지지 않게** (schema/route 변경 시 확인). ORDER BY 는 화이트리스트 컬럼만.
+- 프론트: tsc/vite build/vitest 통과. 다크/라이트 둘 다. 반응형(모바일에서 정렬/달력이 깨지지 않게).
+- 커밋 금지. Phase 별로 무엇을 바꿨는지 파일:라인 요약 반환.
+
+## 권장 순서
+Phase 1(정렬) → Phase 3(달력, 백엔드 count API 포함) → Phase 2(필터 보강). Phase 1 만이라도 완결되면 가치 있음.

--- a/docs/reference/handoff_2026-07-06.md
+++ b/docs/reference/handoff_2026-07-06.md
@@ -27,15 +27,18 @@ secall-web 은 **이미 shadcn/ui 셋업 완료**(components.json, ui/*, Radix+c
 ### 커밋됨
 - `b602a87` — **Sessions 라우트 Linear 톤 + 반응형 파일럿** (tuna-developer). SessionsRoute 3-tier 반응형(모바일 단일컬럼↔md/lg 2-pane, useMatch), SessionListItem 선택(indigo tint)/hover 대비, SessionAside 카드 elevation, SessionList 상태바 sticky. 브라우저(5174) 확인 — 선택 하이라이트 양호.
 
-### 워킹 미커밋 (검증 후 커밋 필요)
-- **렌더 개선 (완료, tuna-developer)**: `web/src/lib/remarkObsidianCallouts.ts`(빈 콜아웃 숨김 `hasVisibleContent`), `web/src/components/MarkdownView.tsx`(`showTurnHeaders` prop + `remarkHideTurnHeadings`), `web/src/routes/SessionDetailRoute.tsx`(턴헤더 토글, localStorage). tsc/build/콜아웃테스트6 통과 확인됨.
-- **세션 패널 (tuna-developer agentId `ab44c6d8e57e954db` — 완료 확인 필요)**: 백엔드 `rest.rs`/`server.rs`/`session_repo.rs`/`tests/rest_routes.rs` + 프론트 `SessionList`/`SessionFilters`/`CollapsibleFilter`/`useSessions`/`api.ts`/`types.ts` + **신규 `MiniCalendar.tsx`, `SessionSortControl.tsx`**. 정렬(날짜/turns/프로젝트/에이전트) + 달력(날짜별 count API + 클릭 필터) + 필터 보강.
+### 커밋 완료
+- `c2d15a9` — **렌더 개선 + 세션 패널** (tuna-developer, 검증: cargo test lib 454 + rest 51 + web tsc/build/vitest 15, 기본 동작 보존).
+  - 렌더: 빈 콜아웃(redacted thinking) 숨김(`hasVisibleContent`) + Turn 헤더 토글(`showTurnHeaders`, localStorage).
+  - 정렬: `SessionSort`/`SortOrder` enum(화이트리스트, 인젝션 불가) + `SessionSortControl`. 기본 date desc 보존.
+  - 달력: `session_calendar_counts` + `GET /api/sessions/calendar`(로컬날짜 GROUP BY, #131 tz) + `MiniCalendar`(count 배지+클릭 필터+월이동, 기본 접힘).
+  - 필터: `include_automated` 토글.
 
-### 다음 세션 첫 작업
-1. `SendMessage` to `ab44c6d8e57e954db` 로 세션 패널 위임 결과 확인 (또는 journal.jsonl 확인). **아직 진행 중이면 완료 대기.**
-2. 통합 검증: `cd web && tsc --noEmit && vite build` + `cargo check -p secall-core && cargo test -p secall-core --lib` + **integration `cargo nextest`(schema/route 변경했으니 tests/ 확인)**.
-3. 세션 패널이 백엔드 변경(정렬 param, /api/sessions/calendar 신규) 포함 → **재빌드·재설치 필요**.
-4. 브라우저 스모크(5174 or 8080) → 파일럿+렌더+세션패널 묶어 커밋 → PR.
+### 다음 세션 첫 작업 (feat/web-shadcn-pilot)
+1. **재빌드·재설치** — 세션 패널이 백엔드 변경(정렬 param, `GET /api/sessions/calendar` 신규) 포함. `cargo build --release -p secall` → 8080 재설치.
+2. **브라우저 스모크** (5174 or 8080, 윈도우 Browser 1) — 정렬/달력/필터 + 렌더(빈 콜아웃 숨김·턴헤더 토글) + Linear톤/반응형(창 좁혀 모바일 확인).
+3. **CI green + CodeRabbit 확인 후 PR** — feat/web-shadcn-pilot → main. **규칙: 머지 전 CodeRabbit 인라인 다 확인 + 사용자에게 머지 여부 물음.**
+4. 정렬/달력/필터 상태는 라우트 로컬 state(새로고침 초기화) — URL 영속화는 후속 선택.
 
 ## 3. 규명된 것 (재작업 방지)
 

--- a/docs/reference/handoff_2026-07-06.md
+++ b/docs/reference/handoff_2026-07-06.md
@@ -1,0 +1,63 @@
+---
+type: reference
+status: in_progress
+updated_at: 2026-07-06
+---
+
+# Handoff 2026-07-06 — 웹UI 고도화 세션 (Windows)
+
+매우 긴 세션. 벡터 최적화 → 원격 GPU 임베딩 → 웹UI 스모크/버그픽스 → UI 고도화(shadcn/Linear/반응형) tuna-developer 위임까지.
+
+## 1. 이번 세션 머지 완료 (main)
+
+| PR | 내용 |
+|---|---|
+| #128~#132 | 웹UI 5개 (가상화·리치렌더·삭제낙관+sticky·데일리tz·그래프live) |
+| #133 | **kiwi-rs Windows 활성화** (선제 제외 철회, Windows CI pass 검증) |
+| #134 | BLOB 벡터 스캔 최적화 ①②③⑤ (query norm·SIMD·dot-only·int8 캐시, 무손실) |
+| #135 | **tool-use 렌더 복구** (server.rs do_get 이 vault 루트 미결합 → DB 폴백 버그. `resolve_session_file` 로 통일. CodeRabbit Major 반영) |
+| #136 | 그래프 hang 완화 (topic degree<2 필터 + alphaMin/alphaDecay 조기수렴) |
+
+**설치 바이너리(`D:\.cargo\bin\secall.exe`)는 #135까지 재빌드된 최신본** (2026-07-06). serve 는 8080.
+
+## 2. 진행 중 — 브랜치 `feat/web-shadcn-pilot` (워킹 미커밋)
+
+secall-web 은 **이미 shadcn/ui 셋업 완료**(components.json, ui/*, Radix+cva+clsx). index.css 에 Linear-tone 토큰(elevation `--shadow-*`, motion `--t-fast/base` `--ease`, 타이포/여백) 정교하게 있음. "스켈레톤 느낌"의 원인은 토큰을 **안 쓰는 것** + 반응형 부재였음.
+
+### 커밋됨
+- `b602a87` — **Sessions 라우트 Linear 톤 + 반응형 파일럿** (tuna-developer). SessionsRoute 3-tier 반응형(모바일 단일컬럼↔md/lg 2-pane, useMatch), SessionListItem 선택(indigo tint)/hover 대비, SessionAside 카드 elevation, SessionList 상태바 sticky. 브라우저(5174) 확인 — 선택 하이라이트 양호.
+
+### 워킹 미커밋 (검증 후 커밋 필요)
+- **렌더 개선 (완료, tuna-developer)**: `web/src/lib/remarkObsidianCallouts.ts`(빈 콜아웃 숨김 `hasVisibleContent`), `web/src/components/MarkdownView.tsx`(`showTurnHeaders` prop + `remarkHideTurnHeadings`), `web/src/routes/SessionDetailRoute.tsx`(턴헤더 토글, localStorage). tsc/build/콜아웃테스트6 통과 확인됨.
+- **세션 패널 (tuna-developer agentId `ab44c6d8e57e954db` — 완료 확인 필요)**: 백엔드 `rest.rs`/`server.rs`/`session_repo.rs`/`tests/rest_routes.rs` + 프론트 `SessionList`/`SessionFilters`/`CollapsibleFilter`/`useSessions`/`api.ts`/`types.ts` + **신규 `MiniCalendar.tsx`, `SessionSortControl.tsx`**. 정렬(날짜/turns/프로젝트/에이전트) + 달력(날짜별 count API + 클릭 필터) + 필터 보강.
+
+### 다음 세션 첫 작업
+1. `SendMessage` to `ab44c6d8e57e954db` 로 세션 패널 위임 결과 확인 (또는 journal.jsonl 확인). **아직 진행 중이면 완료 대기.**
+2. 통합 검증: `cd web && tsc --noEmit && vite build` + `cargo check -p secall-core && cargo test -p secall-core --lib` + **integration `cargo nextest`(schema/route 변경했으니 tests/ 확인)**.
+3. 세션 패널이 백엔드 변경(정렬 param, /api/sessions/calendar 신규) 포함 → **재빌드·재설치 필요**.
+4. 브라우저 스모크(5174 or 8080) → 파일럿+렌더+세션패널 묶어 커밋 → PR.
+
+## 3. 규명된 것 (재작업 방지)
+
+- **Thinking 빈 콜아웃 = 원본 부재, 파서 정상**: claude-code JSONL 의 thinking 215개 전부 `""`(len=0) + signature 215개. Anthropic redacted thinking. codex reasoning 도 `content:null`→skip. **gemini 만 thinking 저장됨**. → claude/codex 는 렌더 숨김(R1)이 정답. 재ingest/파서수정 불가.
+- **assistant 반복 근본** = #135 (해결됨). "고쳐졌다 롤백"은 vault 읽기 경로 회귀였고 resolve_session_file 로 견고화.
+- **벡터 검색 실제 0.2s** (curl 실측). ⚠ **PowerShell Invoke-RestMethod 는 ~2s 측정 오버헤드(착시)** — 성능측정은 `curl.exe` 로. 병목은 스캔도 임베딩도 아니었음(둘 다 빠름).
+
+## 4. 미착수 백로그
+
+- **ANSI strip fix (ingest)**: secall 세션 내용에 PowerShell/Bash tool output 의 색 escape(`\x1b[32;1m`)가 그대로 저장됨. ingest 에 ANSI strip 없음. → strip 헬퍼 + tool output(claude/codex/gemini 파서 output_summary)에 적용. **재ingest 필요**(기존 세션 정리). tuna-developer 위임 가능(간단).
+- **Daily 최근 세션 0**: 07-05/06 데일리 빈 = 최근 세션 미ingest (tz 문제 아님). `secall ingest --auto` 필요.
+- **그래프 근본**: #136 로 완화. secall 본질(위키/검색)상 그래프는 "가볍게" 유지 확정 (Web Worker/canvas 근본리팩터 폐기).
+- **@tuna/ui 디자인 시스템 (장기)**: Codex 조사 결론 = shadcn/ui 기반 `@tuna/ui` 패키지 + 얇은 토큰. secall 을 레퍼런스로 역추출. secall 레포 밖(모노레포/npm) 별도 기획.
+
+## 5. 인프라 상태 (중요)
+
+- **원격 GPU 임베딩**: `boxie` 서버(`d9ng@14.58.110.187:2232`, RTX 5060 Ti 16GB, qwen3-embedding+bge-m3). ssh 터널 `-L 11435:127.0.0.1:11434`. **Task Scheduler `secall-embed-tunnel`**(로그온 트리거+재연결, 스크립트 `C:\Users\사자\secall-embed-tunnel.ps1`, Git ssh `-F none` 필수). secall config `embedding.ollama_url=11435`(원격). → **로컬 VRAM 자유**. 로컬 대안: `config set embedding.ollama_url http://127.0.0.1:11434`.
+- **tunaLlama = kimi-k2.7-code:cloud** (`~/.tunallama/config.toml` [llm]provider=ollama + [llm.ollama]model=kimi-k2.7-code:cloud). 웹UI 작업은 tunaLlama:tuna-developer 위임.
+- **브라우저 자동화**: 윈도우 크롬 확장 연결 복구됨(확장 계정 로그인). deviceId `571bce2e-229e-4e60-a768-7d82c5725fe1` (Windows Browser 1).
+- vite dev: 5173(다른 브랜치일 수), 5174(이 세션 파일럿) — 정리 필요할 수.
+
+## 6. 미해결 질문 / 사용자 대기
+
+- ANSI strip fix 를 tuna-developer 위임할지 (사용자에게 물어본 상태).
+- 세션 패널 완료 후 파일럿 통합 PR.

--- a/web/src/components/CollapsibleFilter.tsx
+++ b/web/src/components/CollapsibleFilter.tsx
@@ -69,5 +69,6 @@ function countActive(f: SessionFilterState): number {
   if (f.tags && f.tags.length > 0) n += f.tags.length;
   if (f.favorite) n++;
   if (f.tag) n++;
+  if (f.include_automated) n++;
   return n;
 }

--- a/web/src/components/MarkdownView.tsx
+++ b/web/src/components/MarkdownView.tsx
@@ -4,6 +4,8 @@ import remarkGfm from "remark-gfm";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkMath from "remark-math";
 import { remarkObsidianCallouts } from "@/lib/remarkObsidianCallouts";
+import { visit, SKIP } from "unist-util-visit";
+import type { Root, Heading, Text as MdastText } from "mdast";
 // remark-wiki-link / rehype-raw / rehype-highlight / rehype-sanitize / rehype-katex: 외부 plugin.
 import remarkWikiLink from "remark-wiki-link";
 import rehypeRaw from "rehype-raw";
@@ -26,6 +28,12 @@ interface Props {
    */
   query?: string;
   className?: string;
+  /**
+   * R2 — Turn 구분 heading(`## Turn N — Role` / `### Turn N (HH:MM)`) 표시 여부.
+   * 기본 false(숨김) → 본문만 자연스럽게 이어짐. 세션 상세의 "턴 구분 표시"
+   * 토글이 제어. true 면 remarkHideTurnHeadings 를 빼서 헤더를 그대로 노출.
+   */
+  showTurnHeaders?: boolean;
 }
 
 /**
@@ -41,7 +49,12 @@ interface Props {
  * react-markdown components override는 `p / li / code` 의 children에서만 동작.
  * heading / link 안 매칭은 acceptable한 누락 (Risks 참조).
  */
-export function MarkdownView({ content, query, className }: Props) {
+export function MarkdownView({
+  content,
+  query,
+  className,
+  showTurnHeaders = false,
+}: Props) {
   const terms = useMemo(() => tokenizeQuery(query ?? ""), [query]);
 
   const components = useMemo<Components>(() => {
@@ -121,6 +134,9 @@ export function MarkdownView({ content, query, className }: Props) {
       // 표시되도록 한다. P49 의 `### Turn N` (같은 role 연속) 강등과 결합되어
       // 본문이 turn 별 callout 묶음으로 자연스럽게 펼침/접힘.
       remarkObsidianCallouts,
+      // R2 — 기본은 Turn 구분 heading 숨김. 토글 ON(showTurnHeaders) 이면
+      // 제거 플러그인을 빼서 헤더가 그대로 렌더된다.
+      ...(showTurnHeaders ? [] : [remarkHideTurnHeadings]),
       [
         remarkWikiLink,
         {
@@ -130,7 +146,7 @@ export function MarkdownView({ content, query, className }: Props) {
         },
       ],
     ],
-    [],
+    [showTurnHeaders],
   );
 
   const rehypePlugins = useMemo(() => {
@@ -213,6 +229,33 @@ export function MarkdownView({ content, query, className }: Props) {
       </ReactMarkdown>
     </div>
   );
+}
+
+/**
+ * R2 — `## Turn N — Role` / `### Turn N (HH:MM)` 형태의 Turn 구분 heading 을
+ * 트리에서 제거해 본문만 자연스럽게 이어지게 한다. showTurnHeaders 가 false 일
+ * 때만 remarkPlugins 에 포함된다. Turn 판정: heading 텍스트가 `Turn <숫자>`
+ * 로 시작하는 경우.
+ */
+function remarkHideTurnHeadings() {
+  return (tree: Root) => {
+    visit(tree, "heading", (node: Heading, index, parent) => {
+      if (!parent || typeof index !== "number") return;
+      if (/^turn\s+\d+/i.test(headingText(node).trim())) {
+        parent.children.splice(index, 1);
+        // 노드를 제거했으므로 같은 index(다음 sibling)에서 계속.
+        return [SKIP, index];
+      }
+    });
+  };
+}
+
+function headingText(node: Heading): string {
+  let out = "";
+  visit(node, "text", (t: MdastText) => {
+    out += t.value;
+  });
+  return out;
 }
 
 function normalizeWikiName(name: string): string {

--- a/web/src/components/MarkdownView.tsx
+++ b/web/src/components/MarkdownView.tsx
@@ -4,8 +4,7 @@ import remarkGfm from "remark-gfm";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkMath from "remark-math";
 import { remarkObsidianCallouts } from "@/lib/remarkObsidianCallouts";
-import { visit, SKIP } from "unist-util-visit";
-import type { Root, Heading, Text as MdastText } from "mdast";
+import { remarkHideTurnHeadings } from "@/lib/remarkHideTurnHeadings";
 // remark-wiki-link / rehype-raw / rehype-highlight / rehype-sanitize / rehype-katex: 외부 plugin.
 import remarkWikiLink from "remark-wiki-link";
 import rehypeRaw from "rehype-raw";
@@ -229,33 +228,6 @@ export function MarkdownView({
       </ReactMarkdown>
     </div>
   );
-}
-
-/**
- * R2 — `## Turn N — Role` / `### Turn N (HH:MM)` 형태의 Turn 구분 heading 을
- * 트리에서 제거해 본문만 자연스럽게 이어지게 한다. showTurnHeaders 가 false 일
- * 때만 remarkPlugins 에 포함된다. Turn 판정: heading 텍스트가 `Turn <숫자>`
- * 로 시작하는 경우.
- */
-function remarkHideTurnHeadings() {
-  return (tree: Root) => {
-    visit(tree, "heading", (node: Heading, index, parent) => {
-      if (!parent || typeof index !== "number") return;
-      if (/^turn\s+\d+/i.test(headingText(node).trim())) {
-        parent.children.splice(index, 1);
-        // 노드를 제거했으므로 같은 index(다음 sibling)에서 계속.
-        return [SKIP, index];
-      }
-    });
-  };
-}
-
-function headingText(node: Heading): string {
-  let out = "";
-  visit(node, "text", (t: MdastText) => {
-    out += t.value;
-  });
-  return out;
 }
 
 function normalizeWikiName(name: string): string {

--- a/web/src/components/MiniCalendar.tsx
+++ b/web/src/components/MiniCalendar.tsx
@@ -1,0 +1,156 @@
+import { useMemo, useState } from "react";
+import {
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  format,
+  getDay,
+  startOfMonth,
+} from "date-fns";
+import { Calendar as CalendarIcon, ChevronLeft, ChevronRight } from "lucide-react";
+import { useSessionCalendar } from "@/hooks/useSessions";
+
+/**
+ * Phase 3 — 좌측 패널 상단 접이식 미니 캘린더.
+ *
+ * - 월 단위 그리드 + 날짜별 세션 수 배지(0이면 생략).
+ * - 날짜 클릭 → 해당 로컬 날짜로 date 필터(date_from=date_to) 적용. 재클릭 시 해제.
+ * - 이전/다음 달 이동. 표시 중인 월 범위만 count API 호출(월 이동 시 자동 refetch).
+ * - 기본 접힘(defaultOpen=false)이라 열기 전에는 API 호출/레이아웃 영향 없음.
+ * - index.css 디자인 토큰만 사용 → 다크/라이트 자동 대응.
+ */
+const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
+// 브라우저 로컬 tz 오프셋(분, 로컬-UTC). getTimezoneOffset 은 UTC-로컬이라 부호 반전 (useDaily 와 동일).
+const TZ_OFFSET_MIN = -new Date().getTimezoneOffset();
+
+interface Props {
+  /** 현재 date 필터가 단일 날짜(date_from===date_to)면 그 값. 셀 하이라이트용. */
+  selectedDate?: string;
+  /** 날짜 선택/해제 콜백. undefined 면 필터 해제 의도. */
+  onSelectDate: (date: string | undefined) => void;
+  defaultOpen?: boolean;
+}
+
+export function MiniCalendar({
+  selectedDate,
+  onSelectDate,
+  defaultOpen = false,
+}: Props) {
+  const [open, setOpen] = useState(defaultOpen);
+  const [cursor, setCursor] = useState(() => startOfMonth(new Date()));
+
+  const monthEnd = useMemo(() => endOfMonth(cursor), [cursor]);
+  const from = format(cursor, "yyyy-MM-dd");
+  const to = format(monthEnd, "yyyy-MM-dd");
+  const today = format(new Date(), "yyyy-MM-dd");
+
+  const { data } = useSessionCalendar(from, to, TZ_OFFSET_MIN, { enabled: open });
+
+  const counts = useMemo(() => {
+    const m = new Map<string, number>();
+    (data ?? []).forEach((d) => m.set(d.date, d.count));
+    return m;
+  }, [data]);
+
+  const days = useMemo(
+    () => eachDayOfInterval({ start: cursor, end: monthEnd }),
+    [cursor, monthEnd],
+  );
+  const leadingBlanks = getDay(cursor); // 0=일 ~ 6=토
+
+  return (
+    <div className="border-b border-hairline bg-surface">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-ds-2 px-ds-3 py-ds-2 text-t-meta text-text-3 transition-colors duration-fast ease-ds hover:bg-surface-2 hover:text-text"
+      >
+        <CalendarIcon className="size-3.5" aria-hidden />
+        <span className="font-mono text-t-mono text-text-2">달력</span>
+        <span className="flex-1" />
+        <ChevronRight
+          className={`size-3 transition-transform duration-fast ease-ds ${open ? "rotate-90" : ""}`}
+          aria-hidden
+        />
+      </button>
+
+      {open && (
+        <div className="border-t border-hairline px-ds-3 pb-ds-3 pt-ds-2">
+          {/* 월 네비게이션 */}
+          <div className="mb-ds-2 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => setCursor((c) => addMonths(c, -1))}
+              aria-label="이전 달"
+              className="flex size-6 items-center justify-center rounded-sm text-text-3 hover:bg-surface-2 hover:text-text"
+            >
+              <ChevronLeft className="size-4" />
+            </button>
+            <span className="font-mono text-t-small tabular-nums text-text-2">
+              {format(cursor, "yyyy.MM")}
+            </span>
+            <button
+              type="button"
+              onClick={() => setCursor((c) => addMonths(c, 1))}
+              aria-label="다음 달"
+              className="flex size-6 items-center justify-center rounded-sm text-text-3 hover:bg-surface-2 hover:text-text"
+            >
+              <ChevronRight className="size-4" />
+            </button>
+          </div>
+
+          {/* 요일 헤더 */}
+          <div className="mb-0.5 grid grid-cols-7 gap-0.5">
+            {WEEKDAYS.map((w) => (
+              <div
+                key={w}
+                className="text-center text-t-caption text-text-4"
+                aria-hidden
+              >
+                {w}
+              </div>
+            ))}
+          </div>
+
+          {/* 날짜 그리드 */}
+          <div className="grid grid-cols-7 gap-0.5">
+            {Array.from({ length: leadingBlanks }).map((_, i) => (
+              <div key={`blank-${i}`} aria-hidden />
+            ))}
+            {days.map((day) => {
+              const ds = format(day, "yyyy-MM-dd");
+              const count = counts.get(ds) ?? 0;
+              const isSelected = selectedDate === ds;
+              const isToday = ds === today;
+              const stateCls = isSelected
+                ? "bg-brand-soft text-brand ring-1 ring-brand font-medium"
+                : isToday
+                  ? "text-brand font-medium hover:bg-surface-2"
+                  : count > 0
+                    ? "text-text hover:bg-surface-2"
+                    : "text-text-4 hover:bg-surface-2";
+              return (
+                <button
+                  key={ds}
+                  type="button"
+                  onClick={() => onSelectDate(isSelected ? undefined : ds)}
+                  aria-pressed={isSelected}
+                  aria-label={`${ds} 세션 ${count}개`}
+                  className={`relative flex aspect-square flex-col items-center justify-center rounded-sm text-t-caption tabular-nums transition-colors duration-fast ease-ds ${stateCls}`}
+                >
+                  <span className="leading-none">{format(day, "d")}</span>
+                  {count > 0 && (
+                    <span className="mt-0.5 text-[10px] leading-none tabular-nums text-brand">
+                      {count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/MiniCalendar.tsx
+++ b/web/src/components/MiniCalendar.tsx
@@ -8,7 +8,7 @@ import {
   startOfMonth,
 } from "date-fns";
 import { Calendar as CalendarIcon, ChevronLeft, ChevronRight } from "lucide-react";
-import { useSessionCalendar } from "@/hooks/useSessions";
+import { useSessionCalendar, type CalendarFilters } from "@/hooks/useSessions";
 
 /**
  * Phase 3 — 좌측 패널 상단 접이식 미니 캘린더.
@@ -20,20 +20,22 @@ import { useSessionCalendar } from "@/hooks/useSessions";
  * - index.css 디자인 토큰만 사용 → 다크/라이트 자동 대응.
  */
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
-// 브라우저 로컬 tz 오프셋(분, 로컬-UTC). getTimezoneOffset 은 UTC-로컬이라 부호 반전 (useDaily 와 동일).
-const TZ_OFFSET_MIN = -new Date().getTimezoneOffset();
 
 interface Props {
   /** 현재 date 필터가 단일 날짜(date_from===date_to)면 그 값. 셀 하이라이트용. */
   selectedDate?: string;
   /** 날짜 선택/해제 콜백. undefined 면 필터 해제 의도. */
   onSelectDate: (date: string | undefined) => void;
+  /** 리스트와 동일한 활성 필터(project/agent/tag/favorite/include_automated/q).
+   *  배지 카운트를 필터된 리스트와 일치시킨다. date_from/date_to 는 제외. */
+  filters?: CalendarFilters;
   defaultOpen?: boolean;
 }
 
 export function MiniCalendar({
   selectedDate,
   onSelectDate,
+  filters,
   defaultOpen = false,
 }: Props) {
   const [open, setOpen] = useState(defaultOpen);
@@ -43,8 +45,19 @@ export function MiniCalendar({
   const from = format(cursor, "yyyy-MM-dd");
   const to = format(monthEnd, "yyyy-MM-dd");
   const today = format(new Date(), "yyyy-MM-dd");
+  // tz 오프셋(분, 로컬-UTC)을 '표시 중인 월 중순' 기준으로 계산한다. 모듈 로드 시
+  // 1회 고정하면 DST 지역에서 다른 DST 구간의 월에 잘못된 오프셋을 보내므로,
+  // cursor 가 바뀔 때마다 그 월에 맞는 오프셋을 다시 구한다. getTimezoneOffset 은
+  // UTC-로컬이라 부호 반전 (useDaily 와 동일).
+  const tzOffset = useMemo(
+    () =>
+      -new Date(cursor.getFullYear(), cursor.getMonth(), 15).getTimezoneOffset(),
+    [cursor],
+  );
 
-  const { data } = useSessionCalendar(from, to, TZ_OFFSET_MIN, { enabled: open });
+  const { data } = useSessionCalendar(from, to, tzOffset, filters ?? {}, {
+    enabled: open,
+  });
 
   const counts = useMemo(() => {
     const m = new Map<string, number>();

--- a/web/src/components/SessionAside.tsx
+++ b/web/src/components/SessionAside.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 export function SessionAside({ sessionId, detail }: Props) {
   return (
-    <aside className="w-full max-w-[300px] shrink-0 space-y-ds-4 lg:sticky lg:top-ds-6 lg:self-start">
+    <aside className="w-full space-y-ds-4 lg:sticky lg:top-ds-6 lg:self-start">
       <MetaCard detail={detail} />
       <MiniChartCard detail={detail} />
       <RelatedCard sessionId={sessionId} />
@@ -40,7 +40,7 @@ function Card({
   children: React.ReactNode;
 }) {
   return (
-    <section className="rounded-lg border border-hairline bg-[var(--surface)] p-ds-3">
+    <section className="rounded-lg border border-hairline bg-[var(--surface)] p-ds-3 shadow-ds-1 transition-shadow duration-base ease-ds hover:shadow-ds-2">
       <div className="flex items-center justify-between mb-ds-2">
         <div className="eyebrow">{title}</div>
         {hint}

--- a/web/src/components/SessionFilters.tsx
+++ b/web/src/components/SessionFilters.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { format, startOfMonth, startOfWeek } from "date-fns";
-import { Star, X } from "lucide-react";
+import { Bot, Star, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -264,16 +264,32 @@ export function SessionFilters({ value, onChange }: Props) {
       </div>
 
       <div className="flex items-center justify-between">
-        <Button
-          type="button"
-          variant={value.favorite ? "secondary" : "ghost"}
-          size="sm"
-          className="h-7 px-2 text-xs gap-1"
-          onClick={() => set("favorite", value.favorite ? undefined : true)}
-        >
-          <Star className={`size-3.5 ${value.favorite ? "fill-status-warn text-status-warn" : ""}`} />
-          즐겨찾기만
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant={value.favorite ? "secondary" : "ghost"}
+            size="sm"
+            className="h-7 px-2 text-xs gap-1"
+            onClick={() => set("favorite", value.favorite ? undefined : true)}
+          >
+            <Star className={`size-3.5 ${value.favorite ? "fill-status-warn text-status-warn" : ""}`} />
+            즐겨찾기만
+          </Button>
+          {/* Phase 2 — automated 세션 포함 토글 (기본 제외). */}
+          <Button
+            type="button"
+            variant={value.include_automated ? "secondary" : "ghost"}
+            size="sm"
+            className="h-7 px-2 text-xs gap-1"
+            onClick={() =>
+              set("include_automated", value.include_automated ? undefined : true)
+            }
+            title="automated(자동화) 세션 포함"
+          >
+            <Bot className="size-3.5" />
+            자동화 포함
+          </Button>
+        </div>
         {hasAny && (
           <Button
             type="button"

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -197,7 +197,7 @@ export function SessionList({
     return (
       <div>
         {semanticList.isFetching && (
-          <div className="px-ds-3 py-ds-1 text-t-caption text-text-3 border-b border-hairline">
+          <div className="sticky top-0 z-10 bg-surface px-ds-3 py-ds-1 text-t-caption text-text-3 border-b border-hairline shadow-ds-1">
             업데이트 중…
           </div>
         )}
@@ -263,7 +263,7 @@ export function SessionList({
   return (
     <div>
       {keywordList.isFetching && !keywordList.isFetchingNextPage && (
-        <div className="px-ds-3 py-ds-1 text-t-caption text-text-3 border-b border-hairline">
+        <div className="sticky top-0 z-10 bg-surface px-ds-3 py-ds-1 text-t-caption text-text-3 border-b border-hairline shadow-ds-1">
           업데이트 중…
         </div>
       )}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -15,6 +15,8 @@ import type {
   SearchMode,
   SessionFilterState,
   SessionListItem as Session,
+  SessionSort,
+  SortOrder,
 } from "@/lib/types";
 
 interface Props {
@@ -25,6 +27,10 @@ interface Props {
   pageSize?: number;
   /** keyword 리스트 가상화용 스크롤 컨테이너(SessionsRoute 소유). */
   scrollParentRef: RefObject<HTMLDivElement | null>;
+  /** Phase 1 — 정렬 기준. 미지정 시 서버 기본(date). keyword 경로에만 적용. */
+  sort?: SessionSort;
+  /** Phase 1 — 정렬 방향. 미지정 시 서버 기본(desc). */
+  order?: SortOrder;
 }
 
 /**
@@ -65,6 +71,8 @@ export function SessionList({
   filters,
   pageSize = 100,
   scrollParentRef,
+  sort,
+  order,
 }: Props) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -92,6 +100,9 @@ export function SessionList({
     {
       q: trimmed === "" ? undefined : trimmed,
       ...filters,
+      // 정렬은 keyword 경로에만 적용 (semantic 은 score 정렬). 미지정 시 서버 기본.
+      sort,
+      order,
     },
     pageSize,
   );

--- a/web/src/components/SessionListItem.tsx
+++ b/web/src/components/SessionListItem.tsx
@@ -44,10 +44,10 @@ export function SessionListItem({
       type="button"
       onClick={onSelect}
       className={[
-        "w-full text-left block px-ds-4 py-ds-3 border-l-2 transition-colors duration-fast ease-ds",
+        "w-full text-left block px-ds-4 py-ds-3 border-l-2 transition-colors duration-base ease-ds",
         selected
-          ? "border-l-brand bg-surface-2"
-          : "border-l-transparent hover:bg-surface-2",
+          ? "border-l-brand bg-brand-soft"
+          : "border-l-transparent hover:bg-surface-2 hover:border-l-hairline",
       ].join(" ")}
     >
       {/* head */}
@@ -122,7 +122,7 @@ export function SessionListItem({
             onDelete();
           }}
           aria-label="세션 삭제"
-          className="absolute right-ds-2 top-ds-2 flex size-6 items-center justify-center rounded-md text-text-4 opacity-0 transition-opacity hover:bg-surface-3 hover:text-status-danger focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-status-danger group-hover:opacity-100"
+          className="absolute right-ds-2 top-ds-2 flex size-6 items-center justify-center rounded-md text-text-4 opacity-0 transition-opacity duration-fast ease-ds hover:bg-surface-3 hover:text-status-danger focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-status-danger group-hover:opacity-100"
         >
           <X className="size-3.5" />
         </button>

--- a/web/src/components/SessionSortControl.tsx
+++ b/web/src/components/SessionSortControl.tsx
@@ -1,0 +1,76 @@
+import { ArrowDown, ArrowUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { SessionSort, SortOrder } from "@/lib/types";
+
+/**
+ * Phase 1 — 좌측 리스트 상단 정렬 컨트롤.
+ *
+ * 정렬 기준(날짜/턴 수/프로젝트/에이전트) shadcn Select + asc/desc 토글 버튼.
+ * keyword 모드에서만 렌더된다(semantic 은 score 정렬이라 SessionsRoute 에서 숨김).
+ */
+const SORT_LABELS: Record<SessionSort, string> = {
+  date: "날짜",
+  turns: "턴 수",
+  project: "프로젝트",
+  agent: "에이전트",
+};
+
+const SORT_KEYS = Object.keys(SORT_LABELS) as SessionSort[];
+
+interface Props {
+  sort: SessionSort;
+  order: SortOrder;
+  onSortChange: (next: SessionSort) => void;
+  onOrderChange: (next: SortOrder) => void;
+}
+
+export function SessionSortControl({
+  sort,
+  order,
+  onSortChange,
+  onOrderChange,
+}: Props) {
+  return (
+    <div className="flex items-center gap-ds-2 border-b border-hairline bg-surface px-ds-3 py-ds-2">
+      <span className="shrink-0 text-t-meta text-text-3">정렬</span>
+      <Select value={sort} onValueChange={(v) => onSortChange(v as SessionSort)}>
+        <SelectTrigger className="h-8 flex-1 text-xs" aria-label="정렬 기준">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {SORT_KEYS.map((k) => (
+            <SelectItem key={k} value={k}>
+              {SORT_LABELS[k]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8 w-8 shrink-0 p-0"
+        aria-label={
+          order === "asc"
+            ? "오름차순 — 클릭 시 내림차순"
+            : "내림차순 — 클릭 시 오름차순"
+        }
+        title={order === "asc" ? "오름차순" : "내림차순"}
+        onClick={() => onOrderChange(order === "asc" ? "desc" : "asc")}
+      >
+        {order === "asc" ? (
+          <ArrowUp className="size-4" />
+        ) : (
+          <ArrowDown className="size-4" />
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -56,15 +56,22 @@ export function useInfiniteSessions(
  * `from`/`to` 는 표시 중인 월의 로컬 날짜 경계. `enabled`(기본 true)로 달력이
  * 접혀 있을 때 호출을 막을 수 있다. query key 에 인자가 포함돼 월 이동 시 자동 refetch.
  */
+export type CalendarFilters = Pick<
+  SessionsListParams,
+  "project" | "agent" | "tag" | "tags" | "favorite" | "include_automated" | "q"
+>;
+
 export function useSessionCalendar(
   from: string,
   to: string,
   tzOffset: number,
+  filters: CalendarFilters = {},
   opts: { enabled?: boolean } = {},
 ) {
   return useQuery({
-    queryKey: ["sessions", "calendar", from, to, tzOffset],
-    queryFn: () => api.sessionsCalendar({ from, to, tzOffset }),
+    // filters 를 key 에 포함 → 필터 변경 시 배지 카운트 자동 refetch (리스트와 동기화).
+    queryKey: ["sessions", "calendar", from, to, tzOffset, filters],
+    queryFn: () => api.sessionsCalendar({ from, to, tzOffset, ...filters }),
     enabled: opts.enabled ?? true,
     staleTime: 60_000,
     placeholderData: (prev) => prev,

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -50,6 +50,27 @@ export function useInfiniteSessions(
   });
 }
 
+/**
+ * Phase 3 — 달력 뷰 날짜별 세션 수 (`/api/sessions/calendar`).
+ *
+ * `from`/`to` 는 표시 중인 월의 로컬 날짜 경계. `enabled`(기본 true)로 달력이
+ * 접혀 있을 때 호출을 막을 수 있다. query key 에 인자가 포함돼 월 이동 시 자동 refetch.
+ */
+export function useSessionCalendar(
+  from: string,
+  to: string,
+  tzOffset: number,
+  opts: { enabled?: boolean } = {},
+) {
+  return useQuery({
+    queryKey: ["sessions", "calendar", from, to, tzOffset],
+    queryFn: () => api.sessionsCalendar({ from, to, tzOffset }),
+    enabled: opts.enabled ?? true,
+    staleTime: 60_000,
+    placeholderData: (prev) => prev,
+  });
+}
+
 /** 세션 상세 (`/api/get`). full=true면 마크다운 본문(`content`) 포함. */
 export function useSession(id: string | undefined, full = false) {
   return useQuery({

--- a/web/src/lib/__tests__/remarkHideTurnHeadings.test.ts
+++ b/web/src/lib/__tests__/remarkHideTurnHeadings.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { remark } from "remark";
+import remarkHtml from "remark-html";
+import {
+  remarkHideTurnHeadings,
+  isGeneratedTurnHeading,
+} from "../remarkHideTurnHeadings";
+import type { Heading } from "mdast";
+
+async function render(md: string): Promise<string> {
+  const out = await remark()
+    .use(remarkHideTurnHeadings)
+    .use(remarkHtml, { sanitize: false })
+    .process(md);
+  return String(out);
+}
+
+/** depth + 단일 text child 로 heading 노드 mock. */
+function heading(depth: 1 | 2 | 3, text: string): Heading {
+  return {
+    type: "heading",
+    depth,
+    children: [{ type: "text", value: text }],
+  };
+}
+
+describe("remarkHideTurnHeadings — 생성된 Turn 헤더만 제거", () => {
+  it("`## Turn N — Role` (depth 2) 제거", async () => {
+    const html = await render("## Turn 1 — User\n\nbody");
+    expect(html).not.toContain("Turn 1");
+    expect(html).toContain("body");
+  });
+
+  it("`### Turn N` (depth 3) 제거", async () => {
+    const html = await render("### Turn 2\n\nbody");
+    expect(html).not.toContain("Turn 2");
+    expect(html).toContain("body");
+  });
+
+  it("`### Turn N (HH:MM)` (depth 3, 시각) 제거", async () => {
+    const html = await render("### Turn 3 (14:30)\n\nbody");
+    expect(html).not.toContain("Turn 3");
+  });
+
+  it("사용자 heading `## Turn 3 회고` (em-dash 없음) 은 보존", async () => {
+    const html = await render("## Turn 3 회고\n\nbody");
+    expect(html).toContain("Turn 3 회고");
+  });
+
+  it("사용자 heading `# Turn 1` (depth 1) 은 보존", async () => {
+    const html = await render("# Turn 1\n\nbody");
+    expect(html).toContain("Turn 1");
+  });
+
+  it("`### Turntable setup` (Turn+숫자 아님) 은 보존", async () => {
+    const html = await render("### Turntable setup\n\nbody");
+    expect(html).toContain("Turntable setup");
+  });
+});
+
+describe("isGeneratedTurnHeading — 판정 단위 테스트", () => {
+  it("생성 포맷은 true", () => {
+    expect(isGeneratedTurnHeading(heading(2, "Turn 1 — User"))).toBe(true);
+    expect(isGeneratedTurnHeading(heading(2, "Turn 12 — Assistant"))).toBe(
+      true,
+    );
+    expect(isGeneratedTurnHeading(heading(3, "Turn 2"))).toBe(true);
+    expect(isGeneratedTurnHeading(heading(3, "Turn 3 (14:30)"))).toBe(true);
+  });
+
+  it("사용자 heading 은 false", () => {
+    // depth 2 인데 em-dash 구분자 없음
+    expect(isGeneratedTurnHeading(heading(2, "Turn 3 회고"))).toBe(false);
+    // depth 2 인데 숫자 뒤 em-dash 없이 텍스트
+    expect(isGeneratedTurnHeading(heading(2, "Turn of the century"))).toBe(
+      false,
+    );
+    // depth 1
+    expect(isGeneratedTurnHeading(heading(1, "Turn 1"))).toBe(false);
+    // depth 3 인데 숫자 뒤 시각 외 텍스트
+    expect(isGeneratedTurnHeading(heading(3, "Turn 2 extra"))).toBe(false);
+    // Turn + 숫자 아님
+    expect(isGeneratedTurnHeading(heading(3, "Turntable"))).toBe(false);
+  });
+});

--- a/web/src/lib/__tests__/remarkObsidianCallouts.test.ts
+++ b/web/src/lib/__tests__/remarkObsidianCallouts.test.ts
@@ -57,3 +57,39 @@ describe("remarkObsidianCallouts", () => {
     expect(html).toContain("<summary>A &amp; B</summary>");
   });
 });
+
+// R1 — 본문 없는 콜아웃 숨김은 thinking 타입에 한정한다. 제목만 있는 다른
+// 타입(tool/warning 등)까지 지우면 헤더(제목) 정보가 사라지는 content-loss 회귀.
+describe("remarkObsidianCallouts — R1 empty-callout 숨김 (thinking 한정)", () => {
+  async function render(md: string): Promise<string> {
+    const out = await remark()
+      .use(remarkObsidianCallouts)
+      .use(remarkHtml, { sanitize: false })
+      .process(md);
+    return String(out);
+  }
+
+  it("본문 없는 thinking 콜아웃은 제거 (redacted/빈 thinking)", async () => {
+    const html = await render("> [!thinking]- Thinking");
+    expect(html).not.toContain("callout-thinking");
+    expect(html).not.toContain("<summary>Thinking</summary>");
+  });
+
+  it("본문 없는 tool 콜아웃(제목만)은 보존 — 헤더 유지", async () => {
+    const html = await render("> [!tool]- Bash");
+    expect(html).toContain('<details class="callout callout-tool">');
+    expect(html).toContain("<summary>Bash</summary>");
+  });
+
+  it("본문 없는 warning 콜아웃(제목만)은 보존", async () => {
+    const html = await render("> [!warning] Deprecated API");
+    expect(html).toContain('<details class="callout callout-warning" open>');
+    expect(html).toContain("<summary>Deprecated API</summary>");
+  });
+
+  it("본문 있는 thinking 콜아웃은 정상 렌더", async () => {
+    const html = await render("> [!thinking]- Thinking\n> real reasoning");
+    expect(html).toContain('<details class="callout callout-thinking">');
+    expect(html).toContain("real reasoning");
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -148,12 +148,28 @@ export const api = {
     from?: string;
     to?: string;
     tzOffset?: number;
+    // 리스트와 동일한 필터 — 배지 카운트를 필터된 리스트와 일치시키기 위함.
+    project?: string;
+    agent?: string;
+    tag?: string;
+    tags?: string[];
+    favorite?: boolean;
+    include_automated?: boolean;
+    q?: string;
   }) => {
     const qs = new URLSearchParams();
     if (opts.from) qs.set("from", opts.from);
     if (opts.to) qs.set("to", opts.to);
     if (typeof opts.tzOffset === "number")
       qs.set("tz_offset", String(opts.tzOffset));
+    if (opts.project) qs.set("project", opts.project);
+    if (opts.agent) qs.set("agent", opts.agent);
+    if (opts.tag) qs.set("tag", opts.tag);
+    if (opts.tags && opts.tags.length > 0) qs.set("tags", opts.tags.join(","));
+    if (typeof opts.favorite === "boolean")
+      qs.set("favorite", String(opts.favorite));
+    if (opts.include_automated) qs.set("include_automated", "true");
+    if (opts.q) qs.set("q", opts.q);
     return jfetch<CalendarDay[]>(`/api/sessions/calendar?${qs}`);
   },
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type {
+  CalendarDay,
   GraphRebuildArgs,
   IngestArgs,
   JobStartResponse,
@@ -7,6 +8,8 @@ import type {
   RecallResponse,
   SessionDetail,
   SessionListPage,
+  SessionSort,
+  SortOrder,
   SyncArgs,
   TagsResponse,
   WikiPage,
@@ -117,6 +120,12 @@ export const api = {
       tags: string[];
       favorite: boolean;
       q: string;
+      /** Phase 1 — 정렬 기준(date|turns|project|agent). 미지정 시 서버 기본 date. */
+      sort: SessionSort;
+      /** Phase 1 — 정렬 방향(asc|desc). 미지정 시 서버 기본 desc. */
+      order: SortOrder;
+      /** Phase 2 — true 면 automated 세션 포함. 미지정 시 기본 제외. */
+      include_automated: boolean;
     }>,
   ) => {
     const qs = new URLSearchParams();
@@ -129,6 +138,23 @@ export const api = {
       }
     });
     return jfetch<SessionListPage>(`/api/sessions?${qs}`);
+  },
+
+  /**
+   * Phase 3 — 날짜별 세션 수 (달력 배지용).
+   * `from`/`to` 는 로컬 날짜(YYYY-MM-DD), `tzOffset` 은 로컬-UTC(분).
+   */
+  sessionsCalendar: (opts: {
+    from?: string;
+    to?: string;
+    tzOffset?: number;
+  }) => {
+    const qs = new URLSearchParams();
+    if (opts.from) qs.set("from", opts.from);
+    if (opts.to) qs.set("to", opts.to);
+    if (typeof opts.tzOffset === "number")
+      qs.set("tz_offset", String(opts.tzOffset));
+    return jfetch<CalendarDay[]>(`/api/sessions/calendar?${qs}`);
   },
 
   listProjects: () => jfetch<{ projects: string[] }>("/api/projects"),

--- a/web/src/lib/remarkHideTurnHeadings.ts
+++ b/web/src/lib/remarkHideTurnHeadings.ts
@@ -1,0 +1,41 @@
+import { visit, SKIP } from "unist-util-visit";
+import type { Root, Heading, Text as MdastText } from "mdast";
+
+/**
+ * R2 — `## Turn N — Role` / `### Turn N (HH:MM)` 형태의 Turn 구분 heading 을
+ * 트리에서 제거해 본문만 자연스럽게 이어지게 하는 remark plugin. showTurnHeaders 가
+ * false 일 때만 remarkPlugins 에 포함된다.
+ */
+export function remarkHideTurnHeadings() {
+  return (tree: Root) => {
+    visit(tree, "heading", (node: Heading, index, parent) => {
+      if (!parent || typeof index !== "number") return;
+      if (isGeneratedTurnHeading(node)) {
+        parent.children.splice(index, 1);
+        // 노드를 제거했으므로 같은 index(다음 sibling)에서 계속.
+        return [SKIP, index];
+      }
+    });
+  };
+}
+
+/**
+ * markdown.rs 가 생성한 Turn 구분 heading 인지 판정. 사용자가 본문에 쓴
+ * "Turn 3 회고" 같은 heading 을 실수로 지우지 않도록 생성 포맷에 정확히 맞춘다:
+ *   - `## Turn N — Role`        (depth 2, em-dash 구분자 필수)
+ *   - `### Turn N` / `### Turn N (HH:MM)` (depth 3, 숫자 뒤 시각만 허용)
+ */
+export function isGeneratedTurnHeading(node: Heading): boolean {
+  const t = headingText(node).trim();
+  if (node.depth === 2) return /^turn\s+\d+\s+—\s+\S/i.test(t);
+  if (node.depth === 3) return /^turn\s+\d+(?:\s+\(\d{1,2}:\d{2}\))?$/i.test(t);
+  return false;
+}
+
+function headingText(node: Heading): string {
+  let out = "";
+  visit(node, "text", (t: MdastText) => {
+    out += t.value;
+  });
+  return out;
+}

--- a/web/src/lib/remarkObsidianCallouts.ts
+++ b/web/src/lib/remarkObsidianCallouts.ts
@@ -64,6 +64,15 @@ export function remarkObsidianCallouts() {
         }
       }
 
+      // R1 — 본문 없는 콜아웃 숨김: summary(헤더) 라인을 제거한 뒤 남은 body 가
+      // 공백뿐이면(claude-code 의 redacted/빈 thinking 등) 콜아웃 노드를 만들지
+      // 않고 blockquote 자체를 제거한다. 모든 타입 공통. tool 콜아웃은 보통
+      // 명령/Output 본문이 있어 영향 없음.
+      if (!hasVisibleContent(node.children as RootContent[])) {
+        parent.children.splice(index, 1);
+        return [SKIP, index];
+      }
+
       const openAttr = open ? " open" : "";
       const openHtml: Html = {
         type: "html",
@@ -84,6 +93,40 @@ export function remarkObsidianCallouts() {
       return [SKIP, index + replacement.length];
     });
   };
+}
+
+/**
+ * mdast 노드 배열에 렌더링될 실제 콘텐츠가 있는지 검사.
+ * text/inlineCode/code/html 값이 공백이 아니거나, image/break 등 시각적
+ * 콘텐츠가 있으면 true. 그 외 컨테이너 노드는 children 을 재귀 검사.
+ * R1 의 "본문 없음" 판정에 사용.
+ */
+function hasVisibleContent(nodes: RootContent[]): boolean {
+  for (const n of nodes) {
+    switch (n.type) {
+      case "text":
+      case "inlineCode":
+      case "code":
+      case "html":
+        if ((n.value ?? "").trim() !== "") return true;
+        break;
+      case "image":
+      case "imageReference":
+      case "break":
+        return true;
+      default:
+        if (
+          "children" in n &&
+          Array.isArray((n as { children?: unknown }).children) &&
+          hasVisibleContent(
+            (n as unknown as { children: RootContent[] }).children,
+          )
+        ) {
+          return true;
+        }
+    }
+  }
+  return false;
 }
 
 function capitalize(s: string): string {

--- a/web/src/lib/remarkObsidianCallouts.ts
+++ b/web/src/lib/remarkObsidianCallouts.ts
@@ -64,11 +64,15 @@ export function remarkObsidianCallouts() {
         }
       }
 
-      // R1 — 본문 없는 콜아웃 숨김: summary(헤더) 라인을 제거한 뒤 남은 body 가
-      // 공백뿐이면(claude-code 의 redacted/빈 thinking 등) 콜아웃 노드를 만들지
-      // 않고 blockquote 자체를 제거한다. 모든 타입 공통. tool 콜아웃은 보통
-      // 명령/Output 본문이 있어 영향 없음.
-      if (!hasVisibleContent(node.children as RootContent[])) {
+      // R1 — 본문 없는 thinking 콜아웃만 숨김: claude-code 의 redacted/빈 thinking
+      // (`> [!thinking]- Thinking` + 빈 본문)은 펼쳐도 볼 게 없어 노이즈다. summary
+      // 제거 후 body 가 공백뿐이면 blockquote 자체를 제거한다.
+      // ⚠ thinking 으로 한정한다 — 제목만 있는 tool/warning 등 다른 콜아웃까지
+      //   지우면 헤더(제목) 정보가 통째로 사라지는 content-loss 회귀가 된다.
+      if (
+        type.toLowerCase() === "thinking" &&
+        !hasVisibleContent(node.children as RootContent[])
+      ) {
         parent.children.splice(index, 1);
         return [SKIP, index];
       }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -255,12 +255,33 @@ export interface SessionFilterState {
   /** P34 Task 03: 다중 태그 AND 매칭. */
   tags?: string[];
   favorite?: boolean;
+  /** Phase 2 — true 면 automated 세션 포함. 미지정/false 면 기본 제외(현행). */
+  include_automated?: boolean;
 }
+
+/** Phase 1 — 정렬 기준. 백엔드 `SessionSort` enum 과 1:1 (lowercase). */
+export type SessionSort = "date" | "turns" | "project" | "agent";
+/** Phase 1 — 정렬 방향. 백엔드 `SortOrder` enum 과 1:1. */
+export type SortOrder = "asc" | "desc";
 
 export interface SessionsListParams extends SessionFilterState {
   q?: string;
   page?: number;
   page_size?: number;
+  /** 미지정 시 백엔드 기본 date. */
+  sort?: SessionSort;
+  /** 미지정 시 백엔드 기본 desc(현행 최신순). */
+  order?: SortOrder;
+}
+
+/**
+ * `GET /api/sessions/calendar` 응답 한 항목 (Phase 3).
+ * 백엔드 `CalendarDayCount` 직렬화 형태 — 로컬 날짜 기준 세션 수.
+ */
+export interface CalendarDay {
+  /** "YYYY-MM-DD" (요청자 로컬 날짜) */
+  date: string;
+  count: number;
 }
 
 /**

--- a/web/src/routes/SessionDetailRoute.tsx
+++ b/web/src/routes/SessionDetailRoute.tsx
@@ -22,16 +22,27 @@ export default function SessionDetailRoute() {
   const { data, isLoading, error } = useSession(id, true);
 
   // R2 — "턴 구분 표시" 토글. 기본 OFF, localStorage 에 저장해 세션 이동해도 유지.
-  const [showTurnHeaders, setShowTurnHeaders] = useState<boolean>(
-    () =>
-      typeof window !== "undefined" &&
-      window.localStorage.getItem("secall.showTurnHeaders") === "1",
-  );
+  // Safari "모든 쿠키 차단"/프라이빗 모드 등에서는 localStorage 접근 자체가
+  // SecurityError 를 던지므로 try-catch 로 감싸 렌더 크래시를 막는다(리뷰 반영).
+  const [showTurnHeaders, setShowTurnHeaders] = useState<boolean>(() => {
+    try {
+      return (
+        typeof window !== "undefined" &&
+        window.localStorage.getItem("secall.showTurnHeaders") === "1"
+      );
+    } catch {
+      return false;
+    }
+  });
   useEffect(() => {
-    window.localStorage.setItem(
-      "secall.showTurnHeaders",
-      showTurnHeaders ? "1" : "0",
-    );
+    try {
+      window.localStorage.setItem(
+        "secall.showTurnHeaders",
+        showTurnHeaders ? "1" : "0",
+      );
+    } catch {
+      // 저장소 접근 차단 환경 — 무시 (토글은 세션 내에서만 유지).
+    }
   }, [showTurnHeaders]);
 
   if (isLoading) {

--- a/web/src/routes/SessionDetailRoute.tsx
+++ b/web/src/routes/SessionDetailRoute.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useOutletContext, useParams } from "react-router";
 import { MarkdownView } from "@/components/MarkdownView";
@@ -19,6 +20,19 @@ export default function SessionDetailRoute() {
   const outletCtx = useOutletContext<SessionsOutletContext | undefined>();
   const query = outletCtx?.query ?? "";
   const { data, isLoading, error } = useSession(id, true);
+
+  // R2 — "턴 구분 표시" 토글. 기본 OFF, localStorage 에 저장해 세션 이동해도 유지.
+  const [showTurnHeaders, setShowTurnHeaders] = useState<boolean>(
+    () =>
+      typeof window !== "undefined" &&
+      window.localStorage.getItem("secall.showTurnHeaders") === "1",
+  );
+  useEffect(() => {
+    window.localStorage.setItem(
+      "secall.showTurnHeaders",
+      showTurnHeaders ? "1" : "0",
+    );
+  }, [showTurnHeaders]);
 
   if (isLoading) {
     return (
@@ -43,7 +57,24 @@ export default function SessionDetailRoute() {
       <div className="min-w-0">
         <SessionDetailHead id={id} detail={data} />
         {body ? (
-          <MarkdownView content={body} query={query} />
+          <>
+            <div className="flex justify-end mb-ds-3">
+              <label className="inline-flex items-center gap-ds-2 text-t-meta text-text-3 cursor-pointer select-none hover:text-text transition-colors duration-fast ease-ds">
+                <input
+                  type="checkbox"
+                  checked={showTurnHeaders}
+                  onChange={(e) => setShowTurnHeaders(e.target.checked)}
+                  className="size-3.5 accent-brand cursor-pointer"
+                />
+                턴 구분 표시
+              </label>
+            </div>
+            <MarkdownView
+              content={body}
+              query={query}
+              showTurnHeaders={showTurnHeaders}
+            />
+          </>
         ) : (
           <div className="text-t-small text-text-3 italic">
             본문이 비어 있습니다. (vault 파일 없음 · turns 없음)

--- a/web/src/routes/SessionsRoute.tsx
+++ b/web/src/routes/SessionsRoute.tsx
@@ -1,10 +1,17 @@
 import { useRef, useState } from "react";
 import { Outlet, useMatch } from "react-router";
 import { CollapsibleFilter } from "@/components/CollapsibleFilter";
+import { MiniCalendar } from "@/components/MiniCalendar";
 import { SessionFilters } from "@/components/SessionFilters";
 import { SessionList } from "@/components/SessionList";
+import { SessionSortControl } from "@/components/SessionSortControl";
 import { useUi, type GlobalSearchMode } from "@/lib/store";
-import type { SearchMode, SessionFilterState } from "@/lib/types";
+import type {
+  SearchMode,
+  SessionFilterState,
+  SessionSort,
+  SortOrder,
+} from "@/lib/types";
 
 /**
  * 2-pane 세션 화면.
@@ -16,7 +23,30 @@ export default function SessionsRoute() {
   const query = useUi((s) => s.query);
   const globalMode = useUi((s) => s.searchMode);
   const [filters, setFilters] = useState<SessionFilterState>({});
+  // Phase 1 — 정렬 상태(기본 date desc = 현행 동작). keyword 경로에만 적용.
+  const [sort, setSort] = useState<SessionSort>("date");
+  const [order, setOrder] = useState<SortOrder>("desc");
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Phase 3 — 달력 셀 하이라이트: date 필터가 단일 날짜일 때만.
+  const selectedDate =
+    filters.date_from && filters.date_from === filters.date_to
+      ? filters.date_from
+      : undefined;
+
+  const handleSelectDate = (date: string | undefined) => {
+    setFilters((prev) => {
+      const next = { ...prev };
+      if (date) {
+        next.date_from = date;
+        next.date_to = date;
+      } else {
+        delete next.date_from;
+        delete next.date_to;
+      }
+      return next;
+    });
+  };
 
   // 반응형: 모바일(<md)에서는 단일 컬럼. 세션이 선택되면(:id) 상세가 리스트를
   // 전체 폭으로 덮고, 미선택 시 리스트만 보인다. md+ 에서는 항상 2-pane.
@@ -38,6 +68,21 @@ export default function SessionsRoute() {
           hasSelection ? "hidden md:flex" : "flex",
         ].join(" ")}
       >
+        {/* Phase 3 달력 + Phase 1 정렬 — keyword 모드 전용 (semantic 은 score 정렬). */}
+        {mode === "keyword" && (
+          <>
+            <MiniCalendar
+              selectedDate={selectedDate}
+              onSelectDate={handleSelectDate}
+            />
+            <SessionSortControl
+              sort={sort}
+              order={order}
+              onSortChange={setSort}
+              onOrderChange={setOrder}
+            />
+          </>
+        )}
         <div
           ref={scrollRef}
           className="flex-1 overflow-auto overscroll-contain"
@@ -47,6 +92,8 @@ export default function SessionsRoute() {
             mode={mode}
             filters={filters}
             scrollParentRef={scrollRef}
+            sort={sort}
+            order={order}
           />
         </div>
         <CollapsibleFilter filters={filters} resultCount={null}>

--- a/web/src/routes/SessionsRoute.tsx
+++ b/web/src/routes/SessionsRoute.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { Outlet } from "react-router";
+import { Outlet, useMatch } from "react-router";
 import { CollapsibleFilter } from "@/components/CollapsibleFilter";
 import { SessionFilters } from "@/components/SessionFilters";
 import { SessionList } from "@/components/SessionList";
@@ -18,6 +18,11 @@ export default function SessionsRoute() {
   const [filters, setFilters] = useState<SessionFilterState>({});
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  // 반응형: 모바일(<md)에서는 단일 컬럼. 세션이 선택되면(:id) 상세가 리스트를
+  // 전체 폭으로 덮고, 미선택 시 리스트만 보인다. md+ 에서는 항상 2-pane.
+  // (부모 라우트라 useParams 로는 자식 :id 를 못 읽으므로 useMatch 로 감지)
+  const hasSelection = Boolean(useMatch("/sessions/:id"));
+
   // wiki 모드(`hybrid`)가 store 에 남아 있으면 sessions 에선 keyword 로 폴백.
   const mode: SearchMode =
     globalMode === "hybrid" ? "keyword" : (globalMode as SearchMode);
@@ -25,9 +30,18 @@ export default function SessionsRoute() {
   const outletContext: SessionsOutletContext = { query, mode };
 
   return (
-    <div className="grid grid-cols-[var(--list-w)_1fr] h-full">
-      <div className="border-r border-hairline bg-[var(--surface)] flex flex-col overflow-hidden min-h-0">
-        <div ref={scrollRef} className="flex-1 overflow-auto">
+    <div className="grid h-full min-h-0 grid-cols-1 md:grid-cols-[300px_minmax(0,1fr)] lg:grid-cols-[var(--list-w)_minmax(0,1fr)]">
+      {/* 좌: 리스트 (surface 계층). 모바일에서 세션 선택 시 상세가 덮으므로 숨김. */}
+      <div
+        className={[
+          "min-h-0 flex-col overflow-hidden bg-surface md:border-r md:border-hairline",
+          hasSelection ? "hidden md:flex" : "flex",
+        ].join(" ")}
+      >
+        <div
+          ref={scrollRef}
+          className="flex-1 overflow-auto overscroll-contain"
+        >
           <SessionList
             query={query}
             mode={mode}
@@ -40,7 +54,13 @@ export default function SessionsRoute() {
         </CollapsibleFilter>
       </div>
 
-      <div className="overflow-auto min-w-0 bg-[var(--bg)]">
+      {/* 우: 상세/빈 상태 (bg 계층). 모바일에선 선택됐을 때만 전체 폭 노출. */}
+      <div
+        className={[
+          "min-h-0 min-w-0 overflow-auto overscroll-contain bg-[var(--bg)]",
+          hasSelection ? "block" : "hidden md:block",
+        ].join(" ")}
+      >
         <Outlet context={outletContext} />
       </div>
     </div>

--- a/web/src/routes/SessionsRoute.tsx
+++ b/web/src/routes/SessionsRoute.tsx
@@ -74,6 +74,18 @@ export default function SessionsRoute() {
             <MiniCalendar
               selectedDate={selectedDate}
               onSelectDate={handleSelectDate}
+              // date_from/date_to 는 제외 — 달력은 월 전체를 보여주되 나머지
+              // 활성 필터(project/agent/tag/favorite/include_automated/q)로 카운트를
+              // 리스트와 일치시킨다.
+              filters={{
+                project: filters.project,
+                agent: filters.agent,
+                tag: filters.tag,
+                tags: filters.tags,
+                favorite: filters.favorite,
+                include_automated: filters.include_automated,
+                q: query.trim() || undefined,
+              }}
             />
             <SessionSortControl
               sort={sort}


### PR DESCRIPTION
## 개요

Sessions 라우트를 shadcn/Linear 톤 + 3-tier 반응형으로 재구성하고, 세션 상세 렌더(빈 thinking 숨김·턴헤더 토글)와 좌측 패널(정렬/달력/필터)을 고도화. 병합 전 **셀프 적대적 코드리뷰**(12건 raise → 11건 확정)를 돌려 회귀·결함을 잡고 수정.

## 커밋

- `b602a87` Sessions 라우트 Linear 톤 + 반응형 파일럿
- `c2d15a9` 세션 상세 렌더 개선 + 좌측 패널 정렬/달력/필터
- `cb7ddf1` **코드리뷰 회귀 11건 수정** (아래)

## 셀프리뷰 수정 (11건 확정)

**정확성**
- **#1 (HIGH·회귀)** `server.rs do_get(full=true)` — `c2d15a9` 가 `resolve_session_file` 을 제거하고 vault 상대경로를 서버 CWD 기준으로 직접 읽어, tool-use 턴이 빈 `## assistant` 로 저하되던 **#135/#115 회귀 재발**. `resolve_session_file` 복원.
- **#2** `remarkObsidianCallouts` 빈 콜아웃 숨김을 **thinking 타입에 한정** — 제목만 있는 tool/warning 콜아웃까지 삭제하던 content-loss 방지.
- **#3** `remarkHideTurnHeadings` 정규식을 생성 포맷(`## Turn N — Role` / `### Turn N (HH:MM)`)에 정밀 매칭 — 사용자가 쓴 "Turn N …" 제목 보존. 별도 lib 분리로 테스트 가능화.
- **#4** 달력 배지 카운트가 리스트와 **동일 필터** 적용 — `session_calendar_counts` 를 공유 헬퍼 `push_content_conditions` 로 통일(하드코딩 WHERE 발산 제거), REST/hook/UI 로 필터 전달.
- **#5** `MiniCalendar` tz offset 을 표시 월 기준으로 계산 — DST 지역 월 이동 오차 방지.

**테스트 갭 6건** — calendar 필터/empty-WHERE, 정렬 tiebreak, sort=project/agent, 달력 route 실데이터+tz 경계, turn-heading/thinking-gating.

## 검증

- `cargo test` — lib **458** + rest **52** 통과
- web — typecheck clean + vitest **27** + build 통과
- 8080 라이브 — `/api/get full=true` tool 콜아웃 **273개 복원**(빈 assistant 0), 달력 `project=seCall` **713** = 리스트 total **713** 일치, 상세 렌더/턴토글/달력/날짜필터/반응형 브라우저 확인

## 머지 전 체크 (규칙)

- [ ] CI green
- [ ] CodeRabbit 인라인 전부 확인
- [ ] 사용자 머지 승인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 세션 목록에 정렬 기준/방향(오름·내림)을 선택할 수 있게 되었습니다.
  * 기간과 타임존 기준으로 세션 수를 보여주는 미니 캘린더가 추가되었습니다.
  * 세션 상세에서 Turn 구분 헤더 표시를 토글로 제어할 수 있게 되었습니다.
  * 자동화 세션 포함 여부를 필터로 제어할 수 있게 되었습니다.
* **Bug Fixes**
  * 세션/캘린더 필터 적용과 제외 규칙을 더 일관되게 반영하도록 개선했습니다.
  * 빈 Thinking 콜아웃과 생성된 Turn 헤더를 필요 시 숨기도록 수정했습니다.
* **Tests**
  * 정렬 및 캘린더(타임존/필터) 회귀 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->