### PR TITLE
fix(kiwi): PR #143 후속 — libkiwi 버전 핀(v0.22.2) + FFI ABI 회귀 테스트/CI + 0.23 비호환 발견

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,17 @@ jobs:
   # (every kiwi runtime test is `#[ignore]`), so a `KiwiAnalyzeOption` ABI
   # drift would segfault a user's `secall sync` while CI stays green. This
   # dedicated job runs the real-libkiwi regression against the pinned tag
-  # (KIWI_LIBKIWI_TAG in tokenizer.rs). Split out so libkiwi's runtime
-  # download (network) can't flake the required test matrix.
+  # (KIWI_LIBKIWI_TAG in tokenizer.rs). Split out so libkiwi provisioning
+  # (network) can't flake the required test matrix.
+  #
+  # libkiwi/model are provisioned explicitly via authenticated `gh release
+  # download` and handed to kiwi-rs through KIWI_LIBRARY_PATH / KIWI_MODEL_PATH
+  # so `Kiwi::new()` loads them directly, NOT via kiwi-rs's own runtime
+  # auto-download, which hits the unauthenticated GitHub API (rate-limited)
+  # and, in the pinned fork, mis-parses the release JSON (find_asset_url
+  # brace-matching breaks on the nested `uploader` object). See PR #143 notes.
+  # Tag is v0.22.x on purpose: libkiwi >= 0.23 crashes this binding in init
+  # (see KIWI_LIBKIWI_TAG in tokenizer.rs for the details).
   kiwi-ffi:
     name: kiwi FFI ABI regression
     runs-on: ubuntu-latest
@@ -123,17 +132,33 @@ jobs:
             ~/.cargo/git
             target
             ${{ github.workspace }}/.kiwi-cache
-          key: ${{ runner.os }}-kiwiffi-v0.23.2-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-kiwiffi-v0.22.2-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-kiwiffi-v0.23.2-
+            ${{ runner.os }}-kiwiffi-v0.22.2-
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
 
-      - name: Run kiwi FFI ABI regression (downloads real libkiwi v0.23.2)
+      - name: Provision libkiwi + model (v0.22.2, authenticated download)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          KROOT="${{ github.workspace }}/.kiwi-cache"
+          mkdir -p "$KROOT"
+          gh release download v0.22.2 -R bab2min/Kiwi \
+            -p 'kiwi_lnx_x86_64_v0.22.2.tgz' -p 'kiwi_model_v0.22.2_base.tgz' \
+            -D "$KROOT" --skip-existing
+          tar -xzf "$KROOT/kiwi_lnx_x86_64_v0.22.2.tgz" -C "$KROOT"
+          tar -xzf "$KROOT/kiwi_model_v0.22.2_base.tgz" -C "$KROOT"
+          test -f "$KROOT/lib/libkiwi.so"
+          test -f "$KROOT/models/cong/base/sj.morph"
+          echo "KIWI_LIBRARY_PATH=$KROOT/lib/libkiwi.so" >> "$GITHUB_ENV"
+          echo "KIWI_MODEL_PATH=$KROOT/models/cong/base" >> "$GITHUB_ENV"
+
+      - name: Run kiwi FFI ABI regression (real libkiwi v0.22.2)
         env:
           SECALL_KIWI_FFI_TEST: "1"
-          KIWI_RS_CACHE_DIR: ${{ github.workspace }}/.kiwi-cache
         run: cargo nextest run -p secall-core --no-fail-fast -E 'test(kiwi_ffi_abi)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,41 @@ jobs:
       - name: cargo audit
         run: cargo audit
         continue-on-error: true
