### PR TITLE
fix(ingest): 파싱 리뷰 Stage 3 — MED/LOW 폴리시 (#9~13·#17·#18·#20~22 + display)

### DIFF
--- a/crates/secall-core/src/ingest/chatgpt.rs
+++ b/crates/secall-core/src/ingest/chatgpt.rs
@@ -179,13 +179,15 @@ fn extract_message_content(message: &GptMessage) -> (String, Option<String>) {
         .unwrap_or("text");
 
     let text = match content_type {
-        "text" | "code" | "multimodal_text" => message
+        "text" | "multimodal_text" => message
             .content
             .get("parts")
             .and_then(|v| v.as_array())
             .map(|parts| extract_parts(parts))
             .unwrap_or_default(),
-        "execution_output" => message
+        // ChatGPT stores "code" payload under a `text` STRING field (no `parts`),
+        // so route it to the text reader instead of the parts-only arm.
+        "code" | "execution_output" => message
             .content
             .get("text")
             .and_then(|v| v.as_str())
@@ -339,7 +341,11 @@ fn conversation_to_session(conv: &GptConversation) -> crate::error::Result<Sessi
         cwd: None,
         git_branch: None,
         host: Some(gethostname::gethostname().to_string_lossy().to_string()),
-        start_time: epoch_to_datetime(conv.create_time).unwrap_or_else(Utc::now),
+        start_time: epoch_to_datetime(conv.create_time)
+            // When the conversation has no create_time, fall back to the earliest
+            // available message timestamp (chain is chronological) before import time.
+            .or_else(|| chain.iter().find_map(|m| epoch_to_datetime(m.create_time)))
+            .unwrap_or_else(Utc::now),
         end_time,
         turns,
         total_tokens: TokenUsage::default(),
@@ -707,6 +713,37 @@ mod tests {
 
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].turns.len(), 2);
+    }
+
+    #[test]
+    fn test_code_content_reads_text_field() {
+        // ChatGPT "code" payload lives in a `text` STRING field (no `parts`).
+        let message = GptMessage {
+            id: "code-1".to_string(),
+            author: GptAuthor {
+                role: "assistant".to_string(),
+            },
+            content: serde_json::json!({
+                "content_type": "code",
+                "language": "python",
+                "text": "print('hello')"
+            }),
+            create_time: Some(1711234568.0),
+            metadata: Some(serde_json::json!({})),
+        };
+
+        let (content, thinking) = extract_message_content(&message);
+        assert_eq!(content, "print('hello')");
+        assert!(thinking.is_none());
+    }
+
+    #[test]
+    fn test_start_time_falls_back_to_earliest_message() {
+        let mut conv = sample_conversation();
+        conv.create_time = None;
+        let session = conversation_to_session(&conv).unwrap();
+        // Earliest message in the chain (system-1) has create_time 1711234567.123.
+        assert_eq!(session.start_time.timestamp(), 1711234567);
     }
 
     #[test]

--- a/crates/secall-core/src/ingest/claude.rs
+++ b/crates/secall-core/src/ingest/claude.rs
@@ -1,9 +1,11 @@
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader};
 use std::path::Path;
+use std::sync::OnceLock;
 
 use anyhow::{anyhow, Result};
 use chrono::DateTime;
+use regex::Regex;
 use serde_json::Value;
 
 use super::types::{Action, AgentKind, Role, Session, TokenUsage, Turn};
@@ -141,6 +143,24 @@ pub fn parse_claude_jsonl(path: &Path) -> Result<Session> {
                                     }
                                 }
                             }
+                        }
+
+                        // A user message can carry BOTH tool_result blocks and
+                        // free-text blocks (e.g. the user typed something while the
+                        // tools were still resolving). Still surface that text as a
+                        // User turn instead of dropping it along with the results.
+                        let text = extract_user_text(content_val);
+                        if !text.is_empty() {
+                            turns.push(Turn {
+                                index: turns.len() as u32,
+                                role: Role::User,
+                                timestamp: ts,
+                                content: text,
+                                actions: Vec::new(),
+                                tokens: None,
+                                thinking: None,
+                                is_sidechain,
+                            });
                         }
                         continue;
                     }
