### PR TITLE
fix(deps): kiwi-rs libkiwi 0.23 ABI 불일치로 인한 sync 세그폴트 수정

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,8 +1832,7 @@ dependencies = [
 [[package]]
 name = "kiwi-rs"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9b6b1cf30362df090420a0f4bd4d6cf961fdf9667a6b9846923a2be09017a8"
+source = "git+https://github.com/yeonsh/kiwi-rs?rev=668a7c024f516496be027926c66c7d45d3b799ba#668a7c024f516496be027926c66c7d45d3b799ba"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,10 @@ rust-embed = "8"
 mime_guess = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 sysinfo = "0.34"
+
+# kiwi-rs 0.1.4 is ABI-incompatible with libkiwi >= 0.23.0 (kiwi_analyze_option_t
+# gained typo_transformer/typo_threshold; by-value struct → segfault in kiwi_analyze).
+# Remove once upstream releases a fixed version (> 0.1.4).
+[patch.crates-io]
+# (branch: fix/analyze-option-abi-kiwi-0.23 — rev-pinned for reproducible builds)
+kiwi-rs = { git = "https://github.com/yeonsh/kiwi-rs", rev = "668a7c024f516496be027926c66c7d45d3b799ba" }


### PR DESCRIPTION
## 문제

`secall sync`가 "Ingesting local sessions..." 단계에서 매번 SIGSEGV로 죽음 (2026-07-03, 07-06 크래시 리포트 동일 시그니처 — `kiwi_analyze` → `splitByTrieUsingTypo` → `PreparedTypoTransformer::generateGraph`, `KERN_INVALID_ADDRESS at 0x8`).

## 근본 원인

kiwi-rs 0.1.4의 `#[repr(C)] KiwiAnalyzeOption`(5필드 32바이트)은 **Kiwi 0.22.x**의 `kiwi_analyze_option_t` 레이아웃. **Kiwi 0.23.0**부터 이 C 구조체 끝에 `kiwi_prepared_typo_h typo_transformer` + `float typo_threshold`가 추가되어 48바이트가 됐고, 값(by value)으로 전달되기 때문에 libkiwi 0.23.x의 `toAnalyzeOption()`이 Rust가 초기화하지 않은 +32..+48 스택 쓰레기를 typo 필드로 읽음 → 쓰레기 값이 오타 교정 경로를 켜면 무효한 `PreparedTypoTransformer`로 분석을 시도하다 널/쓰레기 포인터 역참조.

로컬에 수동 설치된 libkiwi가 0.23.2라 즉시 노출됐지만, kiwi-rs의 자동 다운로드 기본값도 `latest`(현재 0.23.2)라서 크레이트 자체 결함임.

## 수정

kiwi-rs 포크에 두 필드를 추가하고 모든 생성 지점(6곳)에서 `null`/`2.5`(헤더 문서화 기본값)로 초기화 — 구조체가 커지는 방향은 0.22.x에도 안전(callee가 아는 prefix만 읽음). seCall은 업스트림 수정 릴리스 전까지 `[patch.crates-io]`로 이 포크를 참조:

- 포크 커밋: yeonsh/kiwi-rs@668a7c024f516496be027926c66c7d45d3b799ba (`rev` 고정, Cargo.lock 검증 완료 — 리뷰 시점 `git ls-remote`로 도달성 확인)
- 업스트림 이슈: JAICHANGPARK/kiwi-rs#1 (감사 중 발견된 별개의 잠재 버그 — `kiwi_config_t` 0.23 중간 삽입 불일치, seCall 미사용 API — 도 함께 보고)
- 업스트림 PR: JAICHANGPARK/kiwi-rs#2 — 머지·릴리스되면 이 patch 블록 제거 가능

## 검증

- **kiwi-rs 포크**: libkiwi 0.23.2 상대로 패치 전 통합 테스트 SIGSEGV → 패치 후 전부 그린 (61 unit + 통합 + doc). RED→GREEN 직접 증거.
- **seCall**: `cargo build --release` 성공, `cargo test` 746 passed / 0 failed.
- **e2e 재현**: 크래시가 났던 `secall sync` 경로가 exit 0으로 완주 — 밀려 있던 249개 세션 ingest, 그래프 1,278노드/1,039엣지 갱신, 한국어 recall 검색 정상.

## Fast-follow 제안 (이번 PR 범위 밖)

CI cargo 스텝에 `--locked` 추가 — 현재 CI가 lockfile을 강제하지 않아 `cargo update` 시 git 의존성이 이동할 수 있음 (rev 고정으로 이번 건은 방어됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
