### PR TITLE
feat(embedding): 임베딩 모델 불일치 가드 — 교차모델 벡터 silent 저하 방지

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -508,13 +508,12 @@ secall embed --concurrency 4 --batch-size 32
 
 > To use ONNX Runtime instead: `secall config set embedding.backend ort` then `secall model download`.
 
-> **⚠️ Upgrade note (`bge-m3` → `qwen3-embedding`)**
-> Since v0.6.5 the default embedding model changed from `bge-m3` to `qwen3-embedding:0.6b`. If your existing vectors were built with `bge-m3`, a cross-model mismatch degrades semantic search quality (no error — both are 1024-dim — but similarity becomes meaningless). Run one of:
->
-> - `secall embed --all` — re-embed everything with qwen3-embedding (recommended)
-> - `secall config set embedding.ollama_model bge-m3` — keep the old model
->
-> BM25 keyword search is unaffected. `secall status` detects and warns about the mismatch.
+**⚠️ Upgrade note (`bge-m3` → `qwen3-embedding`)** — Since v0.6.5 the default embedding model changed from `bge-m3` to `qwen3-embedding:0.6b`. If your existing vectors were built with `bge-m3`, a cross-model mismatch degrades semantic search quality (no error — both are 1024-dim — but similarity becomes meaningless). Run one of:
+
+- `secall embed --all` — re-embed everything with qwen3-embedding (recommended)
+- `secall config set embedding.ollama_model bge-m3` — keep the old model
+
+BM25 keyword search is unaffected. `secall status` detects and warns about the mismatch.
 
 ### Session Classification
 

--- a/README.en.md
+++ b/README.en.md
@@ -508,6 +508,14 @@ secall embed --concurrency 4 --batch-size 32
 
 > To use ONNX Runtime instead: `secall config set embedding.backend ort` then `secall model download`.
 
+> **⚠️ Upgrade note (`bge-m3` → `qwen3-embedding`)**
+> Since v0.6.5 the default embedding model changed from `bge-m3` to `qwen3-embedding:0.6b`. If your existing vectors were built with `bge-m3`, a cross-model mismatch degrades semantic search quality (no error — both are 1024-dim — but similarity becomes meaningless). Run one of:
+>
+> - `secall embed --all` — re-embed everything with qwen3-embedding (recommended)
+> - `secall config set embedding.ollama_model bge-m3` — keep the old model
+>
+> BM25 keyword search is unaffected. `secall status` detects and warns about the mismatch.
+
 ### Session Classification
 
 Tag sessions automatically during ingest using config-driven regex rules:

--- a/README.md
+++ b/README.md
@@ -588,6 +588,14 @@ secall serve --port 8080 --allow-config-edit
 | `wiki.review_backend`    | 위키 리뷰 백엔드            | `wiki.default_backend`    |
 | `log.backend`            | 작업 일기 백엔드            | `graph.semantic_backend`  |
 
+> **⚠️ 업그레이드 안내 (`bge-m3` → `qwen3-embedding`)**
+> v0.6.5부터 기본 임베딩 모델이 `bge-m3` → `qwen3-embedding:0.6b`로 바뀌었습니다. 기존 벡터가 `bge-m3`라면 교차모델 불일치로 시맨틱 검색 정확도가 떨어집니다(차원이 같아 에러는 없지만 유사도가 무의미). 둘 중 하나를 실행하세요:
+>
+> - `secall embed --all` — qwen3-embedding으로 전체 재임베딩 (권장)
+> - `secall config set embedding.ollama_model bge-m3` — 기존 모델 유지
+>
+> BM25 키워드 검색은 영향 없습니다. `secall status`가 불일치를 감지해 안내합니다.
+
 설정 파일 위치:
 
 | OS      | 경로                                                 |