@@ -339,12 +359,10 @@ fn extract_user_text(content: &Value) -> String {
 }
 
 fn extract_tool_result_content(content: &Value) -> String {
-    if content.is_string() {
-        return content.as_str().unwrap_or("").to_string();
-    }
-    if let Some(arr) = content.as_array() {
-        let parts: Vec<String> = arr
-            .iter()
+    let raw = if content.is_string() {
+        content.as_str().unwrap_or("").to_string()
+    } else if let Some(arr) = content.as_array() {
+        arr.iter()
             .filter_map(|item| {
                 if item["type"].as_str() == Some("text") {
                     item["text"].as_str().map(String::from)
@@ -352,10 +370,36 @@ fn extract_tool_result_content(content: &Value) -> String {
                     None
                 }
             })
-            .collect();
-        return parts.join("\n");
-    }
-    String::new()
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        String::new()
+    };
+
+    // Tool output (PowerShell/Bash) frequently carries ANSI color/cursor escapes
+    // and stray control bytes. Strip them before the content is stored/truncated.
+    strip_ansi(&raw)
+}
+
+fn re_ansi() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        // CSI sequences (colors/cursor): ESC [ params intermediates final
+        // OSC sequences (titles etc.): ESC ] ... (BEL | ST)
+        // Other Fe two-char escapes: ESC + 0x40..0x5F (excluding [ which starts CSI)
+        Regex::new(r"\x1b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[@-Z\x5c-\x5f])")
+            .unwrap()
+    })
+}
+
+/// Strip ANSI escape sequences and stray C0 control bytes (keeping only
+/// newline and tab) from a string.
+fn strip_ansi(s: &str) -> String {
+    let no_esc = re_ansi().replace_all(s, "");
+    no_esc
+        .chars()
+        .filter(|&c| c == '\n' || c == '\t' || !c.is_control())
+        .collect()
 }
 
 fn summarize_tool_input(tool_name: &str, input: &Value) -> String {
@@ -581,5 +625,73 @@ mod tests {
             out_b.contains("BBB"),
             "expected BBB in b's output, got {out_b:?}"
         );
+    }
+
+    #[test]
+    fn test_user_message_tool_result_plus_text_keeps_text() {
+        // A user message can carry BOTH a tool_result and a free-text block.
+        // The text must NOT be dropped along with the tool_result handling.
+        let lines = &[
+            r#"{"type":"user","message":{"role":"user","content":"Run it"},"timestamp":"2026-04-05T10:00:00Z","sessionId":"mix1","cwd":"/tmp","gitBranch":"main","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","id":"msg_1","model":"claude","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}}],"usage":{"input_tokens":5,"output_tokens":3}},"timestamp":"2026-04-05T10:00:01Z"}"#,
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"file1.txt","is_error":false},{"type":"text","text":"actually stop and do X instead"}]},"timestamp":"2026-04-05T10:00:02Z"}"#,
+        ];
+        let f = write_jsonl(lines);
+        let session = parse_claude_jsonl(f.path()).unwrap();
+
+        // The free-text alongside the tool_result must surface as a User turn.
+        let user_texts: Vec<&str> = session
+            .turns
+            .iter()
+            .filter(|t| t.role == Role::User)
+            .map(|t| t.content.as_str())
+            .collect();
+        assert!(
+            user_texts
+                .iter()
+                .any(|t| t.contains("actually stop and do X instead")),
+            "user text alongside tool_result must not be dropped, got {user_texts:?}"
+        );
+
+        // The tool_result is still attached to the owning assistant action.
+        if let Action::ToolUse { output_summary, .. } = &session.turns[1].actions[0] {
+            assert!(output_summary.contains("file1.txt"));
+        } else {
+            panic!("expected tool use action");
+        }
+    }
+
+    #[test]
+    fn test_tool_output_ansi_escapes_stripped() {
+        // Tool output with ANSI color codes must be stored with the escapes removed.
+        let lines = &[
+            r#"{"type":"user","message":{"role":"user","content":"color"},"timestamp":"2026-04-05T10:00:00Z","sessionId":"ansi1","cwd":"/tmp","gitBranch":"main","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","id":"msg_1","model":"claude","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"echo hi"}}],"usage":{"input_tokens":5,"output_tokens":3}},"timestamp":"2026-04-05T10:00:01Z"}"#,
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"\u001b[32mhello\u001b[0m","is_error":false}]},"timestamp":"2026-04-05T10:00:02Z"}"#,
+        ];
+        let f = write_jsonl(lines);
+        let session = parse_claude_jsonl(f.path()).unwrap();
+        if let Action::ToolUse { output_summary, .. } = &session.turns[1].actions[0] {
+            assert_eq!(
+                output_summary, "hello",
+                "ANSI escapes must be stripped, got {output_summary:?}"
+            );
+        } else {
+            panic!("expected tool use action");
+        }
+    }
+
+    #[test]
+    fn test_strip_ansi_helper() {
+        // Simple color codes.
+        assert_eq!(strip_ansi("\x1b[32mhello\x1b[0m"), "hello");
+        // Multiple SGR params.
+        assert_eq!(strip_ansi("a\x1b[1;31mb\x1b[0mc"), "abc");
+        // OSC title sequence terminated by BEL.
+        assert_eq!(strip_ansi("\x1b]0;title\x07done"), "done");
+        // Stray control bytes dropped, but newline/tab preserved.
+        assert_eq!(strip_ansi("x\ry\n\tz\x07"), "xy\n\tz");
+        // Plain text untouched.
+        assert_eq!(strip_ansi("plain text 123"), "plain text 123");
     }
 }

--- a/crates/secall-core/src/ingest/codex.rs
+++ b/crates/secall-core/src/ingest/codex.rs
@@ -74,11 +74,14 @@ struct ResponsePayload {
 }
 
 pub fn parse_codex_jsonl(path: &Path) -> Result<Session> {
-    // Extract session ID from filename: rollout-<uuid>.jsonl → uuid
+    // Extract session ID from filename. Real codex files are named
+    // `rollout-<timestamp>-<uuid>.jsonl` and the timestamp itself contains
+    // hyphens (e.g. `2026-02-15T09-20-58`), so a bare `strip_prefix("rollout-")`
+    // would leave the timestamp glued to the uuid — see fallback_session_id.
     let session_id = path
         .file_stem()
         .and_then(|s| s.to_str())
-        .map(|s| s.strip_prefix("rollout-").unwrap_or(s).to_string())
+        .map(fallback_session_id)
         .ok_or_else(|| anyhow!("invalid codex session filename: {}", path.display()))?;
 
     let file = std::fs::File::open(path)?;
@@ -146,6 +149,13 @@ pub fn parse_codex_jsonl(path: &Path) -> Result<Session> {
 
                         let content = extract_content(&rp.content);
                         if role == Role::User && content.is_empty() {
+                            continue;
+                        }
+                        // codex는 실제 프롬프트 앞에 role:user 로 합성 컨텍스트
+                        // (AGENTS.md 지침, <environment_context>, <user_instructions>,
+                        // <permissions ...>)를 주입한다. developer 프롬프트와 동일하게
+                        // 이런 주입 컨텍스트는 건너뛴다.
+                        if role == Role::User && is_injected_context(&content) {
                             continue;
                         }
 
@@ -305,6 +315,46 @@ fn ensure_assistant_turn(
     });
     *turn_idx += 1;
     turns.len() - 1
+}
+
+/// Detect codex-injected `role: user` context that is not genuine user text.
+///
+/// Codex prepends synthetic context messages (AGENTS.md project instructions,
+/// `<environment_context>`, `<user_instructions>`, `<permissions ...>` blocks)
+/// as `role: user` items before the human's real prompt. These pollute the
+/// first user turn (summary/noise heuristics key on it), so we skip them the
+/// same way `role == "developer"` is skipped. Conservative: only messages that
+/// *begin* with a known injected marker match, so genuine user text that merely
+/// mentions one of these tags is preserved.
+fn is_injected_context(content: &str) -> bool {
+    let trimmed = content.trim_start();
+    trimmed.starts_with("<environment_context>")
+        || trimmed.starts_with("<user_instructions>")
+        || trimmed.starts_with("<permissions")
+        || trimmed.starts_with("# AGENTS.md instructions")
+}
+
+/// Derive a fallback session id from a codex rollout filename stem.
+///
+/// Real files are named `rollout-<timestamp>-<uuid>.jsonl` where the timestamp
+/// itself contains hyphens (e.g. `2026-02-15T09-20-58`), so `strip_prefix`
+/// alone leaves the timestamp glued to the uuid. The uuid is the trailing five
+/// hyphen-joined groups shaped `8-4-4-4-12` hex; extract those when present,
+/// otherwise return the stripped stem unchanged (no mangling of non-uuid names).
+fn fallback_session_id(stem: &str) -> String {
+    let rest = stem.strip_prefix("rollout-").unwrap_or(stem);
+    let groups: Vec<&str> = rest.split('-').collect();
+    if groups.len() >= 5 {
+        let tail = &groups[groups.len() - 5..];
+        let is_uuid = [8usize, 4, 4, 4, 12]
+            .iter()
+            .zip(tail.iter())
+            .all(|(&len, g)| g.len() == len && g.bytes().all(|b| b.is_ascii_hexdigit()));
+        if is_uuid {
+            return tail.join("-");
+        }
+    }
+    rest.to_string()
 }
 
 /// Convert a serde_json::Value to String — strings pass through, others serialize to JSON.
