### PR TITLE
fix(ingest): 파싱 리뷰 Stage 2 — HIGH 데이터무결성 6건 (#3~7·#16)

### DIFF
--- a/crates/secall-core/src/ingest/claude.rs
+++ b/crates/secall-core/src/ingest/claude.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
@@ -46,8 +46,15 @@ pub fn parse_claude_jsonl(path: &Path) -> Result<Session> {
     let mut turns: Vec<Turn> = Vec::new();
     let mut total_tokens = TokenUsage::default();
 
-    // Pending tool_use entries keyed by tool_use_id waiting for tool_result
-    let mut pending_tool_uses: HashMap<String, usize> = HashMap::new(); // tool_use_id -> action index in last assistant turn
+    // Pending tool_use entries keyed by tool_use_id waiting for tool_result.
+    // Value is (turn_index, action_index) so parallel tool calls spread across
+    // multiple assistant lines are each attributed to the correct owning action.
+    let mut pending_tool_uses: HashMap<String, (usize, usize)> = HashMap::new();
+
+    // Assistant message ids already counted for tokens. claude-code splits one
+    // assistant message (same message.id, identical usage object) across many
+    // JSONL lines; count usage only the first time an id is seen.
+    let mut seen_message_ids: HashSet<String> = HashSet::new();
 
     let mut line_count = 0;
 
@@ -111,7 +118,10 @@ pub fn parse_claude_jsonl(path: &Path) -> Result<Session> {
                         .any(|item| item["type"].as_str() == Some("tool_result"));
 
                     if has_tool_result {
-                        // Attach tool results to the last assistant turn
+                        // Attach tool results to the owning assistant turn/action,
+                        // located by tool_use_id. Parallel tool calls each emit their
+                        // own result (often in separate user messages); remove only the
+                        // matched id so the other pending outputs still resolve.
                         for item in items {
                             if item["type"].as_str() == Some("tool_result") {
                                 let tool_use_id =
@@ -119,10 +129,12 @@ pub fn parse_claude_jsonl(path: &Path) -> Result<Session> {
                                 let output = extract_tool_result_content(&item["content"]);
                                 let truncated = truncate_str(&output, TOOL_OUTPUT_MAX_CHARS);
 
-                                // Find the corresponding action in the last assistant turn
-                                if let Some(&action_idx) = pending_tool_uses.get(&tool_use_id) {
+                                // Locate the owning action by tool_use_id
+                                if let Some((turn_idx, action_idx)) =
+                                    pending_tool_uses.remove(&tool_use_id)
+                                {
                                     if let Some(Action::ToolUse { output_summary, .. }) = turns
-                                        .last_mut()
+                                        .get_mut(turn_idx)
                                         .and_then(|turn| turn.actions.get_mut(action_idx))
                                     {
                                         *output_summary = truncated;
@@ -130,7 +142,6 @@ pub fn parse_claude_jsonl(path: &Path) -> Result<Session> {
                                 }
                             }
                         }
-                        pending_tool_uses.clear();
                         continue;
                     }
                 }
@@ -164,9 +175,18 @@ pub fn parse_claude_jsonl(path: &Path) -> Result<Session> {
 
                 let is_sidechain = value["isSidechain"].as_bool().unwrap_or(false);
 
+                // De-duplicate token accounting by message.id: claude-code splits one
+                // assistant message (same id, identical usage object) across many JSONL
+                // lines (thinking, text, one per tool_use). Count usage and set the Turn
+                // tokens only the first time a given message id is seen.
+                let first_seen = match message["id"].as_str() {
+                    Some(id) => seen_message_ids.insert(id.to_string()),
+                    None => true, // no id: treat each line as its own message
+                };
+
                 // Parse usage
                 let usage = &message["usage"];
-                let tokens = if !usage.is_null() {
+                let tokens = if first_seen && !usage.is_null() {
                     let input = usage["input_tokens"].as_u64().unwrap_or(0);
                     let output = usage["output_tokens"].as_u64().unwrap_or(0);
                     let cached = usage["cache_read_input_tokens"].as_u64().unwrap_or(0);
@@ -186,7 +206,7 @@ pub fn parse_claude_jsonl(path: &Path) -> Result<Session> {
                 let mut text_parts: Vec<String> = Vec::new();
                 let mut actions: Vec<Action> = Vec::new();
                 let mut thinking_parts: Vec<String> = Vec::new();
-                let mut new_pending: HashMap<String, usize> = HashMap::new();
+                let turn_index = turns.len();
 
                 if let Some(content_arr) = message["content"].as_array() {
                     for item in content_arr {
@@ -208,7 +228,10 @@ pub fn parse_claude_jsonl(path: &Path) -> Result<Session> {
 
                                 let action_idx = actions.len();
                                 if !tool_use_id.is_empty() {
-                                    new_pending.insert(tool_use_id.clone(), action_idx);
+                                    // Accumulate across lines of the same assistant
+                                    // message; do NOT overwrite earlier parallel entries.
+                                    pending_tool_uses
+                                        .insert(tool_use_id.clone(), (turn_index, action_idx));
                                 }
 
                                 actions.push(Action::ToolUse {
@@ -222,8 +245,6 @@ pub fn parse_claude_jsonl(path: &Path) -> Result<Session> {
                         }
                     }
                 }
-
-                pending_tool_uses = new_pending;
 
                 let content = text_parts.join("\n\n");
                 let thinking = if thinking_parts.is_empty() {
@@ -485,5 +506,80 @@ mod tests {
         assert_eq!(session.total_tokens.input, 100);
         assert_eq!(session.total_tokens.output, 50);
         assert_eq!(session.total_tokens.cached, 200);
+    }
+
+    #[test]
+    fn test_split_assistant_message_counts_tokens_once() {
+        // Real claude-code splits ONE assistant message (same message.id, an
+        // identical usage object repeated on each line) across many JSONL lines:
+        // a thinking line, a text line, one line per tool_use. Usage must be
+        // counted ONCE, not once per line.
+        let lines = &[
+            r#"{"type":"user","message":{"role":"user","content":"Q"},"timestamp":"2026-04-05T10:00:00Z","sessionId":"dedup1","cwd":"/tmp","gitBranch":"main","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","id":"msg_dup","model":"claude","content":[{"type":"thinking","thinking":"hmm"}],"usage":{"input_tokens":100,"output_tokens":200,"cache_read_input_tokens":10}},"timestamp":"2026-04-05T10:00:01Z"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","id":"msg_dup","model":"claude","content":[{"type":"text","text":"answer"}],"usage":{"input_tokens":100,"output_tokens":200,"cache_read_input_tokens":10}},"timestamp":"2026-04-05T10:00:02Z"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","id":"msg_dup","model":"claude","content":[{"type":"tool_use","id":"toolu_x","name":"Bash","input":{"command":"ls"}}],"usage":{"input_tokens":100,"output_tokens":200,"cache_read_input_tokens":10}},"timestamp":"2026-04-05T10:00:03Z"}"#,
+        ];
+        let f = write_jsonl(lines);
+        let session = parse_claude_jsonl(f.path()).unwrap();
+        // Counted once, not 3x (would be 300 / 600 / 30 before the fix).
+        assert_eq!(session.total_tokens.input, 100);
+        assert_eq!(session.total_tokens.output, 200);
+        assert_eq!(session.total_tokens.cached, 10);
+        // Only the first line of the split message carries the Turn tokens.
+        let with_tokens = session
+            .turns
+            .iter()
+            .filter(|t| t.role == Role::Assistant && t.tokens.is_some())
+            .count();
+        assert_eq!(with_tokens, 1);
+    }
+
+    #[test]
+    fn test_parallel_tool_outputs_all_captured() {
+        // Two parallel tool calls — here split across two lines of the same
+        // assistant message.id, as real claude-code emits them — with their
+        // results delivered in separate user messages. Both outputs must be
+        // captured and attributed to the correct action; none silently dropped.
+        let lines = &[
+            r#"{"type":"user","message":{"role":"user","content":"Do two things"},"timestamp":"2026-04-05T10:00:00Z","sessionId":"par1","cwd":"/tmp","gitBranch":"main","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","id":"msg_par","model":"claude","content":[{"type":"tool_use","id":"toolu_a","name":"Bash","input":{"command":"echo a"}}],"usage":{"input_tokens":5,"output_tokens":3}},"timestamp":"2026-04-05T10:00:01Z"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","id":"msg_par","model":"claude","content":[{"type":"tool_use","id":"toolu_b","name":"Bash","input":{"command":"echo b"}}],"usage":{"input_tokens":5,"output_tokens":3}},"timestamp":"2026-04-05T10:00:02Z"}"#,
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_a","content":"output AAA","is_error":false}]},"timestamp":"2026-04-05T10:00:03Z"}"#,
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_b","content":"output BBB","is_error":false}]},"timestamp":"2026-04-05T10:00:04Z"}"#,
+        ];
+        let f = write_jsonl(lines);
+        let session = parse_claude_jsonl(f.path()).unwrap();
+
+        // Collect each ToolUse output by its input command, across all turns.
+        let mut out_a: Option<String> = None;
+        let mut out_b: Option<String> = None;
+        for turn in &session.turns {
+            for action in &turn.actions {
+                if let Action::ToolUse {
+                    input_summary,
+                    output_summary,
+                    ..
+                } = action
+                {
+                    match input_summary.as_str() {
+                        "echo a" => out_a = Some(output_summary.clone()),
+                        "echo b" => out_b = Some(output_summary.clone()),
+                        _ => {}
+                    }
+                }
+            }
+        }
+        let out_a = out_a.expect("tool_use a should exist");
+        let out_b = out_b.expect("tool_use b should exist");
+        // Both outputs captured and attributed to the right action.
+        assert!(
+            out_a.contains("AAA"),
+            "expected AAA in a's output, got {out_a:?}"
+        );
+        assert!(
+            out_b.contains("BBB"),
+            "expected BBB in b's output, got {out_b:?}"
+        );
     }
 }

--- a/crates/secall-core/src/ingest/codex.rs
+++ b/crates/secall-core/src/ingest/codex.rs
@@ -155,6 +155,22 @@ pub fn parse_codex_jsonl(path: &Path) -> Result<Session> {
                             .and_then(|t| DateTime::parse_from_rfc3339(&t).ok())
                             .map(|dt| dt.with_timezone(&Utc));
 
+                        // codex는 assistant 응답의 텍스트를 reasoning/function_call
+                        // 뒤(응답 끝)에 emit한다. 앞선 reasoning/function_call이 이미
+                        // 열어둔 (아직 텍스트가 없는) assistant 턴이 있으면 새 턴을
+                        // 만들지 않고 이 텍스트를 그 턴에 접는다.
+                        if role == Role::Assistant {
+                            if let Some(last) = turns.last_mut() {
+                                if last.role == Role::Assistant && last.content.is_empty() {
+                                    last.content = content;
+                                    if last.timestamp.is_none() {
+                                        last.timestamp = ts;
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
+
                         turns.push(Turn {
                             index: turn_idx,
                             role,
@@ -171,18 +187,24 @@ pub fn parse_codex_jsonl(path: &Path) -> Result<Session> {
                         let name = rp.name.unwrap_or_else(|| "unknown".to_string());
                         let call_id = rp.call_id.unwrap_or_default();
                         let arguments = value_to_string(rp.arguments);
+                        let ts = jl
+                            .timestamp
+                            .and_then(|t| DateTime::parse_from_rfc3339(&t).ok())
+                            .map(|dt| dt.with_timezone(&Utc));
 
-                        if let Some(last) = turns.last_mut() {
-                            let action_idx = last.actions.len();
-                            last.actions.push(Action::ToolUse {
-                                name,
-                                input_summary: arguments,
-                                output_summary: String::new(),
-                                tool_use_id: Some(call_id.clone()),
-                            });
-                            if !call_id.is_empty() {
-                                pending_calls.insert(call_id, (turns.len() - 1, action_idx));
-                            }
+                        // codex는 assistant 텍스트 없이 곧바로 tool을 호출할 수 있다.
+                        // 이때 turns.last()는 직전 user 턴이므로, ToolUse가 user 턴에
+                        // 잘못 붙지 않도록 assistant 턴을 확보해 거기에 붙인다.
+                        let turn_pos = ensure_assistant_turn(&mut turns, &mut turn_idx, ts);
+                        let action_idx = turns[turn_pos].actions.len();
+                        turns[turn_pos].actions.push(Action::ToolUse {
+                            name,
+                            input_summary: arguments,
+                            output_summary: String::new(),
+                            tool_use_id: Some(call_id.clone()),
+                        });
+                        if !call_id.is_empty() {
+                            pending_calls.insert(call_id, (turn_pos, action_idx));
                         }
                     }
                     "function_call_output" => {
@@ -199,7 +221,17 @@ pub fn parse_codex_jsonl(path: &Path) -> Result<Session> {
                             }
                         }
                     }
-                    // "reasoning" 등 → skip
+                    "reasoning" => {
+                        // reasoning은 assistant 응답의 시작 신호다. 뒤따르는
+                        // function_call / assistant message가 붙을 assistant 턴을
+                        // 미리 연다 (last가 이미 assistant면 no-op).
+                        let ts = jl
+                            .timestamp
+                            .and_then(|t| DateTime::parse_from_rfc3339(&t).ok())
+                            .map(|dt| dt.with_timezone(&Utc));
+                        ensure_assistant_turn(&mut turns, &mut turn_idx, ts);
+                    }
+                    // 그 외 아이템 → skip
                     _ => {}
                 }
             }
@@ -244,6 +276,35 @@ pub fn parse_codex_jsonl(path: &Path) -> Result<Session> {
         archived: false,
         archived_at: None,
     })
+}
+
+/// Return the index of the assistant turn that the current codex response is
+/// building. Codex emits reasoning / function_call items before (or entirely
+/// without) the assistant message text, so if the most recent turn is not an
+/// assistant turn we open a fresh (empty) one — otherwise tool calls would be
+/// misattributed to the preceding user turn.
+fn ensure_assistant_turn(
+    turns: &mut Vec<Turn>,
+    turn_idx: &mut u32,
+    ts: Option<DateTime<Utc>>,
+) -> usize {
+    if let Some(last) = turns.last() {
+        if last.role == Role::Assistant {
+            return turns.len() - 1;
+        }
+    }
+    turns.push(Turn {
+        index: *turn_idx,
+        role: Role::Assistant,
+        timestamp: ts,
+        content: String::new(),
+        actions: Vec::new(),
+        tokens: None,
+        thinking: None,
+        is_sidechain: false,
+    });
+    *turn_idx += 1;
+    turns.len() - 1
 }
 
 /// Convert a serde_json::Value to String — strings pass through, others serialize to JSON.
@@ -456,5 +517,105 @@ mod tests {
             }
             _ => panic!("expected ToolUse"),
         }
+    }
+
+    #[test]
+    fn test_codex_tool_call_attaches_to_assistant_not_user() {
+        // 실제 codex: leading assistant message 없이
+        // reasoning -> function_call -> function_call_output 로 tool을 호출.
+        // ToolUse는 반드시 assistant 턴에 붙어야 하고, 직전 user 턴에 새면 안 된다.
+        let f = make_codex_file(&[
+            r#"{"type":"session_meta","payload":{"id":"tool-first"}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"ls 실행"}]}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:02Z","type":"response_item","payload":{"type":"reasoning","content":null,"summary":[]}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:03Z","type":"response_item","payload":{"type":"function_call","name":"shell","call_id":"call-1","arguments":"{\"command\":\"ls\"}"}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"file1.rs\nfile2.rs"}}"#,
+        ]);
+        let session = parse_codex_jsonl(f.path()).unwrap();
+
+        // user 턴에는 tool action이 전혀 없어야 한다 (오귀속 방지)
+        let user = session.turns.iter().find(|t| t.role == Role::User).unwrap();
+        assert!(
+            user.actions.is_empty(),
+            "tool call leaked onto the user turn"
+        );
+
+        // assistant 턴이 존재하고 ToolUse(+resolved output)를 보유해야 한다
+        let assistant = session
+            .turns
+            .iter()
+            .find(|t| t.role == Role::Assistant)
+            .unwrap();
+        assert_eq!(assistant.actions.len(), 1);
+        match &assistant.actions[0] {
+            Action::ToolUse {
+                name,
+                output_summary,
+                ..
+            } => {
+                assert_eq!(name, "shell");
+                assert!(output_summary.contains("file1.rs"));
+            }
+            _ => panic!("expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn test_codex_normal_message_first_response() {
+        // assistant가 텍스트를 먼저 emit한 뒤 tool을 호출하는 정상 응답.
+        // 텍스트와 ToolUse가 하나의 assistant 턴에 담겨야 하고,
+        // 빈 중복 assistant 턴이 생기면 안 된다.
+        let f = make_codex_file(&[
+            r#"{"type":"session_meta","payload":{"id":"msg-first"}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"검색"}]}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"실행합니다"}]}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:03Z","type":"response_item","payload":{"type":"function_call","name":"shell","call_id":"call-2","arguments":"{\"command\":\"ls\"}"}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-2","output":"ok"}}"#,
+        ]);
+        let session = parse_codex_jsonl(f.path()).unwrap();
+        let assistant_turns: Vec<_> = session
+            .turns
+            .iter()
+            .filter(|t| t.role == Role::Assistant)
+            .collect();
+        assert_eq!(
+            assistant_turns.len(),
+            1,
+            "should not create duplicate assistant turns"
+        );
+        let a = assistant_turns[0];
+        assert!(a.content.contains("실행합니다"));
+        assert_eq!(a.actions.len(), 1);
+        match &a.actions[0] {
+            Action::ToolUse {
+                name,
+                output_summary,
+                ..
+            } => {
+                assert_eq!(name, "shell");
+                assert_eq!(output_summary, "ok");
+            }
+            _ => panic!("expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn test_codex_tool_first_then_trailing_message() {
+        // reasoning -> function_call -> output -> assistant message(text) 순서에서
+        // 마지막 텍스트가 같은 assistant 턴에 접혀야 한다.
+        let f = make_codex_file(&[
+            r#"{"type":"session_meta","payload":{"id":"trailing"}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"go"}]}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:02Z","type":"response_item","payload":{"type":"reasoning","content":null,"summary":[]}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:03Z","type":"response_item","payload":{"type":"function_call","name":"shell","call_id":"c1","arguments":"{}"}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":"c1","output":"done"}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:05Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"완료했습니다"}]}}"#,
+        ]);
+        let session = parse_codex_jsonl(f.path()).unwrap();
+        assert_eq!(session.turns.len(), 2, "user + one folded assistant turn");
+        let a = &session.turns[1];
+        assert_eq!(a.role, Role::Assistant);
+        assert!(a.content.contains("완료"));
+        assert_eq!(a.actions.len(), 1);
     }
 }

--- a/crates/secall-core/src/ingest/markdown.rs
+++ b/crates/secall-core/src/ingest/markdown.rs
@@ -186,17 +186,17 @@ pub fn render_session(session: &Session, tz: chrono_tz::Tz) -> String {
     // Frontmatter
     out.push_str("---\n");
     out.push_str("type: session\n");
-    out.push_str(&format!("agent: {}\n", session.agent.as_str()));
+    out.push_str(&format!("agent: {}\n", yaml_scalar(session.agent.as_str())));
     if let Some(m) = &session.model {
-        out.push_str(&format!("model: {}\n", m));
+        out.push_str(&format!("model: {}\n", yaml_scalar(m)));
     }
     if let Some(p) = &session.project {
-        out.push_str(&format!("project: {}\n", p));
+        out.push_str(&format!("project: {}\n", yaml_scalar(p)));
     }
     if let Some(c) = &session.cwd {
-        out.push_str(&format!("cwd: {}\n", c.display()));
+        out.push_str(&format!("cwd: {}\n", yaml_scalar(&c.display().to_string())));
     }
-    out.push_str(&format!("session_id: {}\n", session.id));
+    out.push_str(&format!("session_id: {}\n", yaml_scalar(&session.id)));
     out.push_str(&format!(
         "date: {}\n",
         session.start_time.with_timezone(&tz).format("%Y-%m-%d")
@@ -241,14 +241,17 @@ pub fn render_session(session: &Session, tz: chrono_tz::Tz) -> String {
     }
     out.push_str(&format!("tools_used: [{}]\n", tools_used.join(", ")));
     if let Some(host) = &session.host {
-        out.push_str(&format!("host: {host}\n"));
+        out.push_str(&format!("host: {}\n", yaml_scalar(host)));
     }
     if let Some(summary) = extract_summary(session) {
         let escaped = escape_yaml_string(&summary);
         out.push_str(&format!("summary: \"{escaped}\"\n"));
     }
     out.push_str("status: raw\n");
-    out.push_str(&format!("session_type: {}\n", session.session_type));
+    out.push_str(&format!(
+        "session_type: {}\n",
+        yaml_scalar(&session.session_type)
+    ));
     out.push_str("---\n\n");
 
     // Title
@@ -413,16 +416,94 @@ fn session_filename(session: &Session) -> String {
         sanitized
     };
     let project = project.as_str();
-    let id_prefix = if session.id.len() >= 8 {
-        &session.id[..8]
-    } else {
-        &session.id
-    };
+    // char-aware prefix: 멀티바이트 id(예: 파일명 stem "세션백업")를 byte-slice 하면
+    // char boundary 위반으로 panic → ingest hot path 전체 abort. char 단위로 자른다.
+    let id_prefix: String = session.id.chars().take(8).collect();
     format!("{agent}_{project}_{id_prefix}.md")
 }
 
+/// 더블쿼트 YAML 스칼라 내부용 이스케이프. backslash/quote 뿐 아니라 제어문자
+/// (개행/탭/ESC 등 C0 및 DEL/C1)도 이스케이프하여 serde_yaml 이 거부하지 않는
+/// 유효한 double-quoted scalar 를 만든다.
 fn escape_yaml_string(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
+    let mut out = String::with_capacity(s.len() + 2);
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\0' => out.push_str("\\0"),
+            // 기타 제어문자(ESC/0x1b 포함 C0, DEL, C1)는 \xNN 로 이스케이프.
+            c if c.is_control() => out.push_str(&format!("\\x{:02x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// 문자열을 안전한 YAML 스칼라로 렌더링한다. 평범한 값은 그대로 두어 기존 vault
+/// 포맷을 유지하고, YAML 메타문자/제어문자가 있으면 double-quote + 이스케이프하여
+/// 항상 유효한 YAML 을 보장한다 (frontmatter 왕복 파싱 실패로 인한 silent session
+/// drop 방지 — 예: `[archive]`, `@work`, ANSI/제어 바이트 포함 summary).
+fn yaml_scalar(s: &str) -> String {
+    if is_safe_plain_scalar(s) {
+        s.to_string()
+    } else {
+        format!("\"{}\"", escape_yaml_string(s))
+    }
+}
+
+/// unquoted(plain) YAML 스칼라로 안전하게 쓸 수 있는지 보수적으로 판정.
+/// 안전하지 않으면 호출측에서 double-quote 로 감싼다.
+fn is_safe_plain_scalar(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    // 제어문자가 있으면 plain 불가.
+    if s.chars().any(|c| c.is_control()) {
+        return false;
+    }
+    let first = s.chars().next().unwrap();
+    // 첫 글자가 YAML indicator 면 flow/anchor/tag 등으로 오해될 수 있음.
+    if matches!(
+        first,
+        '-' | '?'
+            | ':'
+            | ','
+            | '['
+            | ']'
+            | '{'
+            | '}'
+            | '#'
+            | '&'
+            | '*'
+            | '!'
+            | '|'
+            | '>'
+            | '\''
+            | '"'
+            | '%'
+            | '@'
+            | '`'
+            | ' '
+    ) {
+        return false;
+    }
+    // 끝 공백, ": "(mapping), " #"(comment), 끝의 ':' 는 plain 에서 위험.
+    if s.ends_with(' ') || s.ends_with(':') || s.contains(": ") || s.contains(" #") {
+        return false;
+    }
+    // bool/null 로 오파싱될 수 있는 값은 quote.
+    let lower = s.to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "null" | "~" | "true" | "false" | "yes" | "no" | "on" | "off"
+    ) {
+        return false;
+    }
+    true
 }
 
 /// 세션의 첫 User 턴에서 비어있지 않은 첫 줄을 80자로 truncate하여 반환.
@@ -879,6 +960,56 @@ mod tests {
         let fm = parse_session_frontmatter(content).unwrap();
         assert_eq!(fm.archived, None);
         assert_eq!(fm.archived_at, None);
+    }
+
+    // #7 ─ YAML frontmatter injection / silent session drop 회귀 테스트.
+    // project `[archive]`(flow seq 로 오파싱), host `@work`(reserved indicator),
+    // summary 내 제어문자(ESC) 가 unquoted/미이스케이프되면 serde_yaml 이 frontmatter
+    // 전체 파싱에 실패해 세션이 조용히 드랍된다. 렌더 → parse 왕복이 성공해야 한다.
+    #[test]
+    fn test_frontmatter_roundtrip_adversarial_values() {
+        let mut session = make_session(vec![make_turn(Role::User, "hello: world \u{1b}[0m done")]);
+        session.project = Some("[archive]".to_string());
+        session.host = Some("@work".to_string());
+        session.session_type = "type: weird".to_string();
+        let md = render_session(&session, chrono_tz::Tz::UTC);
+
+        // 렌더 결과가 다시 파싱되어야 한다 (silent drop 방지).
+        let fm = parse_session_frontmatter(&md).expect("adversarial frontmatter must parse");
+        assert_eq!(fm.project.as_deref(), Some("[archive]"));
+        assert_eq!(fm.host.as_deref(), Some("@work"));
+        assert_eq!(fm.session_type.as_deref(), Some("type: weird"));
+        // summary 의 콜론과 ESC 제어문자가 그대로 복원되어야 한다.
+        assert_eq!(fm.summary.as_deref(), Some("hello: world \u{1b}[0m done"));
+    }
+
+    #[test]
+    fn test_escape_yaml_string_escapes_control_chars() {
+        // ESC(0x1b) 및 개행/탭이 유효한 double-quoted escape 로 변환되어야 한다.
+        let escaped = escape_yaml_string("a\u{1b}b\nc\td");
+        assert_eq!(escaped, "a\\x1bb\\nc\\td");
+        // 왕복: double-quote 로 감싸 serde_yaml 로 파싱하면 원본 복원.
+        let yaml = format!("v: \"{}\"", escaped);
+        let val: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(val["v"].as_str(), Some("a\u{1b}b\nc\td"));
+    }
+
+    // #16 ─ 멀티바이트 id(예: 파일명 stem "세션백업메모1234") 를 byte-slice 하면
+    // char boundary 위반으로 panic 하여 ingest 전체가 abort 된다. char-aware prefix
+    // 는 panic 없이 앞 8 char 를 취해야 한다.
+    #[test]
+    fn test_session_filename_multibyte_id_no_panic() {
+        let mut session = make_session(vec![]);
+        // 10 chars(각 한글 3바이트) → byte index 8 은 char boundary 아님.
+        session.id = "세션백업메모1234".to_string();
+        let path = session_vault_path(&session, chrono_tz::Tz::UTC);
+        let s = path.to_string_lossy();
+        // 앞 8 char prefix: "세션백업메모12"
+        assert!(
+            s.contains("세션백업메모12"),
+            "filename must contain char-aware 8-char id prefix: {s}"
+        );
+        assert!(s.ends_with(".md"));
     }
 
     // P49 ─ 같은 role 연속 turn 헤더 강등 (h2 → h3) 회귀 테스트

--- a/crates/secall-core/src/ingest/markdown.rs
+++ b/crates/secall-core/src/ingest/markdown.rs
@@ -503,7 +503,31 @@ fn is_safe_plain_scalar(s: &str) -> bool {
     ) {
         return false;
     }
+    // 숫자(정수/실수/16·8·2진수)나 날짜(YYYY-MM-DD)로 오파싱될 수 있는 값은 quote.
+    // 예: project "7" → `project: 7` → serde_yaml 이 정수로 파싱 → String 역직렬화
+    // 실패 → 세션 조용히 drop (리뷰 반영). 과잉 인용은 무해(YAML 파싱 동일).
+    if s.parse::<i64>().is_ok()
+        || s.parse::<u64>().is_ok()
+        || s.parse::<f64>().is_ok()
+        || s.starts_with("0x")
+        || s.starts_with("0o")
+        || s.starts_with("0b")
+        || is_yaml_date_like(s)
+    {
+        return false;
+    }
     true
+}
+
+/// YAML 이 날짜(예: "2026-04-05")로 오파싱할 수 있는 형태인지 (보수적: YYYY-MM-DD).
+fn is_yaml_date_like(s: &str) -> bool {
+    let b = s.as_bytes();
+    s.len() == 10
+        && b[4] == b'-'
+        && b[7] == b'-'
+        && b[..4].iter().all(|c| c.is_ascii_digit())
+        && b[5..7].iter().all(|c| c.is_ascii_digit())
+        && b[8..10].iter().all(|c| c.is_ascii_digit())
 }
 
 /// 세션의 첫 User 턴에서 비어있지 않은 첫 줄을 80자로 truncate하여 반환.
@@ -981,6 +1005,22 @@ mod tests {
         assert_eq!(fm.session_type.as_deref(), Some("type: weird"));
         // summary 의 콜론과 ESC 제어문자가 그대로 복원되어야 한다.
         assert_eq!(fm.summary.as_deref(), Some("hello: world \u{1b}[0m done"));
+    }
+
+    #[test]
+    fn test_frontmatter_numeric_and_date_values_quoted() {
+        // 숫자/날짜형 문자열 값은 quote 되어야 serde_yaml 이 String 으로 복원한다.
+        // 미인용 시 `project: 7` → int, `2026-04-05` → date 로 파싱되어 String
+        // 역직렬화가 실패하고 세션이 조용히 drop 된다.
+        let mut session = make_session(vec![]);
+        session.project = Some("7".to_string()); // 순수 숫자 (인덱스에 실존하는 project)
+        session.host = Some("2026-04-05".to_string()); // 날짜형
+        session.session_type = "42".to_string(); // 숫자
+        let md = render_session(&session, chrono_tz::Tz::UTC);
+        let fm = parse_session_frontmatter(&md).expect("numeric/date frontmatter must parse");
+        assert_eq!(fm.project.as_deref(), Some("7"));
+        assert_eq!(fm.host.as_deref(), Some("2026-04-05"));
+        assert_eq!(fm.session_type.as_deref(), Some("42"));
     }
 
     #[test]

--- a/crates/secall/src/commands/ingest.rs
+++ b/crates/secall/src/commands/ingest.rs
@@ -537,10 +537,31 @@ fn fast_dedup_key(session_path: &Path) -> &str {
         .unwrap_or("")
 }
 
+/// 세션 ID 의 앞 8자를 char 경계 안전하게 잘라 반환한다.
+///
+/// `&id[..8.min(id.len())]` 슬라이싱은 len<8 만 방어할 뿐 byte offset 8 이
+/// UTF-8 char 경계가 아닐 때(비-ASCII/멀티바이트 ID) panic 한다. 로그·진행
+/// 출력용 짧은 식별자이므로 char 단위로 앞 8자를 취해 절대 panic 하지 않게 한다.
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+/// 단일 파일/아카이브에 여러 대화를 담을 수 있어 반드시 `parse_all()` 1:N
+/// 경로로 인제스트해야 하는 agent 종류인지 판정한다.
+///
+/// GeminiWeb ZIP 은 대화 N개를 담을 수 있으므로 `parse()` 1:1 경로로 라우팅되면
+/// 첫 대화만 남고 나머지 N-1개가 조용히 유실된다(#6). ClaudeAi/ChatGpt export 도 동일.
+fn uses_multi_session_path(kind: AgentKind) -> bool {
+    matches!(
+        kind,
+        AgentKind::ClaudeAi | AgentKind::ChatGpt | AgentKind::GeminiWeb
+    )
+}
+
 /// 단일 경로의 detect/parse/ingest_single_session 처리.
 ///
-/// ClaudeAi/ChatGpt 는 `parse_all()` 1:N 경로, 그 외는 filename-stem 힌트로
-/// 중복 체크 후 `parse()` 1:1 경로. 카운터/에러 누적 모두 `&mut` 로 받음.
+/// ClaudeAi/ChatGpt/GeminiWeb 는 `parse_all()` 1:N 경로, 그 외는 filename-stem
+/// 힌트로 중복 체크 후 `parse()` 1:1 경로. 카운터/에러 누적 모두 `&mut` 로 받음.
 #[allow(clippy::too_many_arguments)]
 fn ingest_path(
     config: &Config,
@@ -577,9 +598,10 @@ fn ingest_path(
         }
     };
 
-    // ClaudeAiParser는 항상 parse_all() 경로 (1:N)
+    // ClaudeAi/ChatGpt/GeminiWeb 는 항상 parse_all() 경로 (1:N)
     // agent_kind()로 판단하여 포맷·인코딩 방식과 무관하게 정확히 라우팅
-    if parser.agent_kind() == AgentKind::ClaudeAi || parser.agent_kind() == AgentKind::ChatGpt {
+    // (GeminiWeb ZIP 은 N개 대화를 담을 수 있어 parse() 1:1 경로면 첫 대화만 남고 나머지 유실됨)
+    if uses_multi_session_path(parser.agent_kind()) {
         match parser.parse_all(session_path) {
             Ok(sessions) => {
                 eprintln!(
@@ -733,14 +755,14 @@ async fn embed_vector_tasks(
                 return true;
             }
         }
-        let short = &session.id[..8.min(session.id.len())];
+        let short = short_id(&session.id);
         eprintln!(
             "  [{}/{total}] {short} ({} turns)",
             i + 1,
             session.turns.len()
         );
         if let Err(e) = engine.index_session_vectors(db, session, tz).await {
-            tracing::warn!(session = &session.id[..8.min(session.id.len())], error = %e, "vector embedding failed");
+            tracing::warn!(session = short.as_str(), error = %e, "vector embedding failed");
             error_details.push(IngestError {
                 path: String::new(),
                 session_id: Some(session.id.clone()),
@@ -783,7 +805,8 @@ async fn extract_semantic_edges_batch(
                 return true;
             }
         }
-        let short = &session_id[..8.min(session_id.len())];
+        let short_owned = short_id(session_id);
+        let short = short_owned.as_str();
         // P37 Task 01: 단일 세션 helper 로 추출 (rebuild 경로와 동일 helper).
         // 동작 변경 없음 — 기존 tracing::warn/debug 메시지 그대로 보존.
         match extract_one_session_semantic(db, config, session_id).await {
@@ -850,7 +873,8 @@ pub async fn extract_one_session_semantic(
     config: &Config,
     session_id: &str,
 ) -> ExtractOneResult {
-    let short = &session_id[..8.min(session_id.len())];
+    let short_owned = short_id(session_id);
+    let short = short_owned.as_str();
 
     let vault_path_opt = match db.get_session_vault_path(session_id) {
         Ok(vp) => vp,
@@ -1155,7 +1179,8 @@ fn ingest_single_session(
     new_session_ids.push(session.id.clone());
 
     if let Err(e) = run_post_ingest_hook(config, &session, &abs_path, tz) {
-        tracing::warn!(session = &session.id[..8.min(session.id.len())], error = %e, "post-ingest hook failed");
+        let short = short_id(&session.id);
+        tracing::warn!(session = short.as_str(), error = %e, "post-ingest hook failed");
         *hook_failures += 1;
     }
 
@@ -1359,5 +1384,48 @@ mod tests {
             apply_classification(&r, "일반 내용", Some("macbook"), "interactive"),
             "automated"
         );
+    }
+
+    #[test]
+    fn test_short_id_ascii() {
+        assert_eq!(short_id("22836c74f2ebe4cc"), "22836c74");
+    }
+
+    #[test]
+    fn test_short_id_shorter_than_eight() {
+        // 8자 미만 입력은 통째로 반환 (패닉/잘림 없음)
+        assert_eq!(short_id("abc"), "abc");
+        assert_eq!(short_id(""), "");
+    }
+
+    #[test]
+    fn test_short_id_multibyte_no_panic() {
+        // #16 회귀: byte offset 8 이 char 경계가 아닌 비-ASCII id 도 패닉하지 않고
+        // char 단위 앞 8자를 반환해야 한다 (`&id[..8]` 는 여기서 패닉했다).
+        let id = "한글아이디테스트값"; // 각 char 3바이트 → byte 8 은 char 경계 아님
+        let short = short_id(id);
+        assert_eq!(short.chars().count(), 8);
+        assert_eq!(short, "한글아이디테스트");
+    }
+
+    #[test]
+    fn test_short_id_emoji_no_panic() {
+        // 4바이트 char(이모지) 혼합 id 도 패닉 없이 앞 8 char 반환
+        let short = short_id("😀😀😀😀😀😀😀😀😀😀");
+        assert_eq!(short.chars().count(), 8);
+    }
+
+    #[test]
+    fn test_multi_session_routing_includes_gemini_web() {
+        // #6 회귀: GeminiWeb 은 반드시 parse_all() 1:N 경로로 라우팅되어야
+        // ZIP 내 N개 대화가 모두 인제스트된다.
+        assert!(uses_multi_session_path(AgentKind::GeminiWeb));
+        assert!(uses_multi_session_path(AgentKind::ClaudeAi));
+        assert!(uses_multi_session_path(AgentKind::ChatGpt));
+        // 1:1 파서는 기존대로 parse() 경로 유지
+        assert!(!uses_multi_session_path(AgentKind::Codex));
+        assert!(!uses_multi_session_path(AgentKind::ClaudeCode));
+        assert!(!uses_multi_session_path(AgentKind::GeminiCli));
+        assert!(!uses_multi_session_path(AgentKind::OpenCode));
     }
 }


### PR DESCRIPTION
파싱 서브시스템 리뷰(23 confirmed)의 **HIGH 데이터무결성** 스테이지. Stage 1(#138) 이후 merged main 기준. 4개 파일 병렬 수정.

## 수정

- **#3 (HIGH) `claude.rs`** — 토큰 이중계산. 한 assistant message 가 여러 JSONL 줄(thinking/text/tool_use)로 쪼개지며 동일 usage 를 반복 → `seen_message_ids` 로 message.id 당 1회만 집계 (~3x 부풀림 제거).
- **#4 (HIGH) `claude.rs`** — 병렬 tool 출력 유실. `pending_tool_uses` 를 줄마다 덮고 첫 result 후 `clear()` → 값을 `(turn_index, action_index)` 로 바꿔 id 별 누적 + matched id 만 remove + 소유 턴을 id 로 특정. **병렬 tool output 전부 캡처** (세션 상세 tool 렌더 정확도 직결).
- **#5 (HIGH) `codex.rs`** — `function_call` 이 USER 턴에 오귀속. `ensure_assistant_turn` 으로 assistant 응답(reasoning+function_call+message)을 하나의 assistant 턴에. 선행 텍스트 없는 tool 호출도 올바른 턴에.
- **#6 (HIGH) `ingest.rs`** — gemini web ZIP 다중 대화 유실. `AgentKind::GeminiWeb` 을 `parse_all()` 1:N 라우팅에 추가 → N개 대화 전부 ingest (기존엔 첫 1개만).
- **#7 (HIGH) `markdown.rs`** — frontmatter YAML 무따옴표/제어문자로 세션 **조용히 drop**. `yaml_scalar`/`is_safe_plain_scalar` 로 모든 문자열 필드 안전 인용 + `escape_yaml_string` 이 제어문자(ESC 등)까지 escape. `[archive]`/`@work`/ANSI 값 round-trip 성공.
- **#16 (MED) `markdown.rs`+`ingest.rs`** — `id[..8]` byte-slice → 비ASCII id char-boundary **panic**. `chars().take(8).collect()` 로 교체 (markdown 1 + ingest 5곳).

## 검증

- `cargo test` 전체 통과. 신규 테스트 12+: `split_assistant_message_counts_tokens_once` · `parallel_tool_outputs_all_captured` · `codex_tool_call_attaches_to_assistant_not_user`(+2) · `frontmatter_roundtrip_adversarial_values` · `escape_yaml_string_escapes_control_chars` · `session_filename_multibyte_id_no_panic` · `multi_session_routing_includes_gemini_web` · `short_id_multibyte_no_panic` 등.
- `clippy --workspace --all-targets` (-Dwarnings) clean, `fmt` clean.

## 후속
- Stage 3: MED/LOW 폴리시 (ANSI strip 등 나머지)
- 이미 들어간 정크 세션 DB 정리

## 머지 전
- [ ] CI green + CodeRabbit 확인 (HIGH 지적 시 반영)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 병렬 tool 실행의 결과가 올바른 턴/액션에 정확히 반영됩니다.
  * 동일 message.id 사용량이 중복 집계되지 않도록 토큰 합산이 개선됩니다.
  * Codex JSONL에서 reasoning/기능호출/텍스트 순서에 관계없이 중복 턴이 줄어듭니다.
  * YAML frontmatter의 제어문자·특수문자·멀티바이트 값 처리와 파일명 생성 안정성이 향상됩니다.
  * 여러 세션 경로 라우팅 범위가 더 많은 서비스로 확대됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->