+
+  # PR #143 follow-up: the core `check` job never exercises the kiwi FFI
+  # (every kiwi runtime test is `#[ignore]`), so a `KiwiAnalyzeOption` ABI
+  # drift would segfault a user's `secall sync` while CI stays green. This
+  # dedicated job runs the real-libkiwi regression against the pinned tag
+  # (KIWI_LIBKIWI_TAG in tokenizer.rs). Split out so libkiwi's runtime
+  # download (network) can't flake the required test matrix.
+  kiwi-ffi:
+    name: kiwi FFI ABI regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo & libkiwi assets
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            ${{ github.workspace }}/.kiwi-cache
+          key: ${{ runner.os }}-kiwiffi-v0.23.2-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-kiwiffi-v0.23.2-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Run kiwi FFI ABI regression (downloads real libkiwi v0.23.2)
+        env:
+          SECALL_KIWI_FFI_TEST: "1"
+          KIWI_RS_CACHE_DIR: ${{ github.workspace }}/.kiwi-cache
+        run: cargo nextest run -p secall-core --no-fail-fast -E 'test(kiwi_ffi_abi)'

--- a/crates/secall-core/src/search/tokenizer.rs
+++ b/crates/secall-core/src/search/tokenizer.rs
@@ -106,6 +106,16 @@ impl Tokenizer for LinderaKoTokenizer {
 mod kiwi_impl {
     use super::*;
 
+    /// libkiwi release tag this build's kiwi-rs ABI (the 7-field / 48-byte
+    /// `KiwiAnalyzeOption` layout) is verified against. `Kiwi::init()` would
+    /// otherwise auto-download `latest`; a future libkiwi that appends more
+    /// fields to `kiwi_analyze_option_t` would then desync from the compiled
+    /// struct and reintroduce the by-value ABI SIGSEGV fixed in PR #143.
+    /// Bump deliberately on each Kiwi upgrade after re-checking `capi.h`.
+    /// (Only affects the auto-download fallback — an already-installed libkiwi
+    /// discovered via `KIWI_LIBRARY_PATH`/cache is used as-is by `Kiwi::new()`.)
+    pub(super) const KIWI_LIBKIWI_TAG: &str = "v0.23.2";
+
     /// Newtype wrapper so we can impl Send without Sync.
     /// kiwi_rs::Kiwi contains *mut c_void + RefCell internals — not Sync.
     pub(super) struct KiwiWrapper(pub(super) kiwi_rs::Kiwi);
@@ -115,7 +125,7 @@ mod kiwi_impl {
     unsafe impl Send for KiwiWrapper {}
 
     /// Korean morphological tokenizer backed by kiwi-rs.
-    /// On first use, `Kiwi::init()` downloads the model (~50MB) to ~/.cache/kiwi/.
+    /// On first use, kiwi-rs downloads the pinned libkiwi/model (~50MB) to ~/.cache/kiwi/.
     /// Thread safety is provided by `Mutex<KiwiWrapper>`.
     pub struct KiwiTokenizer {
         pub(super) kiwi: std::sync::Mutex<KiwiWrapper>,
@@ -125,8 +135,8 @@ mod kiwi_impl {
 
     impl KiwiTokenizer {
         pub fn new() -> Result<Self> {
-            let kiwi =
-                kiwi_rs::Kiwi::init().map_err(|e| anyhow::anyhow!("kiwi-rs init failed: {e}"))?;
+            let kiwi = kiwi_rs::Kiwi::init_with_version(KIWI_LIBKIWI_TAG)
+                .map_err(|e| anyhow::anyhow!("kiwi-rs init failed: {e}"))?;
             Ok(Self {
                 kiwi: std::sync::Mutex::new(KiwiWrapper(kiwi)),
             })
@@ -337,6 +347,34 @@ mod tests {
         // Manual: requires kiwi model download
         let tok = create_tokenizer("kiwi");
         assert!(tok.is_ok());
+    }
+
+    /// Real-FFI ABI regression: exercises `kiwi_analyze` end-to-end against the
+    /// actual libkiwi binary. Guards the by-value `KiwiAnalyzeOption` ABI (PR
+    /// #143): a struct-layout drift (e.g. a future libkiwi appending fields)
+    /// would SIGSEGV here or return garbage morphemes — turning CI red instead
+    /// of a user's `secall sync`. Unlike the `#[ignore]` tests above this is a
+    /// normal test, but it self-skips unless opted in (first run downloads
+    /// ~50MB libkiwi+model): set `SECALL_KIWI_FFI_TEST=1`. CI runs it in a
+    /// dedicated step with the libkiwi assets cached (see ci.yml).
+    #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
+    #[test]
+    fn test_kiwi_ffi_abi_smoke() {
+        if std::env::var_os("SECALL_KIWI_FFI_TEST").is_none() {
+            eprintln!(
+                "skipping test_kiwi_ffi_abi_smoke (set SECALL_KIWI_FFI_TEST=1 to run the real FFI check)"
+            );
+            return;
+        }
+        let tok = KiwiTokenizer::new().expect("kiwi init (real libkiwi)");
+        // 표준 Kiwi 분석 문장: 아버지/NNG 가/JKS 방/NNG 에/JKB 들어가/VV 시/EP ㄴ다/EF.
+        // 필터(NNG/NNP/NNB/VV/VA/SL, len>1) 후 '아버지'·'들어가' 가 남아야 한다.
+        let tokens = tok.tokenize("아버지가방에들어가신다");
+        assert!(
+            tokens.iter().any(|t| t == "아버지"),
+            "real kiwi analysis expected the '아버지' morpheme, got {tokens:?} \
+             (empty/garbage/whole-word ⇒ ABI drift or silent fallback — see PR #143)"
+        );
     }
 
     // ─── fts_query: OR + prefix + 외래어 음역 alias ────────────────────────────

--- a/crates/secall-core/src/search/tokenizer.rs
+++ b/crates/secall-core/src/search/tokenizer.rs
@@ -106,15 +106,20 @@ impl Tokenizer for LinderaKoTokenizer {
 mod kiwi_impl {
     use super::*;
 
-    /// libkiwi release tag this build's kiwi-rs ABI (the 7-field / 48-byte
-    /// `KiwiAnalyzeOption` layout) is verified against. `Kiwi::init()` would
-    /// otherwise auto-download `latest`; a future libkiwi that appends more
-    /// fields to `kiwi_analyze_option_t` would then desync from the compiled
-    /// struct and reintroduce the by-value ABI SIGSEGV fixed in PR #143.
-    /// Bump deliberately on each Kiwi upgrade after re-checking `capi.h`.
-    /// (Only affects the auto-download fallback — an already-installed libkiwi
-    /// discovered via `KIWI_LIBRARY_PATH`/cache is used as-is by `Kiwi::new()`.)
-    pub(super) const KIWI_LIBKIWI_TAG: &str = "v0.23.2";
+    /// libkiwi release tag pinned for kiwi-rs's auto-download fallback. This is
+    /// the version VERIFIED to work with the pinned kiwi-rs fork's FFI binding.
+    ///
+    /// WARNING: do NOT bump to v0.23.x. libkiwi >= 0.23 currently SIGSEGVs in
+    /// `Kiwi::new()` (the kiwi builder/init path) with this binding, even though
+    /// the standalone `kiwi-cli` 0.23.x tokenizes fine with the same lib+model.
+    /// PR #143 fixed the analyze-path `KiwiAnalyzeOption` ABI, but a separate
+    /// init-path 0.23 incompatibility remains and needs upstream kiwi-rs work.
+    /// Verified empirically: 0.22.2 tokenizes; 0.23.2 crashes in init.
+    ///
+    /// Only affects the auto-download fallback. An already-installed libkiwi
+    /// found via `KIWI_LIBRARY_PATH` or default discovery is used as-is by
+    /// `Kiwi::new()`, so a user who manually installed 0.23.x can still crash.
+    pub(super) const KIWI_LIBKIWI_TAG: &str = "v0.22.2";
 
     /// Newtype wrapper so we can impl Send without Sync.
     /// kiwi_rs::Kiwi contains *mut c_void + RefCell internals — not Sync.


### PR DESCRIPTION
@
## 배경

#143 이 kiwi-rs 의 `kiwi_analyze_option_t` ABI 불일치로 인한 `secall sync` SIGSEGV 를 포크 패치로 해결했습니다. 그 후속으로 (1) 버전 핀, (2) FFI 회귀 테스트를 추가하던 중, **회귀 테스트가 실제 버그를 잡아** 방향이 바뀌었습니다.

## 핵심 발견 (회귀 테스트가 잡음)

fresh 환경에서 **정품 libkiwi 0.23.2 로는 seCall 바인딩이 `Kiwi::new()` (builder/init 경로)에서 SEGFAULT** 합니다.

- 같은 lib+model 로 번들 `kiwi-cli-0.23.2` 는 정상 분석(`아버지/NNG 가/JKS ...`) → lib/model 이 아니라 **바인딩 문제**.
- probe 로 crash 지점 확정: **init** (analyze 아님). #143 이 고친 건 analyze 경로(`KiwiAnalyzeOption`)라, **init 경로의 0.23 비호환은 미해결** (상류 kiwi-rs 조사 영역).
- 사용자/CI 실측: 기존에 "0.23.2 설치"로 알던 환경이 실제로는 **libkiwi 0.22.2** 였음. 0.22.2 는 48B struct 의 32B prefix 만 읽어 안전 → 그래서 무사했던 것.

**결론**: seCall 은 현재 사실상 **libkiwi 0.22.x 전용**. 0.23.x 는 수동 설치 시 init crash.

## 변경

### 1. 버전 핀 `v0.22.2` (`tokenizer.rs`)
`Kiwi::init()` → `Kiwi::init_with_version(KIWI_LIBKIWI_TAG)`, **`KIWI_LIBKIWI_TAG = "v0.22.2"`** (실증된 working 버전). auto-download fallback 에만 영향 (기존 설치 lib 는 `Kiwi::new()` 가 그대로 사용). 상수 주석에 "0.23+ 로 bump 금지" 경고 명시.

### 2. kiwi FFI ABI 회귀 테스트 (`tokenizer.rs`)
`test_kiwi_ffi_abi_smoke`: 실제 libkiwi 로 kiwi 를 태워 `아버지` 형태소 검증. env `SECALL_KIWI_FFI_TEST=1` opt-in(기본 skip). Windows 컴파일(#133 정합). **이 테스트가 위 0.23 crash 를 잡았음.**

### 3. 전용 CI job (`ci.yml`)
`kiwi-ffi` 잡: 인증된 `gh release download` 로 libkiwi+model(v0.22.2) 직접 provision → `KIWI_LIBRARY_PATH`/`KIWI_MODEL_PATH` 로 `Kiwi::new()` 에 전달(다운로드 우회). 필수 test 매트릭스와 분리.

> 참고: 포크의 런타임 auto-download 는 별개로 깨져 있음 — `find_asset_url` 이 릴리스 JSON 의 중첩 `uploader` 객체에서 brace 매칭이 틀어져 asset 을 못 찾음(fresh 설치자 전원 영향). 그래서 CI 는 인증 다운로드로 직접 provision.

## 검증

- **fresh 0.22.2 provision → env → FFI 테스트 통과** (2.18s). 동일 메커니즘으로 **0.23.2 는 init SEGFAULT** 재현.
- `secall-core` 485 green, `clippy -Dwarnings` 클린, `ci.yml` YAML valid.

## 후속 (별도 트래킹/상류)

- **libkiwi >= 0.23 init 비호환** — kiwi-rs 포크의 init/builder 경로 0.23 대응 필요 (상류 리포트).
- **`find_asset_url` 다운로드 버그** — 중첩 객체 brace 매칭 (상류 리포트).
- upstream `JAICHANGPARK/kiwi-rs#2` 릴리스 시 `[patch.crates-io]` 제거.
- (여유 시) libkiwi 버전 감지 후 graceful 경고/에러 — segfault 대신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVEL1SnCQBtUMeWVy99ebj
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 검색 토크나이저가 라이브러리/모델을 고정된 버전 기준으로 초기화해, 다운로드 불일치로 인한 ABI 호환성 문제 가능성을 줄였습니다.
* **Tests**
  * FFI 연동 결과를 확인하는 스모크 테스트를 추가해, 설정 시 실제 실행 환경에서 드리프트를 조기 탐지합니다.
* **Chores**
  * CI에 별도 회귀 테스트 작업을 보강해 실제 ABI 회귀를 독립적으로 수행하고 탐지 범위를 확대했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->