@@ -617,5 +667,84 @@ mod tests {
         assert_eq!(a.role, Role::Assistant);
         assert!(a.content.contains("완료"));
         assert_eq!(a.actions.len(), 1);
+    }
+
+    #[test]
+    fn test_codex_skip_injected_context_user_messages() {
+        // codex는 실제 프롬프트 앞에 AGENTS.md / environment_context /
+        // user_instructions / permissions 를 role:user 로 주입한다. 이 합성
+        // 컨텍스트는 skip 되어 첫 user 턴이 진짜 질문이어야 한다.
+        let f = make_codex_file(&[
+            r#"{"type":"session_meta","payload":{"id":"inj-test"}}"#,
+            r##"{"timestamp":"2026-04-05T10:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"# AGENTS.md instructions for /home/u/proj\n\nBe concise."}]}}"##,
+            r#"{"timestamp":"2026-04-05T10:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>\n<cwd>/home/u/proj</cwd>\n</environment_context>"}]}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:02Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<user_instructions>\nfollow style\n</user_instructions>"}]}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:03Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<permissions instructions>\nnetwork off\n</permissions instructions>"}]}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:04Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"검색 기능 구현해줘"}]}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:05Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"네"}]}}"#,
+        ]);
+        let session = parse_codex_jsonl(f.path()).unwrap();
+        // 4개의 주입 컨텍스트 user 메시지 skip → 진짜 user + assistant = 2턴
+        assert_eq!(session.turns.len(), 2);
+        assert_eq!(session.turns[0].role, Role::User);
+        assert_eq!(session.turns[0].content, "검색 기능 구현해줘");
+        assert_eq!(session.turns[1].role, Role::Assistant);
+    }
+
+    #[test]
+    fn test_codex_keeps_genuine_user_text_with_angle_brackets() {
+        // 보수적 detection: 알려진 주입 prefix 로 "시작"하는 경우에만 skip.
+        // 무관한 태그로 시작하는 진짜 user 메시지는 유지되어야 한다.
+        let f = make_codex_file(&[
+            r#"{"type":"session_meta","payload":{"id":"guard"}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<div>왜 안 되나요?</div>"}]}}"#,
+            r#"{"timestamp":"2026-04-05T10:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"확인"}]}}"#,
+        ]);
+        let session = parse_codex_jsonl(f.path()).unwrap();
+        assert_eq!(session.turns.len(), 2);
+        assert_eq!(session.turns[0].role, Role::User);
+        assert!(session.turns[0].content.contains("왜 안 되나요"));
+    }
+
+    #[test]
+    fn test_fallback_session_id() {
+        // rollout-<timestamp>-<uuid> → 후행 uuid 만 추출 (timestamp 제거)
+        assert_eq!(
+            fallback_session_id("rollout-2026-02-15T09-20-58-019c5eac-081b-7011-a172-049b28bae864"),
+            "019c5eac-081b-7011-a172-049b28bae864"
+        );
+        // bare rollout-<uuid> → uuid 그대로
+        assert_eq!(
+            fallback_session_id("rollout-019c781a-081b-7011-a172-049b28bae864"),
+            "019c781a-081b-7011-a172-049b28bae864"
+        );
+        // uuid 형태가 아니면 stripped stem 그대로 (임의 이름 훼손 방지)
+        assert_eq!(fallback_session_id("rollout-abc"), "abc");
+    }
+
+    #[test]
+    fn test_codex_fallback_session_id_strips_timestamp() {
+        // session_meta.id 가 없을 때(1행 손상/절단) 파일명에서 fallback id 를
+        // 유도한다. 실제 파일은 rollout-<timestamp>-<uuid>.jsonl 이므로 id 는
+        // timestamp+uuid 가 아니라 후행 uuid 여야 한다.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir
+            .path()
+            .join("rollout-2026-02-15T09-20-58-019c5eac-081b-7011-a172-049b28bae864.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        // session_meta 라인 없음 → fallback 경로 사용
+        writeln!(
+            f,
+            r#"{{"timestamp":"2026-02-15T09:20:59Z","type":"response_item","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"real question"}}]}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"2026-02-15T09:21:00Z","type":"response_item","payload":{{"type":"message","role":"assistant","content":[{{"type":"output_text","text":"answer"}}]}}}}"#
+        )
+        .unwrap();
+        drop(f);
+        let session = parse_codex_jsonl(&path).unwrap();
+        assert_eq!(session.id, "019c5eac-081b-7011-a172-049b28bae864");
     }
 }