--- a/crates/secall-core/src/mcp/server.rs
+++ b/crates/secall-core/src/mcp/server.rs
@@ -314,6 +314,8 @@ impl SeCallMcpServer {
             .lock()
             .map_err(|e| anyhow::anyhow!("DB lock: {e}"))?;
         let stats = db.get_stats()?;
+        // 벡터가 생성된 임베딩 모델 마커 (없으면 null — v0.7.0 이전 DB 이거나 벡터 없음).
+        let embedding_model = db.get_embedding_model().ok().flatten();
         Ok(serde_json::json!({
             // P62: web TopNav 의 version 표시를 server 의 빌드 시점 버전으로
             // 통합 (이전엔 web 측 hardcode 가 v0.4.2 로 고정돼 있었음).
@@ -323,6 +325,7 @@ impl SeCallMcpServer {
             "sessions": stats.session_count,
             "turns": stats.turn_count,
             "vectors": stats.vector_count,
+            "embedding_model": embedding_model,
             "recent_ingests": stats.recent_ingests.len(),
         }))
     }

--- a/crates/secall-core/src/search/embedding.rs
+++ b/crates/secall-core/src/search/embedding.rs
@@ -40,12 +40,17 @@ struct EmbedResponse {
     embeddings: Vec<Vec<f32>>,
 }
 
+/// Ollama 백엔드 기본 임베딩 모델. `#120` 에서 `bge-m3` → 이 값으로 전환.
+/// config 의 `embedding.ollama_model` 미설정 시 이 모델이 쓰이며,
+/// 임베딩 모델 불일치 감지(embedding_identity)의 기준이 된다.
+pub const DEFAULT_OLLAMA_EMBED_MODEL: &str = "qwen3-embedding:0.6b";
+
 impl OllamaEmbedder {
     pub fn new(base_url: Option<&str>, model: Option<&str>) -> Self {
         OllamaEmbedder {
             client: Client::new(),
             base_url: base_url.unwrap_or("http://localhost:11434").to_string(),
-            model: model.unwrap_or("qwen3-embedding:0.6b").to_string(),
+            model: model.unwrap_or(DEFAULT_OLLAMA_EMBED_MODEL).to_string(),
             api_key: None,
         }
     }

--- a/crates/secall-core/src/store/db.rs
+++ b/crates/secall-core/src/store/db.rs
@@ -307,6 +307,29 @@ impl Database {
             .map_err(|e: std::num::ParseIntError| SecallError::Other(e.into()))
     }
 
+    /// 현재 벡터가 생성된 임베딩 모델 식별자(`EmbeddingConfig::embedding_identity`).
+    /// 미설정(None)이면 마커 없음 — v0.7.0 이전 DB 이거나 아직 벡터 생성 전.
+    pub fn get_embedding_model(&self) -> Result<Option<String>> {
+        match self.conn.query_row(
+            "SELECT value FROM config WHERE key = 'embedding_model'",
+            [],
+            |row| row.get::<_, String>(0),
+        ) {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// 벡터를 (재)생성한 모델 식별자를 마커로 저장. `embed --all` / 최초 embed 후 호출.
+    pub fn set_embedding_model(&self, identity: &str) -> Result<()> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO config(key, value) VALUES ('embedding_model', ?1)",
+            rusqlite::params![identity],
+        )?;
+        Ok(())
+    }
+
     #[cfg(test)]
     pub fn table_exists(&self, name: &str) -> Result<bool> {
         let count: i64 = self.conn.query_row(
@@ -385,6 +408,26 @@ mod tests {
             archived: false,
             archived_at: None,
         }
+    }
+
+    #[test]
+    fn test_embedding_model_marker_roundtrip() {
+        let db = Database::open_memory().unwrap();
+        // 초기엔 마커 없음.
+        assert_eq!(db.get_embedding_model().unwrap(), None);
+        // 설정 후 조회.
+        db.set_embedding_model("ollama:qwen3-embedding:0.6b")
+            .unwrap();
+        assert_eq!(
+            db.get_embedding_model().unwrap(),
+            Some("ollama:qwen3-embedding:0.6b".to_string())
+        );
+        // 덮어쓰기(모델 변경) 반영.
+        db.set_embedding_model("ollama:bge-m3").unwrap();
+        assert_eq!(
+            db.get_embedding_model().unwrap(),
+            Some("ollama:bge-m3".to_string())
+        );
     }
 
     #[test]

--- a/crates/secall-core/src/vault/config.rs
+++ b/crates/secall-core/src/vault/config.rs
@@ -384,12 +384,15 @@ impl EmbeddingConfig {
                     .as_deref()
                     .unwrap_or(DEFAULT_OLLAMA_EMBED_MODEL)
             ),
+            // 경로 전체가 아니라 모델 디렉토리/파일명만 식별자로 쓴다 — 절대경로·OS별
+            // 구분자 차이로 크로스머신 동기화 시 헛불일치가 나는 것을 방지(리뷰 반영).
             "ort" | "openvino" => format!(
                 "{}:{}",
                 self.backend,
                 self.model_path
                     .as_ref()
-                    .map(|p| p.display().to_string())
+                    .and_then(|p| p.file_name())
+                    .map(|n| n.to_string_lossy().to_string())
                     .unwrap_or_else(|| "BAAI/bge-m3".to_string())
             ),
             "openai" => format!(

--- a/crates/secall-core/src/vault/config.rs
+++ b/crates/secall-core/src/vault/config.rs
@@ -364,6 +364,45 @@ impl Default for EmbeddingConfig {
     }
 }
 
+impl EmbeddingConfig {
+    /// 벡터 생성에 실제로 쓰이는 임베딩 모델의 정규화 식별자(`backend:model`).
+    /// 모델/백엔드가 바뀌면 값이 달라지므로, DB 에 저장된 마커
+    /// (`Database::get_embedding_model`)와 비교해 기존 벡터와의 불일치를 감지한다.
+    /// (교차모델 임베딩은 차원이 같아도 유사도가 무의미해 검색이 조용히 저하됨)
+    pub fn embedding_identity(&self) -> String {
+        use crate::search::embedding::DEFAULT_OLLAMA_EMBED_MODEL;
+        match self.backend.as_str() {
+            "ollama" => format!(
+                "ollama:{}",
+                self.ollama_model
+                    .as_deref()
+                    .unwrap_or(DEFAULT_OLLAMA_EMBED_MODEL)
+            ),
+            "ollama_cloud" => format!(
+                "ollama_cloud:{}",
+                self.cloud_model
+                    .as_deref()
+                    .unwrap_or(DEFAULT_OLLAMA_EMBED_MODEL)
+            ),
+            "ort" | "openvino" => format!(
+                "{}:{}",
+                self.backend,
+                self.model_path
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "BAAI/bge-m3".to_string())
+            ),
+            "openai" => format!(
+                "openai:{}",
+                self.openai_model
+                    .as_deref()
+                    .unwrap_or("text-embedding-3-large")
+            ),
+            other => other.to_string(),
+        }
+    }
+}
+
 impl Default for VaultConfig {
     fn default() -> Self {
         VaultConfig {
@@ -627,6 +666,20 @@ pub(crate) static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_embedding_identity() {
+        // 기본(ollama, model 미설정) → 기본 모델 식별자.
+        let mut c = EmbeddingConfig::default();
+        assert_eq!(c.embedding_identity(), "ollama:qwen3-embedding:0.6b");
+        // 명시 모델 → 그 값. (bge-m3 로 고정한 기존 사용자)
+        c.ollama_model = Some("bge-m3".to_string());
+        assert_eq!(c.embedding_identity(), "ollama:bge-m3");
+        // 백엔드 변경도 식별자에 반영.
+        c.backend = "ort".to_string();
+        c.model_path = None;
+        assert_eq!(c.embedding_identity(), "ort:BAAI/bge-m3");
+    }
 
     #[test]
     fn test_timezone_default_is_utc() {

--- a/crates/secall/src/commands/embed.rs
+++ b/crates/secall/src/commands/embed.rs
@@ -75,6 +75,29 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
     let db_path = get_default_db_path();
     let db = Database::open(&db_path)?;
 
+    // 임베딩 모델 불일치 감지: 기존 벡터가 다른 모델로 생성됐으면 교차모델 유사도가
+    // 무의미해 시맨틱 검색이 조용히 저하된다(차원이 같아 에러는 안 남). 재임베딩(--all)
+    // 이 아니면 경고만 하고 진행한다.
+    let embed_identity = config.embedding.embedding_identity();
+    let stored_model = db.get_embedding_model()?;
+    let existing_vectors = db.get_stats().map(|s| s.vector_count).unwrap_or(0);
+    if !all {
+        match &stored_model {
+            Some(m) if *m != embed_identity => {
+                eprintln!("⚠ 임베딩 모델 불일치: 기존 벡터={m}, 현재={embed_identity}");
+                eprintln!(
+                    "  섞이면 시맨틱 검색 정확도가 떨어집니다. `secall embed --all` 로 전체 재임베딩을 권장합니다."
+                );
+            }
+            None if existing_vectors > 0 => {
+                eprintln!(
+                    "⚠ 임베딩 모델 마커가 없습니다 (v0.7.0 이전 DB 일 수 있음). 기존 벡터가 현재 모델({embed_identity})과 다르면 `secall embed --all` 을 권장합니다."
+                );
+            }
+            _ => {}
+        }
+    }
+
     let vector_indexer = secall_core::search::vector::create_vector_indexer(&config).await;
     let Some(indexer) = vector_indexer else {
         eprintln!("No embedding backend available.");
@@ -223,6 +246,15 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
     // 모든 세션 완료 후 ANN 인덱스 1회 저장
     if let Err(e) = indexer.save_ann_if_present() {
         eprintln!("Warning: ANN index save failed: {e}");
+    }
+
+    // 임베딩 모델 마커 갱신 — 전체 재임베딩(--all)이거나 최초 embed(기존 벡터 0 +
+    // 마커 없음)일 때만 현재 모델로 확정한다. (기존 벡터가 있는데 마커만 없는
+    // incremental 은 마커를 두지 않아 다음 실행에서도 경고가 유지된다.)
+    if all || (stored_model.is_none() && existing_vectors == 0) {
+        if let Err(e) = db.set_embedding_model(&embed_identity) {
+            eprintln!("Warning: 임베딩 모델 마커 저장 실패: {e}");
+        }
     }
 
     let elapsed = start.elapsed();

--- a/crates/secall/src/commands/embed.rs
+++ b/crates/secall/src/commands/embed.rs
@@ -80,8 +80,11 @@ pub async fn run(all: bool, batch_size: Option<usize>, concurrency: usize) -> Re
     // 이 아니면 경고만 하고 진행한다.
     let embed_identity = config.embedding.embedding_identity();
     let stored_model = db.get_embedding_model()?;
-    let existing_vectors = db.get_stats().map(|s| s.vector_count).unwrap_or(0);
-    if !all {
+    // get_stats() 실패를 0 으로 뭉개면 실제 벡터가 있어도 "최초 embed" 로 오판해
+    // 마커를 잘못 확정할 수 있어 에러를 전파한다(리뷰 반영).
+    let existing_vectors = db.get_stats()?.vector_count;
+    // backend=none 은 임베딩 비활성이라 불일치 경고가 오해만 준다 → skip.
+    if config.embedding.backend != "none" && !all {
         match &stored_model {
             Some(m) if *m != embed_identity => {
                 eprintln!("⚠ 임베딩 모델 불일치: 기존 벡터={m}, 현재={embed_identity}");

--- a/crates/secall/src/commands/status.rs
+++ b/crates/secall/src/commands/status.rs
@@ -63,6 +63,21 @@ pub fn run() -> Result<()> {
     println!("  Sessions:      {}", stats.session_count);
     println!("  Turns:         {}", stats.turn_count);
     println!("  Embedded:      {}", stats.vector_count);
+    // 임베딩 모델 불일치 경고 — 교차모델 벡터는 차원이 같아도 유사도가 무의미해
+    // 시맨틱 검색이 조용히 저하된다.
+    let embed_identity = config.embedding.embedding_identity();
+    match db.get_embedding_model() {
+        Ok(Some(stored)) if stored != embed_identity => {
+            println!("  ⚠ 임베딩 모델 불일치: 기존 벡터={stored} / 현재={embed_identity}");
+            println!("     → `secall embed --all` 로 재임베딩 권장 (BM25 키워드 검색은 무관)");
+        }
+        Ok(None) if stats.vector_count > 0 => {
+            println!(
+                "  ⚠ 임베딩 모델 마커 없음 (v0.7.0 이전 DB 일 수 있음). 벡터가 현재 모델({embed_identity})과 다르면 `secall embed --all` 권장"
+            );
+        }
+        _ => {}
+    }
     println!();
 
     // Vault status

--- a/crates/secall/src/commands/status.rs
+++ b/crates/secall/src/commands/status.rs
@@ -64,19 +64,21 @@ pub fn run() -> Result<()> {
     println!("  Turns:         {}", stats.turn_count);
     println!("  Embedded:      {}", stats.vector_count);
     // 임베딩 모델 불일치 경고 — 교차모델 벡터는 차원이 같아도 유사도가 무의미해
-    // 시맨틱 검색이 조용히 저하된다.
-    let embed_identity = config.embedding.embedding_identity();
-    match db.get_embedding_model() {
-        Ok(Some(stored)) if stored != embed_identity => {
-            println!("  ⚠ 임베딩 모델 불일치: 기존 벡터={stored} / 현재={embed_identity}");
-            println!("     → `secall embed --all` 로 재임베딩 권장 (BM25 키워드 검색은 무관)");
+    // 시맨틱 검색이 조용히 저하된다. backend=none 은 임베딩 비활성이라 skip.
+    if config.embedding.backend != "none" {
+        let embed_identity = config.embedding.embedding_identity();
+        match db.get_embedding_model() {
+            Ok(Some(stored)) if stored != embed_identity => {
+                println!("  ⚠ 임베딩 모델 불일치: 기존 벡터={stored} / 현재={embed_identity}");
+                println!("     → `secall embed --all` 로 재임베딩 권장 (BM25 키워드 검색은 무관)");
+            }
+            Ok(None) if stats.vector_count > 0 => {
+                println!(
+                    "  ⚠ 임베딩 모델 마커 없음 (v0.7.0 이전 DB 일 수 있음). 벡터가 현재 모델({embed_identity})과 다르면 `secall embed --all` 권장"
+                );
+            }
+            _ => {}
         }
-        Ok(None) if stats.vector_count > 0 => {
-            println!(
-                "  ⚠ 임베딩 모델 마커 없음 (v0.7.0 이전 DB 일 수 있음). 벡터가 현재 모델({embed_identity})과 다르면 `secall embed --all` 권장"
-            );
-        }
-        _ => {}
     }
     println!();
 


### PR DESCRIPTION
## 배경

기본 임베딩이 `bge-m3` → `qwen3-embedding:0.6b`(#120)로 바뀌면서, **기존 bge-m3 벡터를 가진 사용자가 업그레이드**하면 쿼리는 qwen 으로 임베딩돼 **교차모델 불일치**가 발생합니다. 두 모델 다 1024-dim 이라 차원 에러는 안 나고, 유사도만 무의미해져 **시맨틱/하이브리드 검색이 조용히 저하**됩니다 (#121 위키 버그와 동일 메커니즘). 지금은 아무 경고도 없어 사용자가 검색이 망가진 줄도 모릅니다.

## 변경

- **`DEFAULT_OLLAMA_EMBED_MODEL` 상수화** (`search/embedding.rs`) — magic string 제거.
- **`EmbeddingConfig::embedding_identity()`** — `backend:model` 정규화 식별자 (모델/백엔드 변경 감지 기준).
- **`Database::get/set_embedding_model()`** — `config` KV 에 벡터 생성 모델 마커 저장 (schema_version 과 동일 패턴).
- **`secall embed`** — 재임베딩(`--all`)/최초 embed 후 마커 저장. incremental 시 마커≠현재모델(불일치)이거나 마커 없이 벡터만 있으면(v0.7.0 이전 DB) **경고**.
- **`secall status`** — 동일 불일치/미표시 경고.
- **`do_status`(REST/MCP)** — `embedding_model` 마커 노출 (web UI 활용 가능).

## 마이그레이션 안내

- `secall embed --all` — qwen 으로 전체 재임베딩 (권장) → 마커 확정 + 경고 해소
- `secall config set embedding.ollama_model bge-m3` — 기존 모델 유지
- (BM25 키워드 검색은 임베딩을 안 쓰므로 무관)

## 검증
- `cargo test` 744 pass (신규 2: `embedding_identity` · `embedding_model_marker_roundtrip`)
- `clippy --workspace --all-targets` (-Dwarnings) clean

## 후속 (별건)
- `secall sync` 의 ingest embed 경로에도 동일 경고 연결 (현재는 `embed`/`status` 만).

## 머지 전
- [ ] CI green + CodeRabbit 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 상태 화면에서 임베딩 모델 정합성(저장된 모델 vs 현재 설정) 검증과 불일치 경고/재임베딩 권장을 추가했습니다.
  * 임베딩 설정을 백엔드별 규칙에 맞춘 식별자(embedding identity)로 정규화해 모델 비교 정확도를 높였습니다.
* **Bug Fixes**
  * DB에 임베딩 모델 마커가 없거나 이전 데이터인 경우에도 재임베딩 안내가 더 정확해졌습니다.
* **Documentation**
  * 기본 임베딩 모델(v0.6.5+) 변경에 따른 업그레이드 안내와 `secall embed --all` 또는 기존 모델 유지 방법, BM25는 영향 없음 안내를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->