--- a/crates/secall-core/src/ingest/codex.rs
+++ b/crates/secall-core/src/ingest/codex.rs
@@ -341,7 +341,10 @@ fn is_injected_context(content: &str) -> bool {
 /// alone leaves the timestamp glued to the uuid. The uuid is the trailing five
 /// hyphen-joined groups shaped `8-4-4-4-12` hex; extract those when present,
 /// otherwise return the stripped stem unchanged (no mangling of non-uuid names).
-fn fallback_session_id(stem: &str) -> String {
+/// 파일명 stem 에서 codex session id 를 도출. `rollout-<timestamp>-<uuid>` 에서
+/// 후행 uuid(8-4-4-4-12) 만 취한다. ingest 의 fast-dedup 힌트(`fast_dedup_key`)가
+/// 저장 id 와 동일 규칙을 쓰도록 pub.
+pub fn fallback_session_id(stem: &str) -> String {
     let rest = stem.strip_prefix("rollout-").unwrap_or(stem);
     let groups: Vec<&str> = rest.split('-').collect();
     if groups.len() >= 5 {

--- a/crates/secall-core/src/ingest/gemini.rs
+++ b/crates/secall-core/src/ingest/gemini.rs
@@ -177,9 +177,10 @@ pub fn parse_gemini_json(path: &Path) -> Result<Session> {
 
                 // tokens — 턴별 사용량을 세션 total_tokens 에 누적 (claude.rs 미러)
                 let tokens = msg.tokens.as_ref().map(|t| {
-                    total_tokens.input += t.input;
-                    total_tokens.output += t.output;
-                    total_tokens.cached += t.cached;
+                    // saturating: 비현실적 대용량 합에서 overflow wrap/panic 방지(리뷰 반영).
+                    total_tokens.input = total_tokens.input.saturating_add(t.input);
+                    total_tokens.output = total_tokens.output.saturating_add(t.output);
+                    total_tokens.cached = total_tokens.cached.saturating_add(t.cached);
                     TokenUsage {
                         input: t.input,
                         output: t.output,

--- a/crates/secall-core/src/ingest/gemini.rs
+++ b/crates/secall-core/src/ingest/gemini.rs
@@ -127,6 +127,7 @@ pub fn parse_gemini_json(path: &Path) -> Result<Session> {
     let mut turns: Vec<Turn> = Vec::new();
     let mut turn_idx: u32 = 0;
     let mut session_model: Option<String> = None;
+    let mut total_tokens = TokenUsage::default();
 
     for msg in &gs.messages {
         // 턴 타임스탬프
@@ -174,11 +175,16 @@ pub fn parse_gemini_json(path: &Path) -> Result<Session> {
                     }
                 });
 
-                // tokens
-                let tokens = msg.tokens.as_ref().map(|t| TokenUsage {
-                    input: t.input,
-                    output: t.output,
-                    cached: t.cached,
+                // tokens — 턴별 사용량을 세션 total_tokens 에 누적 (claude.rs 미러)
+                let tokens = msg.tokens.as_ref().map(|t| {
+                    total_tokens.input += t.input;
+                    total_tokens.output += t.output;
+                    total_tokens.cached += t.cached;
+                    TokenUsage {
+                        input: t.input,
+                        output: t.output,
+                        cached: t.cached,
+                    }
                 });
 
                 // toolCalls → actions
@@ -238,11 +244,14 @@ pub fn parse_gemini_json(path: &Path) -> Result<Session> {
         ));
     }
 
+    // startTime 이 없거나 파싱 불가하면 가장 이른 턴 타임스탬프로 폴백한다.
+    // (Utc::now() 로 바로 떨어지면 세션 날짜 귀속이 인제스트 시각으로 오염됨 — #12)
     let start_time = gs
         .start_time
         .as_deref()
         .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
         .map(|dt| dt.with_timezone(&Utc))
+        .or_else(|| turns.iter().filter_map(|t| t.timestamp).min())
         .unwrap_or_else(Utc::now);
 
     let end_time = gs
@@ -262,7 +271,7 @@ pub fn parse_gemini_json(path: &Path) -> Result<Session> {
         start_time,
         end_time,
         turns,
-        total_tokens: Default::default(),
+        total_tokens,
         session_type: "interactive".to_string(),
         archived: false,
         archived_at: None,
@@ -491,5 +500,44 @@ mod tests {
 
         let path2 = Path::new("/no/gemini/path/session.json");
         assert_eq!(extract_project_id(path2), None);
+    }
+
+    #[test]
+    fn test_gemini_missing_start_time_uses_first_turn_ts() {
+        // startTime 필드가 없으면 Utc::now() 로 떨어지지 않고
+        // 가장 이른 턴 타임스탬프(첫 메시지 ts)로 폴백해야 한다 (#12).
+        let json = r#"{
+            "sessionId": "s-no-start",
+            "messages": [
+                {"id":"m1","timestamp":"2026-04-05T10:00:01Z","type":"user","content":[{"text":"안녕"}]},
+                {"id":"m2","timestamp":"2026-04-05T10:00:02Z","type":"gemini","content":"안녕하세요","tokens":{"input":10,"output":5,"cached":0,"thoughts":0,"tool":0,"total":15}}
+            ]
+        }"#;
+        let f = make_gemini_file(json);
+        let session = parse_gemini_json(f.path()).unwrap();
+        let expected = DateTime::parse_from_rfc3339("2026-04-05T10:00:01Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(session.start_time, expected);
+    }
+
+    #[test]
+    fn test_gemini_total_tokens_summed() {
+        // 여러 gemini 턴의 per-turn 토큰이 세션 total_tokens 로 누적되어야 한다 (#21).
+        let json = r#"{
+            "sessionId": "s-total",
+            "startTime": "2026-04-05T10:00:00Z",
+            "messages": [
+                {"id":"m1","timestamp":"2026-04-05T10:00:01Z","type":"user","content":[{"text":"q1"}]},
+                {"id":"m2","timestamp":"2026-04-05T10:00:02Z","type":"gemini","content":"a1","tokens":{"input":100,"output":50,"cached":10,"thoughts":0,"tool":0,"total":160}},
+                {"id":"m3","timestamp":"2026-04-05T10:00:03Z","type":"user","content":[{"text":"q2"}]},
+                {"id":"m4","timestamp":"2026-04-05T10:00:04Z","type":"gemini","content":"a2","tokens":{"input":200,"output":30,"cached":5,"thoughts":0,"tool":0,"total":235}}
+            ]
+        }"#;
+        let f = make_gemini_file(json);
+        let session = parse_gemini_json(f.path()).unwrap();
+        assert_eq!(session.total_tokens.input, 300);
+        assert_eq!(session.total_tokens.output, 80);
+        assert_eq!(session.total_tokens.cached, 15);
     }
 }

--- a/crates/secall-core/src/ingest/gemini_web.rs
+++ b/crates/secall-core/src/ingest/gemini_web.rs
@@ -43,7 +43,10 @@ enum GeminiWebContent {
 
 #[derive(Debug, Deserialize)]
 struct GeminiWebPart {
-    text: String,
+    // 이미지/thought/function 등 text 가 없는 파트도 있으므로 lenient.
+    // 필드가 없거나 non-text 파트여도 전체 대화가 드롭되지 않도록 Option 처리한다.
+    #[serde(default)]
+    text: Option<String>,
 }
 
 // ── 변환 함수 ──────────────────────────────────────────────────────────────────
@@ -80,7 +83,8 @@ fn json_to_session(export: GeminiWebExport) -> Session {
                 GeminiWebContent::Text(s) => s,
                 GeminiWebContent::Parts(parts) => parts
                     .into_iter()
-                    .map(|p| p.text)
+                    .filter_map(|p| p.text)
+                    .filter(|t| !t.is_empty())
                     .collect::<Vec<_>>()
                     .join("\n"),
             };
@@ -254,6 +258,54 @@ mod tests {
         assert_eq!(session.turns[0].content, "내일 날씨 알려줘");
         assert_eq!(session.turns[1].role, Role::Assistant);
         assert_eq!(session.model, Some("2.5 Flash".to_string()));
+    }
+
+    // 이미지/thought/function 등 text 가 없는 파트를 포함한 대화.
+    // 이전에는 GeminiWebPart.text 가 필수라서 serde 역직렬화가 실패하고
+    // 대화 전체가 조용히 드롭됐다.
+    const SAMPLE_JSON_NONTEXT_PART: &str = r#"{
+  "sessionId": "deadbeefcafef00d",
+  "title": "이미지 포함 세션",
+  "startTime": "2025-07-26T10:00:00.000Z",
+  "lastUpdated": "2025-07-26T10:00:10.000Z",
+  "kind": "main",
+  "projectHash": "gemini-web",
+  "messages": [
+    {
+      "id": "msg-0",
+      "timestamp": "2025-07-26T10:00:00.000Z",
+      "type": "user",
+      "content": [
+        { "inlineData": { "mimeType": "image/png", "data": "AAAA" } },
+        { "text": "이 이미지 설명해줘" }
+      ]
+    },
+    {
+      "id": "msg-1",
+      "timestamp": "2025-07-26T10:00:05.000Z",
+      "type": "gemini",
+      "content": [
+        { "thought": true },
+        { "text": "고양이 사진입니다." }
+      ],
+      "model": "2.5 Flash"
+    }
+  ]
+}"#;
+
+    #[test]
+    fn test_json_to_session_nontext_part_kept() {
+        // 비-text 파트가 있어도 대화가 드롭되지 않고 text 메시지는 유지되어야 한다.
+        let export: GeminiWebExport = serde_json::from_str(SAMPLE_JSON_NONTEXT_PART)
+            .expect("non-text part should not fail deserialization");
+        let session = json_to_session(export);
+
+        assert_eq!(session.id, "deadbeefcafef00d");
+        assert_eq!(session.turns.len(), 2);
+        assert_eq!(session.turns[0].role, Role::User);
+        assert_eq!(session.turns[0].content, "이 이미지 설명해줘");
+        assert_eq!(session.turns[1].role, Role::Assistant);
+        assert_eq!(session.turns[1].content, "고양이 사진입니다.");
     }
 
     #[test]

--- a/crates/secall-core/src/ingest/opencode.rs
+++ b/crates/secall-core/src/ingest/opencode.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use chrono::{DateTime, TimeZone, Utc};
 use serde::Deserialize;
 
-use super::types::{AgentKind, Role, Session, TokenUsage, Turn};
+use super::types::{Action, AgentKind, Role, Session, TokenUsage, Turn};
 use super::SessionParser;
 
 pub struct OpenCodeParser;
@@ -86,6 +86,21 @@ struct OpenCodePart {
     part_type: String,
     #[serde(default)]
     text: Option<String>,
+    // tool parts (type == "tool")
+    #[serde(default)]
+    tool: Option<String>,
+    #[serde(rename = "callID", default)]
+    call_id: Option<String>,
+    #[serde(default)]
+    state: Option<OpenCodeToolState>,
+}
+
+#[derive(Deserialize)]
+struct OpenCodeToolState {
+    #[serde(default)]
+    input: Option<serde_json::Value>,
+    #[serde(default)]
+    output: Option<serde_json::Value>,
 }
 
 // ─── Parser ───────────────���───────────────────────────────���──────────────────
@@ -94,6 +109,16 @@ fn ms_to_datetime(ms: u64) -> Option<DateTime<Utc>> {
     let secs = (ms / 1000) as i64;
     let nsecs = ((ms % 1000) * 1_000_000) as u32;
     Utc.timestamp_opt(secs, nsecs).single()
+}
+
+/// tool state.input / state.output 을 요약 문자열로 변환한다.
+/// 문자열이면 그대로, null 이면 빈 문자열, 그 외(객체/배열 등)는 JSON 직렬화.
+fn value_to_summary(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => String::new(),
+        other => other.to_string(),
+    }
 }
 
 pub fn parse_opencode_json(path: &Path) -> Result<Session> {
@@ -133,7 +158,34 @@ pub fn parse_opencode_json(path: &Path) -> Result<Session> {
             .collect::<Vec<_>>()
             .join("\n");
 
-        if content.is_empty() {
+        // tool parts (type == "tool") → Action::ToolUse
+        // state.input 에서 명령/입력, state.output 에서 출력을 추출한다.
+        let mut actions: Vec<Action> = Vec::new();
+        for part in &msg.parts {
+            if part.part_type != "tool" {
+                continue;
+            }
+            let name = part.tool.clone().unwrap_or_else(|| "unknown".to_string());
+            let (input_summary, output_summary) = part
+                .state
+                .as_ref()
+                .map(|s| {
+                    (
+                        s.input.as_ref().map(value_to_summary).unwrap_or_default(),
+                        s.output.as_ref().map(value_to_summary).unwrap_or_default(),
+                    )
+                })
+                .unwrap_or_default();
+            actions.push(Action::ToolUse {
+                name,
+                input_summary,
+                output_summary,
+                tool_use_id: part.call_id.clone(),
+            });
+        }
+
+        // tool 파트만 있는 assistant 메시지도 실제 턴으로 취급한다.
+        if content.is_empty() && actions.is_empty() {
             continue;
         }
 
@@ -149,7 +201,7 @@ pub fn parse_opencode_json(path: &Path) -> Result<Session> {
             role,
             timestamp,
             content,
-            actions: Vec::new(),
+            actions,
             tokens: None,
             thinking: None,
             is_sidechain: false,
@@ -317,5 +369,59 @@ mod tests {
         let session = parse_opencode_json(f.path()).unwrap();
         assert_eq!(session.turns.len(), 2);
         assert_eq!(session.turns[1].content, "Done!");
+    }
+
+    #[test]
+    fn test_opencode_tool_only_assistant_turn() {
+        // 실제 opencode export 형식: parts[type == "tool"] + 중첩 state.input / state.output.
+        // 텍스트 없이 tool 파트만 있는 assistant 메시지도 실제 턴으로 보존되어야 한다.
+        let json = r#"{
+            "info": {
+                "id": "ses_toolonly",
+                "time": { "created": 1777090810040 }
+            },
+            "messages": [
+                {
+                    "info": { "role": "user", "time": { "created": 1777090810253 } },
+                    "parts": [{ "type": "text", "text": "Run ls" }]
+                },
+                {
+                    "info": { "role": "assistant", "time": { "created": 1777090820000 } },
+                    "parts": [
+                        {
+                            "type": "tool",
+                            "tool": "bash",
+                            "callID": "call_001",
+                            "state": {
+                                "status": "completed",
+                                "input": { "command": "ls -la" },
+                                "output": "total 0\nfile.txt"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }"#;
+        let f = make_opencode_file(json);
+        let session = parse_opencode_json(f.path()).unwrap();
+        assert_eq!(session.turns.len(), 2);
+        let asst = &session.turns[1];
+        assert_eq!(asst.role, Role::Assistant);
+        assert!(asst.content.is_empty());
+        assert_eq!(asst.actions.len(), 1);
+        match &asst.actions[0] {
+            Action::ToolUse {
+                name,
+                input_summary,
+                output_summary,
+                tool_use_id,
+            } => {
+                assert_eq!(name, "bash");
+                assert!(input_summary.contains("ls -la"));
+                assert_eq!(output_summary, "total 0\nfile.txt");
+                assert_eq!(tool_use_id.as_deref(), Some("call_001"));
+            }
+            _ => panic!("expected ToolUse action"),
+        }
     }
 }

--- a/crates/secall/src/commands/classify.rs
+++ b/crates/secall/src/commands/classify.rs
@@ -51,12 +51,12 @@ pub async fn run_backfill(dry_run: bool) -> Result<()> {
             &classification.default,
         );
 
-        let short_id = &session_id[..8.min(session_id.len())];
+        let short_id = session_id.chars().take(8).collect::<String>();
         if dry_run {
             eprintln!("  [dry-run] {} → {}", short_id, new_type);
         } else {
             db.update_session_type(session_id, &new_type)?;
-            tracing::debug!(session = short_id, session_type = new_type, "classified");
+            tracing::debug!(session = %short_id, session_type = new_type, "classified");
         }
         updated += 1;
     }

--- a/crates/secall/src/commands/graph.rs
+++ b/crates/secall/src/commands/graph.rs
@@ -96,13 +96,13 @@ pub async fn run_semantic(
     let mut failed = 0usize;
 
     for (i, (session_id, vault_path)) in sessions.iter().enumerate() {
-        let short = &session_id[..8.min(session_id.len())];
+        let short = session_id.chars().take(8).collect::<String>();
         let md_path = config.vault.path.join(vault_path);
 
         let content = match std::fs::read_to_string(&md_path) {
             Ok(c) => c,
             Err(e) => {
-                tracing::warn!(session = short, "cannot read vault file: {}", e);
+                tracing::warn!(session = %short, "cannot read vault file: {}", e);
                 skipped += 1;
                 continue;
             }
@@ -111,7 +111,7 @@ pub async fn run_semantic(
         let fm = match parse_session_frontmatter(&content) {
             Ok(f) => f,
             Err(e) => {
-                tracing::warn!(session = short, "cannot parse frontmatter: {}", e);
+                tracing::warn!(session = %short, "cannot parse frontmatter: {}", e);
                 skipped += 1;
                 continue;
             }
@@ -354,9 +354,9 @@ pub async fn run_rebuild(
                 outcome.edges_added += n;
                 // 성공 시에만 timestamp 갱신
                 if let Err(e) = db.update_semantic_extracted_at(id, now_secs) {
-                    let short = &id[..8.min(id.len())];
+                    let short = id.chars().take(8).collect::<String>();
                     tracing::warn!(
-                        session = short,
+                        session = %short,
                         error = %e,
                         "failed to update semantic_extracted_at"
                     );

--- a/crates/secall/src/commands/ingest.rs
+++ b/crates/secall/src/commands/ingest.rs
@@ -524,17 +524,17 @@ fn compile_classification_rules(config: &Config) -> Result<Vec<CompiledRule>> {
 
 /// 1:1 파서 fast-dedup 힌트 키.
 ///
-/// CodexParser 는 `rollout-<uuid>.jsonl` 파일명에서 `rollout-` prefix 를 벗겨
-/// session id 로 저장한다(secall_core::ingest::codex `parse_codex_jsonl` 참조).
-/// 따라서 dedup 힌트도 동일하게 정규화하지 않으면 stem != stored id 가 되어
-/// codex 세션의 중복/오픈 세션 감지가 조용히 실패하고 매번 재인제스트된다.
-/// `rollout-` prefix 가 없는 다른 1:1 파서 파일명은 그대로 유지된다.
-fn fast_dedup_key(session_path: &Path) -> &str {
+/// CodexParser 는 `rollout-<timestamp>-<uuid>.jsonl` 파일명에서 후행 uuid 만
+/// session id 로 저장한다. dedup 힌트도 동일 규칙을 써야 stem != stored id 로
+/// codex 세션 중복/오픈 감지가 빗나가 매번 재인제스트되는 것을 막는다. 그래서
+/// codex 의 `fallback_session_id`(rollout- prefix + trailing uuid 정규화)를 그대로
+/// 공유한다. uuid 형태가 아닌 다른 1:1 파서 파일명은 그대로 유지된다.
+fn fast_dedup_key(session_path: &Path) -> String {
     session_path
         .file_stem()
         .and_then(|s| s.to_str())
-        .map(|s| s.strip_prefix("rollout-").unwrap_or(s))
-        .unwrap_or("")
+        .map(secall_core::ingest::codex::fallback_session_id)
+        .unwrap_or_default()
 }
 
 /// 세션 ID 의 앞 8자를 char 경계 안전하게 잘라 반환한다.
@@ -648,7 +648,8 @@ fn ingest_path(
     // 1:1 파서: filename-stem 힌트로 빠른 중복 체크 (--force 시 스킵)
     // codex 는 `rollout-` prefix 를 벗긴 id 로 저장되므로 힌트도 정규화한다.
     if !force {
-        let session_id_hint = fast_dedup_key(session_path);
+        let session_id_owned = fast_dedup_key(session_path);
+        let session_id_hint = session_id_owned.as_str();
 
         match db.session_exists(session_id_hint) {
             Ok(true) => {
@@ -1357,17 +1358,22 @@ mod tests {
 
     #[test]
     fn test_fast_dedup_key_strips_codex_rollout_prefix() {
-        // codex 파일명은 `rollout-<uuid>.jsonl`; 저장 id 는 `<uuid>` 이므로
-        // dedup 힌트도 prefix 를 벗겨 stored id 와 일치해야 한다.
-        let p = Path::new("/home/u/.codex/sessions/rollout-abc-123.jsonl");
-        assert_eq!(fast_dedup_key(p), "abc-123");
+        // codex 파일명 `rollout-<timestamp>-<uuid>.jsonl` → 저장 id 는 후행 uuid.
+        // dedup 힌트도 동일 규칙(fallback_session_id 공유)으로 uuid 만 취해야 한다.
+        let p = Path::new(
+            "/home/u/.codex/sessions/rollout-2026-02-15T09-20-58-12345678-1234-1234-1234-123456789abc.jsonl",
+        );
+        assert_eq!(
+            fast_dedup_key(p).as_str(),
+            "12345678-1234-1234-1234-123456789abc"
+        );
     }
 
     #[test]
     fn test_fast_dedup_key_keeps_non_codex_stem() {
-        // prefix 가 없는 다른 1:1 파서 파일명은 그대로 유지된다.
+        // uuid 형태가 아닌 다른 1:1 파서 파일명은 그대로 유지된다.
         let p = Path::new("/home/u/sessions/session-xyz.jsonl");
-        assert_eq!(fast_dedup_key(p), "session-xyz");
+        assert_eq!(fast_dedup_key(p).as_str(), "session-xyz");
     }
 
     #[test]

--- a/crates/secall/src/commands/lint.rs
+++ b/crates/secall/src/commands/lint.rs
@@ -45,7 +45,7 @@ pub fn run(
         let sid = finding
             .session_id
             .as_deref()
-            .map(|s| format!("session {}: ", &s[..s.len().min(8)]))
+            .map(|s| format!("session {}: ", s.chars().take(8).collect::<String>()))
             .unwrap_or_default();
         println!("{} [{sev:5}] {sid}{}", finding.code, finding.message);
         printed += 1;
@@ -140,13 +140,16 @@ fn run_fix_wiki_invocations(
     for session_id in &suspects {
         match db.archive_session(session_id, &vault, tz) {
             Ok(()) => {
-                eprintln!("  archived {}", &session_id[..session_id.len().min(8)]);
+                eprintln!(
+                    "  archived {}",
+                    session_id.chars().take(8).collect::<String>()
+                );
                 archived += 1;
             }
             Err(e) => {
                 eprintln!(
                     "  failed to archive {}: {e}",
-                    &session_id[..session_id.len().min(8)]
+                    session_id.chars().take(8).collect::<String>()
                 );
                 failed += 1;
             }
@@ -176,10 +179,13 @@ fn run_fix(db: &Database, report: &secall_core::ingest::lint::LintReport) -> Res
     );
     for session_id in &stale {
         match db.delete_session_full(session_id) {
-            Ok(()) => eprintln!("  deleted {}", &session_id[..session_id.len().min(8)]),
+            Ok(()) => eprintln!(
+                "  deleted {}",
+                session_id.chars().take(8).collect::<String>()
+            ),
             Err(e) => eprintln!(
                 "  failed to delete {}: {e}",
-                &session_id[..session_id.len().min(8)]
+                session_id.chars().take(8).collect::<String>()
             ),
         }
     }

--- a/crates/secall/src/commands/recall.rs
+++ b/crates/secall/src/commands/recall.rs
@@ -146,7 +146,7 @@ fn print_related_sessions(related: &[RelatedSession]) {
         }
         println!(
             "      → secall get {}",
-            &r.session_id[..r.session_id.len().min(8)]
+            r.session_id.chars().take(8).collect::<String>()
         );
         println!();
     }

--- a/crates/secall/src/commands/wiki.rs
+++ b/crates/secall/src/commands/wiki.rs
@@ -515,13 +515,22 @@ async fn process_haiku_incremental(
             if !safe.is_empty() {
                 format!("projects/{}.md", safe)
             } else {
-                format!("sessions/{}.md", &full_id[..full_id.len().min(8)])
+                format!(
+                    "sessions/{}.md",
+                    full_id.chars().take(8).collect::<String>()
+                )
             }
         } else {
-            format!("sessions/{}.md", &full_id[..full_id.len().min(8)])
+            format!(
+                "sessions/{}.md",
+                full_id.chars().take(8).collect::<String>()
+            )
         }
     } else {
-        format!("sessions/{}.md", &full_id[..full_id.len().min(8)])
+        format!(
+            "sessions/{}.md",
+            full_id.chars().take(8).collect::<String>()
+        )
     };
 
     let vault_paths = collect_vault_paths(&db, &session_ids);
@@ -1027,7 +1036,7 @@ fn build_haiku_batch_prompt(
                 .collect();
             prompt.push_str(&format!(
                 "#### {} ({}, {}턴, {})\n{}\n\n",
-                &s.id[..8.min(s.id.len())],
+                s.id.chars().take(8).collect::<String>(),
                 date,
                 s.turn_count,
                 s.agent,
@@ -1101,7 +1110,7 @@ fn resolve_session_id(db: &Database, prefix: &str) -> Result<String> {
 /// (CLI stderr 측) 양쪽에서 사용 — 중복 제거 + format 통일 (모두 `session {}`).
 fn build_target_label(session: Option<&str>, since: Option<&str>) -> String {
     if let Some(sid) = session {
-        format!("session {}", &sid[..sid.len().min(8)])
+        format!("session {}", sid.chars().take(8).collect::<String>())
     } else if let Some(s) = since {
         format!("sessions since {s}")
     } else {
@@ -1359,7 +1368,7 @@ fn build_haiku_single_project_prompt(
             .collect();
         prompt.push_str(&format!(
             "### {} ({}, {}턴, {})\n{}\n\n",
-            &s.id[..8.min(s.id.len())],
+            s.id.chars().take(8).collect::<String>(),
             date,
             s.turn_count,
             s.agent,
@@ -1404,7 +1413,7 @@ fn build_review_source(db: &Database, session_ids: &[String]) -> String {
         if let Ok((meta, turns)) = db.get_session_with_turns(sid) {
             summary.push_str(&format!(
                 "### Session {} ({})\n- Agent: {}\n- Summary: {}\n",
-                &sid[..sid.len().min(8)],
+                sid.chars().take(8).collect::<String>(),
                 &meta.start_time[..10.min(meta.start_time.len())],
                 meta.agent,
                 meta.summary.as_deref().unwrap_or("N/A"),

--- a/crates/secall/src/output.rs
+++ b/crates/secall/src/output.rs
@@ -14,6 +14,14 @@ fn format_token_count(n: u64) -> String {
     }
 }
 
+/// 세션 id 표시용 8글자 prefix.
+///
+/// byte-slice (`&id[..8]`) 는 멀티바이트 세션 id 에서
+/// "byte index 8 is not a char boundary" panic 을 내므로 char 단위로 자른다.
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
 pub fn print_search_results(results: &[SearchResult], format: &OutputFormat) {
     match format {
         OutputFormat::Text => {
@@ -50,10 +58,7 @@ pub fn print_ingest_result(
 ) {
     match format {
         OutputFormat::Text => {
-            println!(
-                "✓ Ingested session: {}",
-                &session.id[..session.id.len().min(8)]
-            );
+            println!("✓ Ingested session: {}", short_id(&session.id));
             println!(
                 "  Project: {}",
                 session.project.as_deref().unwrap_or("unknown")
@@ -76,5 +81,27 @@ pub fn print_ingest_result(
             // run()에서 단일 summary JSON을 출력하여 top-level JSON 문서가 하나만 나오도록 함.
             let _ = (session, vault_path, stats);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::short_id;
+
+    #[test]
+    fn short_id_ascii() {
+        assert_eq!(short_id("0123456789abcdef"), "01234567");
+        assert_eq!(short_id("abc"), "abc");
+    }
+
+    #[test]
+    fn short_id_multibyte_no_panic() {
+        // 멀티바이트 세션 id 를 byte-slice (`&id[..8]`) 로 자르면
+        // "byte index 8 is not a char boundary" 로 panic 한다.
+        // char 단위로 자르면 안전하게 앞 8글자를 반환해야 한다.
+        let id = "한글세션식별자입니다";
+        let short = short_id(id);
+        assert_eq!(short.chars().count(), 8);
+        assert_eq!(short, "한글세션식별자입");
     }
 }


### PR DESCRIPTION
파싱 리뷰(23 confirmed)의 마지막 스테이지 — MED/LOW 폴리시. 8-에이전트 병렬 수정, 중앙 검증.

## 수정

- **#9 (MED) codex** — 주입 컨텍스트 user 메시지(AGENTS.md/`<environment_context>`/`<user_instructions>`/`<permissions>`) skip.
- **#20 (LOW) codex** — 파일명 fallback id 를 `rollout-<timestamp>-<uuid>` → trailing uuid 추출.
- **#10 (MED) opencode** — tool 파트(`type:tool`, `state.input/output`) → `Action::ToolUse` + tool-only 턴 보존.
- **#11 (MED) gemini_web** — 비텍스트 파트/누락 필드 시 대화 전체 drop → lenient(text Option) 파싱.
- **#12 (MED) gemini** — startTime 없으면 earliest 턴 ts (now() 오날짜 방지). **#21 (LOW)** per-turn 토큰 total 누적.
- **#13 (MED) chatgpt** — `code` content_type 을 text 필드에서 읽음. **#22 (LOW)** create_time null 시 earliest msg ts.
- **#17 (LOW) claude** — user 의 tool_result+text 공존 시 text 보존. **#18 (LOW)** tool 출력 ANSI/제어 escape strip.
- **display byte-slice** — classify/graph/lint/recall/wiki/output 의 `id[..8]` → `chars().take(8)` (비ASCII panic 방지, CodeRabbit Major 잔여분).

## 드롭 (별도 재설계)

- **#14/#15 (markdown `parse_session_turns`)** — 제안된 render-이스케이프(zero-width) 방식이 **기존 vault 파일**(코드블록 내 미이스케이프 헤더)을 reindex 할 때 phantom turn 을 유발 → 백워드 호환 불가. 기존 fence 추적을 유지하며 별도 재설계 필요.

## 검증
- `cargo test` 742 pass (신규 15+: injected_context / tool_only / nontext_part / earliest_ts / code_content / user_text / ansi_stripped / multibyte 등).
- `clippy --workspace --all-targets` (-Dwarnings) clean, `fmt` clean.

## 후속 (별건)
- codex `fast_dedup_key`(ingest.rs) 를 #20 `fallback_session_id` 와 정합 (fast-path 최적화, 정확성 무관).
- #14/#15 재설계.

## 머지 전
- [ ] CI green + CodeRabbit 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 시작 시간이 누락된 경우 가장 이른 메시지 시각으로 표시됩니다.
  - Gemini 토큰 누적과 Gemini Web/Claude/ChatGPT/Opencode 인제스트가 더 정확해졌고, 도구 호출 시 사용자 텍스트와 도구 결과가 함께 유지됩니다.
  - ANSI 및 제어 문자를 제거해 가독성이 개선됩니다.
- **New Features**
  - 도구 사용 내역 반영 범위가 확대되었습니다.
- **Refactor**
  - 세션 ID 단축/표시를 문자 경계 안전 방식으로 통일했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->